### PR TITLE
spec: add profile families and philosophy mode

### DIFF
--- a/kitty-specs/005-content-intelligence/plan.md
+++ b/kitty-specs/005-content-intelligence/plan.md
@@ -7,6 +7,9 @@
 
 Build a Python profile engine library that ingests author corpora, extracts 129 stylometric features, generates hierarchical writing profiles (person → department → organization), emits platform-consumable skill files, and provides two-tier fidelity verification — exposed via CLI and MCP tools. Phase C adds continuous monitoring with drift detection and repair.
 
+This plan remains **voice-first**. The newer `position` and `philosophy`
+families are architectural extensions, not hidden scope for Phases A-C.
+
 ## Technical Context
 
 **Language/Version**: Python >=3.11, <=3.12 (spaCy 3.x incompatible with Python 3.14)
@@ -18,6 +21,9 @@ Build a Python profile engine library that ingests author corpora, extracts 129 
 **Performance Goals**: Tier 1 verification <500ms, Tier 1 profile build <30s, Tier 2 build <5min
 **Constraints**: Python <=3.12, faststylometry Corpus not thread-safe (per-request instances), all MCP output to stderr
 **Scale/Scope**: 30+ authors, 4 fidelity tiers, 5 drift signals, 6 repair types
+
+**Compatibility goal**: Existing voice-mode contracts stay valid while the
+schema evolves toward profile families.
 
 ## Constitution Check
 
@@ -179,3 +185,14 @@ The following spec sections are intentionally **not covered** in Phases A-C:
 | §1 Self-Service Profile Building | Phase E | Web interface, automatic tier detection |
 | Constitution §2.5 User Correction Feedback | Phase D | No generated content = no user corrections to capture |
 | Constitution §2.7 Automated Pipelines | Phase D | Event-driven workflows need generation capability |
+| `profile_family=position` runtime artifacts | Later feature | Needs stance graph + chronology contract, not just voice files |
+| `profile_family=philosophy` extraction and runtime | Later feature | Needs lens schema, counter-lens logic, and separate verification harness |
+
+### Philosophy Mode Non-Goal for This Plan
+
+Philosophy mode should not be smuggled into current WPs by extending
+`VoiceContext`, `SkillEmitter`, or Burrows' Delta scoring. The safe path is:
+
+- keep Phases A-C voice-first
+- add family-aware schema and versioning in platform-facing specs
+- design philosophy mode as a separate runtime/evaluation track later

--- a/kitty-specs/005-content-intelligence/spec.md
+++ b/kitty-specs/005-content-intelligence/spec.md
@@ -22,6 +22,11 @@ These systems encode organizational knowledge as testable, enforceable skills �
 
 While the legal advocacy org drives the high-fidelity (Tier 4) requirements, the same profile engine can serve anyone who wants to build a writing profile for their own content. A blogger, a marketing team, or a solo consultant should be able to provide a handful of writing samples and get a usable writing skill — even if it's lower fidelity than a full forensic-grade profile. The platform supports four fidelity tiers (see §5.6), each with different data requirements and capabilities, making the profile engine valuable from casual use through expert-level authorship preservation.
 
+This claim applies most directly to **voice/authorship** profiles. Position and
+philosophy profiles need stronger evidence. The platform should degrade those
+modes to "insufficient evidence" instead of pretending a handful of samples can
+support stable reasoning or debate profiles.
+
 ### First validated use case
 
 A nonprofit legal advocacy organization — the foremost experts on consumer law in the United States — that:
