### PR TITLE
fix(governance): replace placeholder paths with descriptive examples in spec 007 WP03

### DIFF
--- a/kitty-specs/007-org-scale-agentic-governance/tasks/WP03-governance-remediations.md
+++ b/kitty-specs/007-org-scale-agentic-governance/tasks/WP03-governance-remediations.md
@@ -87,7 +87,7 @@ health indicator alongside test pass rates and deployment frequency.
 
 **Steps**:
 
-1. Scan all markdown files in `joyus-ai/kitty-specs/` and `joyus-ai/spec/` for internal links (`[text](../path)`, `[text](./path)`, anchor refs `#section`).
+1. Scan all markdown files in `joyus-ai/kitty-specs/` and `joyus-ai/spec/` for internal links (relative refs like `../feature/spec.md`, `./plan.md`, anchor refs `#section`).
 2. For each link, verify the target file exists. Record broken links in a working list.
 3. Categorize breaks:
    - **Missing file**: target `.md` file does not exist → create a stub (T012 handles stub content)


### PR DESCRIPTION
## Summary

Fixes governance-check REF-001 P0 failure that was blocking all PRs.

`kitty-specs/007-org-scale-agentic-governance/tasks/WP03-governance-remediations.md` used `../path` and `./path` as example patterns in a task description. The governance checker treated these as real broken local markdown references.

**Change**: replaced the generic placeholder paths with descriptive examples (`../feature/spec.md`, `./plan.md`) that read clearly as examples, not real links.

This unblocks CI on PRs #18, #19, #23, #25, #26, #28, #33.

Generated with [Claude Code](https://claude.com/claude-code)