### PR TITLE
feat(mediation): atomic idle gap calculation (Spec 011 T3)

### DIFF
--- a/joyus-ai-mcp-server/src/content/mediation/session.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/session.ts
@@ -5,10 +5,13 @@
  * Each session ties an API key (integration) to an end user for a conversation.
  */
 
-import { eq, sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/node-postgres';
 import { createId } from '@paralleldrive/cuid2';
-import { contentMediationSessions } from '../schema.js';
+import { and, eq, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { alias } from 'drizzle-orm/pg-core';
+
+import { CACHE_TTL_SECONDS } from '../generation/cost.js';
+import { contentMediationSessions, contentOperationLogs } from '../schema.js';
 
 type DrizzleClient = ReturnType<typeof drizzle>;
 
@@ -18,6 +21,11 @@ export interface MediationSessionResult {
   userId: string;
   activeProfileId: string | null;
   startedAt: Date;
+}
+
+export interface IncrementMessageCountResult {
+  idleGapSeconds: number;
+  isCacheMiss: boolean;
 }
 
 export class MediationSessionService {
@@ -80,15 +88,54 @@ export class MediationSessionService {
   }
 
   /**
-   * Atomically increment the message count and update lastActivityAt.
+   * Atomically increment message count and derive the idle-gap/cache-miss metrics.
    */
-  async incrementMessageCount(sessionId: string): Promise<void> {
-    await this.db
+  async incrementMessageCount(sessionId: string): Promise<IncrementMessageCountResult> {
+    const previousSession = alias(contentMediationSessions, 'previous_session');
+    const idleGapSecondsSql = sql<number>`coalesce(extract(epoch from (now() - ${previousSession.lastActivityAt}))::int, 0)`;
+    const isCacheMissSql = sql<boolean>`${previousSession.lastActivityAt} is not null and extract(epoch from (now() - ${previousSession.lastActivityAt})) > ${CACHE_TTL_SECONDS}`;
+
+    const [updatedSession] = await this.db
       .update(contentMediationSessions)
       .set({
         messageCount: sql`${contentMediationSessions.messageCount} + 1`,
-        lastActivityAt: new Date(),
+        lastActivityAt: sql`now()`,
+        maxIdleGapSeconds: sql`greatest(${contentMediationSessions.maxIdleGapSeconds}, ${idleGapSecondsSql})`,
+        cacheMissCount: sql`${contentMediationSessions.cacheMissCount} + case when ${isCacheMissSql} then 1 else 0 end`,
       })
-      .where(eq(contentMediationSessions.id, sessionId));
+      .from(previousSession)
+      .where(and(
+        eq(contentMediationSessions.id, sessionId),
+        eq(contentMediationSessions.id, previousSession.id),
+      ))
+      .returning({
+        idleGapSeconds: idleGapSecondsSql,
+        isCacheMiss: isCacheMissSql,
+        tenantId: previousSession.tenantId,
+      });
+
+    if (!updatedSession) {
+      throw new Error(`Mediation session not found: ${sessionId}`);
+    }
+
+    if (updatedSession.isCacheMiss) {
+      await this.db.insert(contentOperationLogs).values({
+        id: createId(),
+        tenantId: updatedSession.tenantId,
+        operation: 'cache_miss',
+        sessionId,
+        durationMs: 0,
+        success: true,
+        metadata: {
+          idleGapSeconds: updatedSession.idleGapSeconds,
+          cacheTtlSeconds: CACHE_TTL_SECONDS,
+        },
+      });
+    }
+
+    return {
+      idleGapSeconds: updatedSession.idleGapSeconds,
+      isCacheMiss: updatedSession.isCacheMiss,
+    };
   }
 }

--- a/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
+++ b/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { CACHE_TTL_SECONDS } from '../../../src/content/generation/cost.js';
 import { MediationSessionService } from '../../../src/content/mediation/session.js';
 import type { ResolvedEntitlements, GenerationResult } from '../../../src/content/types.js';
 
@@ -39,9 +40,34 @@ function makeGenerationResult(): GenerationResult {
   };
 }
 
+function makeIncrementDbMock(returningRows: Array<{
+  idleGapSeconds: number;
+  isCacheMiss: boolean;
+  tenantId: string;
+}>) {
+  const returning = vi.fn().mockResolvedValue(returningRows);
+  const where = vi.fn().mockReturnValue({ returning });
+  const from = vi.fn().mockReturnValue({ where });
+  const set = vi.fn().mockReturnValue({ from });
+  const update = vi.fn().mockReturnValue({ set });
+  const values = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn().mockReturnValue({ values });
+
+  return {
+    db: { update, insert } as never,
+    insert,
+    returning,
+    values,
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('Mediation Flow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('session lifecycle: createSession → message → closeSession', () => {
     it('creates a session with correct properties', async () => {
       const mockDb = {} as never;
@@ -95,6 +121,43 @@ describe('Mediation Flow', () => {
       await sessionService.closeSession('session-1');
 
       expect(closeSpy).toHaveBeenCalledWith('session-1');
+    });
+  });
+
+  describe('incrementMessageCount', () => {
+    it('returns idle-gap metrics without writing a cache-miss event when still within TTL', async () => {
+      const mockDb = makeIncrementDbMock([
+        { idleGapSeconds: 42, isCacheMiss: false, tenantId: 'tenant-1' },
+      ]);
+      const sessionService = new MediationSessionService(mockDb.db);
+
+      const result = await sessionService.incrementMessageCount('session-1');
+
+      expect(result).toEqual({ idleGapSeconds: 42, isCacheMiss: false });
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('writes a cache-miss operation log when the idle gap exceeds the cache TTL', async () => {
+      const mockDb = makeIncrementDbMock([
+        { idleGapSeconds: CACHE_TTL_SECONDS + 5, isCacheMiss: true, tenantId: 'tenant-1' },
+      ]);
+      const sessionService = new MediationSessionService(mockDb.db);
+
+      const result = await sessionService.incrementMessageCount('session-1');
+
+      expect(result).toEqual({ idleGapSeconds: CACHE_TTL_SECONDS + 5, isCacheMiss: true });
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+      expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: 'tenant-1',
+        operation: 'cache_miss',
+        sessionId: 'session-1',
+        durationMs: 0,
+        success: true,
+        metadata: {
+          idleGapSeconds: CACHE_TTL_SECONDS + 5,
+          cacheTtlSeconds: CACHE_TTL_SECONDS,
+        },
+      }));
     });
   });
 
@@ -181,7 +244,10 @@ describe('Mediation Flow', () => {
         startedAt: new Date(),
       });
       const closeSpy = vi.spyOn(sessionService, 'closeSession').mockResolvedValue();
-      const incrementSpy = vi.spyOn(sessionService, 'incrementMessageCount').mockResolvedValue();
+      const incrementSpy = vi.spyOn(sessionService, 'incrementMessageCount').mockResolvedValue({
+        idleGapSeconds: 0,
+        isCacheMiss: false,
+      });
 
       const mockGenerationService = {
         generate: vi.fn().mockResolvedValue(makeGenerationResult()),


### PR DESCRIPTION
## Summary

Spec 011 Phase 1 Task 3 (T3) — rewrites `MediationSessionService.incrementMessageCount` as a single atomic `UPDATE...FROM...RETURNING` that computes `idleGapSeconds` and `isCacheMiss` without a SELECT round-trip.

**Stacked on #48** (E1+E2+E3 bundle). Base should move to `main` once #48 merges.

## Implementation notes
- Single atomic SQL statement via Drizzle `sql` template + `.returning()`
- Self-alias in `FROM` provides access to pre-update `last_activity_at` while the row is being advanced to `NOW()`
- On cache miss, inserts `cache_miss` event to `contentOperationLogs` with `durationMs: 0` (NOT NULL column per schema.ts:282)
- Return type: `Promise<{ idleGapSeconds: number; isCacheMiss: boolean }>` — callers updated

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run tests/content/integration/mediation.test.ts`
- [x] `npm run test` (full suite)
- [ ] Live DB verification after merge (follow-up: E5 concurrency test + E8 smoke test)

## Known minor issue

Codex noted: the schema still has `last_activity_at` NOT NULL, so the specis NULL first-message path is preserved in SQL but unreachable via normal create flow. Minor — deferred to a follow-up migration decision.