@@ -153,6 +158,53 @@ class DepartmentProfile(AuthorProfile):
     # AuthorProfile is the canonical entity name across data-model.md, contracts, and tasks.
 ```
 
+### 3.4 Profile Families
+
+The current spec treats "profile" as one thing. That is now too coarse.
+
+Joyus should explicitly support three profile families:
+
+| Family | Primary question | Core artifact | Verification focus |
+|---|---|---|---|
+| **Voice** | Does this sound like them? | SKILL.md + markers + stylometrics | Stylistic fidelity |
+| **Position** | What do they repeatedly believe? | Topic-keyed stance graph + chronology | Stance accuracy and contradiction detection |
+| **Philosophy** | How do they reason through tradeoffs? | Lens-first review/query/compare runtime | Correct objections, counter-lenses, approval conditions, uncertainty |
+
+These are related but not interchangeable:
+
+- voice without position can sound right while saying the wrong thing
+- position without philosophy can list beliefs without explaining tradeoff logic
+- philosophy without voice can still be useful for review and decision support
+
+The platform should stop assuming that better stylometrics automatically imply
+better philosophy capture.
+
+### 3.5 Philosophy Mode
+
+Philosophy mode is the new family inspired by the lens-first profiles recently
+built in the Drupal work. It is intended for review, query, and comparison
+surfaces where the user needs structured reasoning rather than contributor
+imitation.
+
+The output unit is a **lens**, not a persona:
+
+- selected lenses
+- likely objections
+- likely approval conditions
+- cross-lens tension
+- counter-lenses
+- blind spots / uncertainty
+- optional stewardship or arbiter layer for product, governance, or release
+  decisions
+
+Hard rules for philosophy mode:
+
+- no first-person contributor simulation
+- no signature-phrase imitation
+- named people are evidence/provenance, not the primary speaking unit
+- composite profiles must preserve meaningful disagreement rather than averaging
+  it away
+
 ---
 
 ## 4. System 1: Attribution & Validation Engine
@@ -223,6 +275,8 @@ The profile-engine-spec (`spec/profile-engine-spec.md`) covers the core library:
 - **Composite profile generation** (department and org levels)
 - **Profile diffing** (what changed between profile versions)
 - **Profile inheritance** (org-level prohibited framings cascade to all departments and people)
+- **Profile family resolution** (voice, position, philosophy) with family-aware
+  verification and inheritance semantics
 
 ### 5.3 Generation Workflow
 
@@ -343,6 +397,9 @@ Not every use case requires a 50,000-word corpus and 129-feature analysis. The p
 
 **Why this matters:** Frontier LLMs (Claude, GPT-4o, Gemini) plateau at Tier 1-2 fidelity regardless of prompting sophistication (EMNLP 2025, Wang et al.: 40,000+ generations across 400+ authors). The reason is the **explicit/implicit gap**: explicit style features (tone, vocabulary level) can be described in a prompt; implicit features (function-word fingerprints, syntactic patterns, rare-word preferences) can only be measured numerically. Tier 3-4 profiles capture what cannot be said, only measured.
 
+These tiers are for **voice/authorship fidelity**. They should not be reused as
+the quality ladder for philosophy mode.
+
 | | Tier 1: Surface Tone | Tier 2: Lexical Profile | Tier 3: Syntactic + Rhetorical | Tier 4: Full Stylometric |
 |---|---|---|---|---|
 | **Data required** | ~300-2,000 words | ~2,000-10,000 words | ~10,000-50,000 words | ~50,000+ words |
@@ -382,6 +439,28 @@ The full 129-feature treatment. Character n-grams, rare-word preference signatur
 
 Attribution accuracy (97.9%) and generation fidelity are related but distinct metrics. No reliable mapping between them exists in published literature. The strongest defensible claim is "generation with higher stylometric alignment than any prompting-based approach" — not "indistinguishable from the human author." Sophisticated readers familiar with the author can still detect AI-generated content in an estimated 15-30% of cases even at Tier 4 (per EMNLP 2025 findings).
 
+The same caveat applies more strongly to philosophy mode: attribution accuracy
+and stylometric closeness say almost nothing about whether the system surfaced
+the right objections, counter-lenses, or approval conditions.
+
+### 5.7 Philosophy Readiness Levels
+
+Philosophy mode needs its own readiness ladder:
+
+| Level | What is valid |
+|---|---|
+| **P1 Topical** | Topic tagging and coarse stance extraction |
+| **P2 Lens-Stable** | Lens selection with likely objections and approval conditions |
+| **P3 Debate-Ready** | Counter-lenses, tension axes, chronology |
+| **P4 Stewardship-Ready** | Arbiter/project-stewardship layer for governance, product direction, and release-risk questions |
+
+Fail closed rule:
+
+- If evidence only supports P1, do not emit a confident philosophy review.
+- If counter-lenses are required but unsupported, say so explicitly.
+- If stewardship evidence is missing, omit that layer rather than hallucinating
+  arbitration.
+
 #### What to build vs. leverage
 
 | Component | Build or leverage? | Rationale |
@@ -410,6 +489,13 @@ Every output from System 2 is analyzed:
 | **Tier 1: Inline** | Before delivery | Marker presence, basic stylometric distance, prohibited framing check. <500ms. |
 | **Tier 2: Deep** | After delivery (async) | Full 129-feature Burrows' Delta, cross-document consistency, position accuracy |
 | **Trend analysis** | Daily/weekly rollup | Fidelity score trends over time, per profile, per content type |
+
+For philosophy mode, "fidelity" means reasoning fidelity:
+
+- correct lens selection
+- correct tension preservation
+- explicit uncertainty where evidence is weak
+- no collapse into a single flattened consensus when real disagreement exists
 
 ### 6.3 Drift Detection
 
@@ -513,6 +599,11 @@ The organization's publications are their primary revenue source (subscriber-onl
 7. **Audit trail tracks source provenance.** Every output records which source documents influenced it, enabling access control verification and ensuring the organization can audit for accidental content leakage.
 
 8. **Voice profiles carry independent access levels.** Statistical patterns (markers, stylometrics) within any voice profile remain unrestricted — they are derived knowledge. However, positions, analytical frameworks, strategic approaches, and example outputs within restricted voice profiles inherit the voice's access level. This enables Layer 2 voices (e.g., a restricted composite voice containing privileged domain strategies) to be access-gated without restricting the underlying stylometric infrastructure. See `profile-engine-spec.md §3.1` for the `VoiceAccessLevel` model.
+
+9. **Philosophy profiles may be access-gated separately from voice profiles.**
+The reasoning layer may contain privileged analytical frameworks or governance
+logic even when the underlying stylometric patterns are unrestricted. Access
+control should be profile-family-aware, not voice-only.
 
 ### 7.3 Access Control Integration
 

--- a/kitty-specs/005-content-intelligence/tasks.md
+++ b/kitty-specs/005-content-intelligence/tasks.md
@@ -5,6 +5,11 @@
 **Scope**: Phase A (Profile Engine), Phase B (Hierarchical Profiles), Phase C (Fidelity Monitoring)
 **Work Packages**: 14 | **Subtasks**: 73
 
+**Boundary note:** These tasks are for the current voice-first engine. They do
+not implicitly include philosophy-mode extraction, lens runtimes, or
+family-aware review/query consumers unless a future feature explicitly adds
+them.
+
 ---
 
 ## Subtask Registry

--- a/kitty-specs/008-profile-isolation-and-scale/plan.md
+++ b/kitty-specs/008-profile-isolation-and-scale/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Add multi-tenant profile isolation, versioning, composite inheritance, self-service corpus intake, and resolved-profile caching to the Joyus AI platform. All new code extends the existing `joyus-ai-mcp-server` package (TypeScript/Express) as a new `src/profiles/` module, parallel to the existing `src/content/` module. Profile data lives in a schema-separated PostgreSQL `profiles` schema via Drizzle ORM. Profile generation delegates to Spec 005's stable Python stylometric engine via subprocess invocation. Tenant isolation follows the Leash pattern (ADR-0002): mandatory `tenant_id` filtering on every query, injected from authenticated session context, never from user input.
+Add multi-tenant profile isolation, versioning, composite inheritance, self-service corpus intake, and resolved-profile caching to the Joyus AI platform. All new code extends the existing `joyus-ai-mcp-server` package (TypeScript/Express) as a new `src/profiles/` module, parallel to the existing `src/content/` module. Profile data lives in a schema-separated PostgreSQL `profiles` schema via Drizzle ORM. Profile generation delegates to Spec 005's Python profile engine via subprocess invocation. Existing stylometric voice mode is stable; the persistence and cache model must remain extensible to additional profile families such as philosophy mode. Tenant isolation follows the Leash pattern (ADR-0002): mandatory `tenant_id` filtering on every query, injected from authenticated session context, never from user input.
 
 ## Technical Context
 
@@ -18,7 +18,7 @@ Add multi-tenant profile isolation, versioning, composite inheritance, self-serv
 **Target Platform**: Linux server (Docker), macOS development
 **Project Type**: Single package extension (`joyus-ai-mcp-server/`)
 **Performance Goals**: Profile generation <=10 min for 50-doc corpus, rollback <=30s, cached profile lookup <50ms p95
-**Constraints**: Batch pipeline only (no streaming profile updates), soft tenant isolation (application-scoped tenant_id per ADR-0002), Spec 005 engine is stable and unchanged
+**Constraints**: Batch pipeline only (no streaming profile updates), soft tenant isolation (application-scoped tenant_id per ADR-0002), current voice-mode engine is stable but profile-family-aware storage/caching is required
 **Scale/Scope**: <=500 documents and <=30 authors per tenant (initial cohort), profile versions retained >=90 days
 
 ## Constitution Check
@@ -28,7 +28,7 @@ Add multi-tenant profile isolation, versioning, composite inheritance, self-serv
 | Principle | Status | Notes |
 |-----------|--------|-------|
 | §2.1 Multi-Tenant from Day One | PASS | All profile tables carry `tenant_id`. Every query filters by tenant context from authenticated session. Leash pattern (ADR-0002) enforced at the service layer — tenant_id is never accepted from user input. |
-| §2.2 Skills as Encoded Knowledge | PASS | Profiles are the input to skill generation. Profile versioning ensures skill files are traceable to a specific corpus snapshot and profile version. |
+| §2.2 Skills as Encoded Knowledge | PASS | Profiles are the input to skill generation and lens/runtime artifacts. Profile versioning ensures exported assets are traceable to a specific corpus snapshot, family, and profile version. |
 | §2.3 Sandbox by Default | PASS | New tenants start with zero profiles. Profile data is inaccessible to other tenants at the data layer (tenant_id scoping on all queries). Default: no cross-tenant access. |
 | §2.4 Monitor Everything | PASS | Structured logging for all profile operations (generation, rollback, inheritance resolution, intake). Operation logs track duration, success/failure, and tenant context. |
 | §2.5 Feedback Loops | PASS | Profile versioning enables comparison between versions. Fidelity scores at generation time provide quantitative feedback. Rollback is the corrective action when fidelity degrades. |
@@ -41,7 +41,7 @@ Add multi-tenant profile isolation, versioning, composite inheritance, self-serv
 | §3.2 Compliance Framework Awareness | PASS | Profile generation respects tenant compliance framework declarations. Corpus retention follows tenant-configured retention policies. |
 | §3.3 Non-Negotiables | PASS | Audit trail for all profile operations (generation, rollback, version changes). Corpus data never used for model training. Profile versions are immutable — no silent mutations. |
 
-**Post-design re-check**: All principles remain satisfied. The `profiles` schema separation reinforces tenant isolation (§2.1, §2.3). The immutable version model ensures auditability (§3.3). The subprocess boundary with Spec 005 keeps the stylometric engine stable (§2.2).
+**Post-design re-check**: All principles remain satisfied. The `profiles` schema separation reinforces tenant isolation (§2.1, §2.3). The immutable version model ensures auditability (§3.3). The subprocess boundary with Spec 005 keeps the current voice-mode engine stable while leaving room for additional profile families (§2.2).
 
 ## Project Structure
 

--- a/kitty-specs/008-profile-isolation-and-scale/plan.md
+++ b/kitty-specs/008-profile-isolation-and-scale/plan.md
@@ -140,7 +140,7 @@ Design the `profiles` schema and service interfaces.
 
 | ID | Deliverable | Depends on |
 |----|------------|------------|
-| 1.1 | `profiles` pgSchema with all tables (data-model.md → schema.ts) | R1, R2 |
+| 1.1 | `profiles` pgSchema with all tables (data-model.md → schema.ts) including `profile_family` and non-breaking defaulting to `voice` | R1, R2 |
 | 1.2 | Tenant-scoped query helpers (`tenant-scope.ts`) | R1 |
 | 1.3 | Zod validation schemas (`validation.ts`) | 1.1 |
 | 1.4 | Shared types and constants (`types.ts`) | 1.1 |
@@ -148,6 +148,9 @@ Design the `profiles` schema and service interfaces.
 | 1.6 | Extend `db/client.ts` to import profiles schema | 1.1 |
 
 **Exit criteria**: Schema compiles, migration runs against empty database, types are exported, tenant-scope helpers have unit tests.
+
+**Compatibility gate**: Existing voice consumers continue to resolve profiles
+without specifying `profile_family`; default behavior remains voice-mode.
 
 ### Phase 2 — Profile Generation Pipeline (3–4 days)
 

--- a/kitty-specs/008-profile-isolation-and-scale/spec.md
+++ b/kitty-specs/008-profile-isolation-and-scale/spec.md
@@ -142,6 +142,7 @@ For tenants with large corpora (500+ documents, 20+ authors), resolved profiles 
 | FR-010 | Concurrent profile generation pipelines for different tenants MUST NOT contend on shared resources in a way that causes correctness failures. Performance degradation under contention is acceptable; data corruption is not. | P1 |
 | FR-011 | Every stored profile, version, and cache entry MUST declare a `profile_family`. Lifecycle operations MUST be keyed by `(tenant_id, profile_family, profile_id, version)` rather than profile ID alone. | P1 |
 | FR-012 | Resolved profile caching MUST be family-aware. Voice caches invalidate on stylometric/marker/inheritance changes. Philosophy caches invalidate on lens config, topic taxonomy, evidence map, chronology, or inheritance changes. | P2 |
+| FR-013 | Existing voice profiles MUST migrate with `profile_family=\"voice\"` by default. Introducing profile families MUST NOT require immediate regeneration of all tenant profiles before the platform can boot or serve existing voice consumers. | P1 |
 
 ### Non-Functional Requirements
 
@@ -201,6 +202,13 @@ For philosophy mode specifically, composite resolution must preserve meaningful
 disagreement and counter-lenses rather than collapsing to a single dominant
 stance. The storage and cache model must not assume that every family resolves
 like a weighted stylometric composite.
+
+Migration compatibility assumption:
+
+- Existing persisted profiles can be backfilled lazily to `profile_family=voice`.
+- Family-aware caches may be empty at rollout and warmed on demand.
+- Philosophy-mode rows may not exist at all during the initial platform rollout;
+  the architecture must tolerate that cleanly.
 
 ## References
 

--- a/kitty-specs/008-profile-isolation-and-scale/spec.md
+++ b/kitty-specs/008-profile-isolation-and-scale/spec.md
@@ -20,6 +20,7 @@ This spec defines how profiles are isolated between tenants, how profile lifecyc
 - Tenant-scoped profile generation with data isolation at the data layer (not just API layer)
 - Profile versioning with immutable version identifiers and rollback support
 - Composite profile inheritance (org, department, individual tiers)
+- Profile-family-aware persistence and lifecycle management (`voice`, `position`, `philosophy`)
 - Self-service corpus intake supporting PDF, DOCX, TXT, HTML, Markdown
 - Content-hash corpus deduplication within tenant scope
 - Resolved profile caching with inheritance-aware invalidation
@@ -28,7 +29,7 @@ This spec defines how profiles are isolated between tenants, how profile lifecyc
 
 ### Out of Scope
 
-- Changes to the stylometric engine itself (Spec 005 is stable)
+- Changes to the existing stylometric feature extraction pipeline for voice mode
 - Hard tenant isolation via separate schemas/databases (soft isolation via tenant_id scoping per ADR-0002 Leash pattern)
 - Real-time streaming profile updates (batch pipeline only)
 - Cross-tenant profile sharing or marketplace
@@ -139,6 +140,8 @@ For tenants with large corpora (500+ documents, 20+ authors), resolved profiles 
 | FR-008 | Resolved profile caching MUST invalidate on any upstream change in the inheritance chain. Stale cache entries MUST NOT be served after invalidation. | P3 |
 | FR-009 | Profile version history MUST be retained for at least 90 days or the tenant's configured retention period, whichever is longer. | P1 |
 | FR-010 | Concurrent profile generation pipelines for different tenants MUST NOT contend on shared resources in a way that causes correctness failures. Performance degradation under contention is acceptable; data corruption is not. | P1 |
+| FR-011 | Every stored profile, version, and cache entry MUST declare a `profile_family`. Lifecycle operations MUST be keyed by `(tenant_id, profile_family, profile_id, version)` rather than profile ID alone. | P1 |
+| FR-012 | Resolved profile caching MUST be family-aware. Voice caches invalidate on stylometric/marker/inheritance changes. Philosophy caches invalidate on lens config, topic taxonomy, evidence map, chronology, or inheritance changes. | P2 |
 
 ### Non-Functional Requirements
 
@@ -153,13 +156,15 @@ For tenants with large corpora (500+ documents, 20+ authors), resolved profiles 
 **TenantProfile**
 - `tenant_id`: Scoping key (foreign key to tenant)
 - `profile_id`: Unique within tenant
+- `profile_family`: `voice | position | philosophy`
 - `version`: Monotonically increasing integer
 - `author_id`: Reference to attributed author (nullable for org/dept profiles)
 - `tier`: `org | department | individual`
 - `parent_profile_id`: Reference to parent in inheritance chain (nullable for org-level)
 - `corpus_snapshot_id`: Reference to the corpus version used for generation
-- `stylometric_features`: 129-feature vector (Spec 005 schema)
-- `markers`: Marker set (Spec 005 markers.json schema)
+- `stylometric_features`: 129-feature vector (Spec 005 schema, voice mode)
+- `markers`: Marker set (Spec 005 markers.json schema, voice/position modes)
+- `philosophy_payload`: Lens set, tension axes, chronology, evidence map (philosophy mode)
 - `fidelity_score`: Attribution accuracy at time of generation
 - `status`: `generating | active | rolled_back | archived`
 - `created_at`, `archived_at`
@@ -185,10 +190,17 @@ For tenants with large corpora (500+ documents, 20+ authors), resolved profiles 
 
 ## Assumptions
 
-- Spec 005's stylometric engine is stable and does not require architectural changes to support multi-tenant execution — only scoping and lifecycle management.
+- Spec 005's existing stylometric engine is stable for voice-mode execution. The
+  multi-tenant persistence, versioning, and cache model must remain extensible
+  to non-stylometric profile families such as philosophy mode.
 - Tenant isolation at the data layer (FR-001) will be enforced by the platform's multi-tenancy infrastructure (ADR-0002, Leash pattern), not reimplemented per-feature.
 - Corpus sizes for the initial cohort of clients are <=500 documents and <=30 authors. Scaling beyond this is a future optimization, not a launch blocker.
 - The entitlement model from Spec 006 governs which tenants have access to profile features (generation, versioning, composite inheritance) based on their product tier.
+
+For philosophy mode specifically, composite resolution must preserve meaningful
+disagreement and counter-lenses rather than collapsing to a single dominant
+stance. The storage and cache model must not assume that every family resolves
+like a weighted stylometric composite.
 
 ## References
 

--- a/spec/profile-engine-spec.md
+++ b/spec/profile-engine-spec.md
@@ -11,9 +11,18 @@
 ## 1. Purpose
 
 A standalone Python library that:
-1. **Builds writing profiles** from a document corpus (any domain)
-2. **Emits skill files** consumable by the Joyus AI platform
-3. **Verifies content fidelity** via two-tier checking (inline + async)
+1. **Builds profile families** from a document corpus (any domain)
+2. **Emits runtime assets** consumable by the Joyus AI platform
+3. **Verifies mode-specific fidelity** via inline and async checks
+
+The engine should no longer be thought of as a single "writing profile"
+system. It supports three distinct but composable profile families:
+
+| Profile family | Primary question | Typical output | What it is not |
+|---|---|---|---|
+| **Voice** | "Does this sound like them?" | SKILL.md + markers.json + stylometrics.json | Not a reliable proxy for positions or tradeoff reasoning |
+| **Position** | "What do they consistently believe?" | Topic-keyed stance graph + chronology + evidence map | Not enough on its own to explain how they arbitrate conflicts |
+| **Philosophy** | "How do they reason through tradeoffs?" | Lens-first review/query/compare runtime with counter-lenses and approval conditions | Not first-person roleplay and not signature-phrase imitation |
 
 This is the platform's moat — domain knowledge that models can't generate on their own and that doesn't get subsumed by model upgrades (Decision #18).
 
@@ -108,6 +117,7 @@ class AuthorProfile(BaseModel):
     # Metadata
     profile_id: str                          # Unique identifier
     author_name: str                         # Display name
+    profile_family: Literal["voice", "position", "philosophy"] = "voice"
     domain: str                              # legal_advocacy | technical | marketing | general
     corpus_size: int                         # Number of documents analyzed
     created_at: datetime
@@ -184,11 +194,75 @@ class AuthorProfile(BaseModel):
     #   minimum_fidelity_score: float
 ```
 
-### 3.1 VoiceContext Architecture (Added Feb 19, 2026)
+### 3.1 Philosophy Mode (Added Apr 7, 2026)
+
+Philosophy mode captures **reasoning patterns**, not just tone or static
+positions. It exists for the kind of lens-first profiles now proven in the
+Drupal core work: profiles that answer "which lens applies, what objection
+does it raise, what would change the verdict, and which counter-lens must be
+surfaced?"
+
+A philosophy profile is **not** a voice profile with more `positions`. Voice
+profiles optimize for stylistic fidelity. Philosophy profiles optimize for:
+
+- lens selection from canonical topics
+- likely objections and approval conditions
+- normal debate edges and counter-lenses
+- chronology of position shifts
+- evidence hierarchy and arbiter/stewardship rules
+
+Philosophy profiles must preserve disagreement. Composite philosophy profiles
+must not collapse tension into "the most common stance" because that destroys
+the main value of the mode.
+
+```python
+class PhilosophyLens(BaseModel):
+    lens_id: str
+    label: str
+    trigger_topics: list[str]
+    likely_objections: list[str]
+    approval_conditions: list[str]
+    anti_patterns: list[str]
+    evidence_hierarchy: list[str]
+
+class TensionAxis(BaseModel):
+    axis_id: str
+    left_lens: str
+    right_lens: str
+    description: str
+
+class PhilosophyProfile(BaseModel):
+    profile_id: str
+    author_name: str
+    profile_family: Literal["philosophy"] = "philosophy"
+    canonical_topics: list[str]
+    lenses: list[PhilosophyLens]
+    counter_lenses: list[str]
+    tension_axes: list[TensionAxis]
+    chronology: list[Position]
+    evidence_map: dict[str, list[str]]
+    stewardship_rules: list[str]
+    confidence: float
+```
+
+**Readiness gates for philosophy mode:**
+
+| Readiness | What is valid |
+|---|---|
+| **Topical** | Topic tagging and stance extraction only |
+| **Lens-stable** | Lens selection + likely objections + approval conditions |
+| **Debate-ready** | Counter-lenses, tension axes, chronology |
+| **Stewardship-ready** | Arbiter/project-stewardship layer for product, governance, release, or access disputes |
+
+Unlike voice tiers, philosophy readiness should fail closed. If the corpus does
+not support stable lens extraction, the engine should emit "insufficient
+evidence" rather than pretending a low-tier philosophy profile exists.
+
+### 3.2 VoiceContext Architecture (Added Feb 19, 2026)
 
 The `RegisterShift` model (simple parameter deltas on voice/tone) is insufficient for organizations whose authors write in fundamentally different voices for different audiences. Legal advocacy attorneys, for example, write as Formal (courts), Accessible (public), Technical (practitioners), and Persuasive (legislators) — these differ across vocabulary, argumentation, citations, structure, and positions, not just tone.
 
-**Three-layer opt-in design:**
+**Three-layer opt-in design for voice mode:**
 
 | Layer | Who needs it | What it adds | Backwards impact |
 |-------|-------------|-------------|-----------------|
@@ -281,11 +355,23 @@ class CompositeVoiceConfig(BaseModel):
 | Edge cases | Optional | Optional | Optional | Optional |
 | Validation | Required | Required | Required | Required |
 
+### 3.3 Mode Boundaries
+
+The engine now has two different override systems with different purposes:
+
+- `voice_contexts` are for **audience-specific delivery** differences.
+- philosophy contexts are for **reasoning/lens** differences.
+
+Do not encode philosophy mode as more `voice_contexts`. That leads to the wrong
+merge semantics and the wrong verification model.
+
 ---
 
 ## 4. Skill File Output Format
 
-The emitter produces three files per author profile:
+The emitter produces family-specific runtime assets.
+
+For **voice** profiles, the emitter produces three files per author profile:
 
 ### SKILL.md
 Human-readable and Claude-readable instructions. Generated from profile sections.
@@ -402,6 +488,19 @@ Baseline feature distributions for Tier 2 deep analysis.
 }
 ```
 
+For **philosophy** profiles, the emitter should produce a lens-first artifact
+set instead of a voice skill:
+
+- `philosophy-lenses.json`
+- `positions.json`
+- `evidence-map.json`
+- optional `review-runtime.md` or runtime config describing required output
+  structure and disclosure rules
+
+The philosophy emitter is explicitly lens-first and evidence-backed. It should
+never emit "write as this person" instructions or signature-phrase imitation
+rules.
+
 ---
 
 ## 5. Two-Tier Verification
@@ -493,6 +592,34 @@ def deep_analyze(text: str, profile: AuthorProfile, history: list[str] = None) -
 
     return DeepResult(...)
 ```
+
+### 5.1 Mode-Specific Verification
+
+The existing Tier 1 / Tier 2 design is correct for **voice** mode and only
+partially correct for **position** mode. It is insufficient for philosophy
+mode.
+
+| Mode | Inline check | Deep check |
+|---|---|---|
+| **Voice** | Marker presence + quick stylometric distance | Full Burrows' Delta + drift analysis |
+| **Position** | Required stance markers present; prohibited framings absent | Topic/stance consistency, chronology drift, contradiction analysis |
+| **Philosophy** | Required lenses surfaced; mandatory counter-lens present when configured; explicit uncertainty when evidence is weak | Lens-selection accuracy, approval-condition coverage, tension-axis preservation, stewardship trigger correctness |
+
+Philosophy verification should not use Burrows' Delta as its primary success
+metric. A philosophy profile can be perfectly correct while sounding nothing
+like the original author. The core failure mode is wrong objections, collapsed
+tradeoffs, or false certainty.
+
+### 5.2 Composite Semantics by Profile Family
+
+Composite behavior must be family-aware:
+
+- **Voice composites** may use weighted aggregation and range merging.
+- **Position composites** may aggregate consensus positions, but should keep
+  minority or conflicting positions when they materially affect downstream
+  review.
+- **Philosophy composites** must preserve disagreement, counter-lenses, and
+  tension axes. They must not resolve to a single "dominant stance" by default.
 
 ### Feedback Loop: Tier 2 → Skill Updates
 

--- a/spec/profile-engine-spec.md
+++ b/spec/profile-engine-spec.md
@@ -24,6 +24,11 @@ system. It supports three distinct but composable profile families:
 | **Position** | "What do they consistently believe?" | Topic-keyed stance graph + chronology + evidence map | Not enough on its own to explain how they arbitrate conflicts |
 | **Philosophy** | "How do they reason through tradeoffs?" | Lens-first review/query/compare runtime with counter-lenses and approval conditions | Not first-person roleplay and not signature-phrase imitation |
 
+**Compatibility rule:** Existing profile-engine consumers remain on
+`profile_family="voice"` by default. Philosophy mode is additive. No existing
+voice emitter, CLI, or verification contract should be broken in order to
+introduce it.
+
 This is the platform's moat — domain knowledge that models can't generate on their own and that doesn't get subsumed by model upgrades (Decision #18).
 
 ---
@@ -365,6 +370,26 @@ The engine now has two different override systems with different purposes:
 Do not encode philosophy mode as more `voice_contexts`. That leads to the wrong
 merge semantics and the wrong verification model.
 
+### 3.4 Rollout Strategy
+
+Philosophy mode should land in three explicit stages:
+
+1. **Schema + storage readiness**
+   - `profile_family` added everywhere
+   - family-aware versioning and cache keys
+   - no philosophy generation required yet
+2. **Private engine readiness**
+   - philosophy extraction artifacts
+   - philosophy verification harness
+   - internal-only fixtures and regression tests
+3. **Consumer activation**
+   - review/query/compare runtimes consume philosophy artifacts
+   - public or tenant-facing surfaces enabled only after evaluation is stable
+
+This staging is intentional. Stage 1 is required for safe architecture. Stages
+2 and 3 should not be back-ported into current voice-mode WPs as “just one more
+feature”.
+
 ---
 
 ## 4. Skill File Output Format
@@ -500,6 +525,10 @@ set instead of a voice skill:
 The philosophy emitter is explicitly lens-first and evidence-backed. It should
 never emit "write as this person" instructions or signature-phrase imitation
 rules.
+
+**Compatibility rule:** The existing `SkillEmitter.emit()` contract remains the
+voice-mode emitter. Philosophy mode should use a separate emitter contract
+rather than overloading the voice skill schema.
 
 ---
 


### PR DESCRIPTION
## Summary
- split Joyus profile thinking into explicit profile families: voice, position, and philosophy
- add a first-class philosophy mode to the profile-engine and content-intelligence specs
- make profile isolation and caching family-aware so future philosophy profiles do not inherit voice-only assumptions
- tighten the implementation plan language so the existing stylometric engine is treated as stable for voice mode, not as the whole future of the profile system

## Why
The current specs still assume that one profile model can cover style, positions, and tradeoff reasoning. The Drupal lens-first work showed that philosophy capture is a different product surface: it needs lens selection, counter-lenses, approval conditions, chronology, and explicit uncertainty rather than stylometric mimicry.

## Files changed
- spec/profile-engine-spec.md
- kitty-specs/005-content-intelligence/spec.md
- kitty-specs/008-profile-isolation-and-scale/spec.md
- kitty-specs/008-profile-isolation-and-scale/plan.md

## Validation
- `git diff --check` passed
- `python3 scripts/spec-governance-check.py` still reports pre-existing repo issues unrelated to this branch, including broken links in `kitty-specs/011-inngest-migration/` and older checklist/platform-section findings
