### PR TITLE
test(mediation): missing idle-gap test cases (Spec 011 T5)

### DIFF
--- a/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
+++ b/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { CACHE_TTL_SECONDS } from '../../../src/content/generation/cost.js';
+import { contentMediationSessions, contentOperationLogs } from '../../../src/content/schema.js';
 import { MediationSessionService } from '../../../src/content/mediation/session.js';
 import type { ResolvedEntitlements, GenerationResult } from '../../../src/content/types.js';
 
@@ -58,6 +59,183 @@ function makeIncrementDbMock(returningRows: Array<{
     insert,
     returning,
     values,
+  };
+}
+
+type SessionRow = {
+  id: string;
+  tenantId: string;
+  apiKeyId: string;
+  userId: string;
+  activeProfileId: string | null;
+  messageCount: number;
+  startedAt: Date;
+  lastActivityAt: Date;
+  endedAt: Date | null;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheWriteTokens: number;
+  totalCacheReadTokens: number;
+  totalEstimatedCostUsd: string;
+  cacheMissCount: number;
+  maxIdleGapSeconds: number;
+};
+
+function extractSqlEqValue(cond: unknown): unknown {
+  if (cond === null || typeof cond !== 'object') return undefined;
+
+  const obj = cond as Record<string, unknown>;
+  const chunks = obj.queryChunks;
+  if (!Array.isArray(chunks)) return undefined;
+
+  for (const chunk of chunks) {
+    if (chunk === null || typeof chunk !== 'object') continue;
+
+    const value = extractSqlEqValue(chunk);
+    if (value !== undefined) return value;
+
+    const candidate = (chunk as Record<string, unknown>).value;
+    if (typeof candidate === 'string' || typeof candidate === 'number' || typeof candidate === 'boolean') {
+      if (candidate !== '' && candidate !== ' = ' && candidate !== ' is not null ' && candidate !== ' and ') {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function makeSessionRow(values: Record<string, unknown>): SessionRow {
+  return {
+    id: values.id as string,
+    tenantId: values.tenantId as string,
+    apiKeyId: values.apiKeyId as string,
+    userId: values.userId as string,
+    activeProfileId: (values.activeProfileId as string | null | undefined) ?? null,
+    messageCount: (values.messageCount as number | undefined) ?? 0,
+    startedAt: values.startedAt as Date,
+    lastActivityAt: values.lastActivityAt as Date,
+    endedAt: (values.endedAt as Date | null | undefined) ?? null,
+    totalInputTokens: (values.totalInputTokens as number | undefined) ?? 0,
+    totalOutputTokens: (values.totalOutputTokens as number | undefined) ?? 0,
+    totalCacheWriteTokens: (values.totalCacheWriteTokens as number | undefined) ?? 0,
+    totalCacheReadTokens: (values.totalCacheReadTokens as number | undefined) ?? 0,
+    totalEstimatedCostUsd: (values.totalEstimatedCostUsd as string | undefined) ?? '0',
+    cacheMissCount: (values.cacheMissCount as number | undefined) ?? 0,
+    maxIdleGapSeconds: (values.maxIdleGapSeconds as number | undefined) ?? 0,
+  };
+}
+
+function createStatefulSessionDb(options: {
+  now?: Date;
+  barrierTarget?: number;
+} = {}) {
+  const sessions = new Map<string, SessionRow>();
+  const operationLogs: Array<Record<string, unknown>> = [];
+  let now = options.now ?? new Date('2026-04-15T12:00:00.000Z');
+  let incrementEntrants = 0;
+  let releaseBarrier: (() => void) | null = null;
+  const barrier = options.barrierTarget
+    ? new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    })
+    : null;
+
+  const resolveSession = (cond: unknown): SessionRow | undefined => {
+    const sessionId = extractSqlEqValue(cond);
+    if (typeof sessionId === 'string') return sessions.get(sessionId);
+    return Array.from(sessions.values())[0];
+  };
+
+  const db = {
+    insert: vi.fn().mockImplementation((table: unknown) => ({
+      values: vi.fn().mockImplementation((values: Record<string, unknown>) => {
+        if (table === contentMediationSessions) {
+          const row = makeSessionRow(values);
+          sessions.set(row.id, row);
+          return Promise.resolve();
+        }
+
+        if (table === contentOperationLogs) {
+          operationLogs.push(values);
+        }
+
+        return Promise.resolve();
+      }),
+    })),
+    update: vi.fn().mockImplementation((table: unknown) => ({
+      set: vi.fn().mockImplementation((values: Record<string, unknown>) => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation((cond: unknown) => ({
+            returning: vi.fn().mockImplementation(async () => {
+              const session = resolveSession(cond);
+              if (!session) return [];
+
+              if (barrier && options.barrierTarget) {
+                incrementEntrants += 1;
+                if (incrementEntrants === options.barrierTarget) {
+                  releaseBarrier?.();
+                }
+                await barrier;
+              }
+
+              const idleGapSeconds = Math.max(
+                0,
+                Math.floor((now.getTime() - session.lastActivityAt.getTime()) / 1000),
+              );
+              const isCacheMiss = idleGapSeconds > CACHE_TTL_SECONDS;
+
+              session.messageCount += 1;
+              session.lastActivityAt = now;
+              session.maxIdleGapSeconds = Math.max(session.maxIdleGapSeconds, idleGapSeconds);
+              if (isCacheMiss) {
+                session.cacheMissCount += 1;
+              }
+
+              return [{
+                idleGapSeconds,
+                isCacheMiss,
+                tenantId: session.tenantId,
+              }];
+            }),
+          })),
+        }),
+        where: vi.fn().mockImplementation(async (cond: unknown) => {
+          if (table !== contentMediationSessions) return;
+          const session = resolveSession(cond);
+          if (!session) return;
+          Object.assign(session, values);
+        }),
+      })),
+    })),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockImplementation((table: unknown) => ({
+        where: vi.fn().mockImplementation((cond: unknown) => {
+          const rows = table === contentMediationSessions
+            ? Array.from(sessions.values()).filter((session) => {
+              const sessionId = extractSqlEqValue(cond);
+              return typeof sessionId !== 'string' || session.id === sessionId;
+            })
+            : [];
+
+          return {
+            limit: vi.fn().mockResolvedValue(rows),
+          };
+        }),
+      })),
+    }),
+  };
+
+  return {
+    db: db as never,
+    operationLogs,
+    sessions,
+    setNow(nextNow: Date) {
+      now = nextNow;
+    },
+    getIncrementEntrants() {
+      return incrementEntrants;
+    },
   };
 }
 
@@ -158,6 +336,80 @@ describe('Mediation Flow', () => {
           cacheTtlSeconds: CACHE_TTL_SECONDS,
         },
       }));
+    });
+
+    it('returns zero idle gap for the first message and does not log a cache miss', async () => {
+      const mockDb = createStatefulSessionDb();
+      const sessionService = new MediationSessionService(mockDb.db);
+      const session = await sessionService.createSession('tenant-1', 'key-1', 'user-1', 'profile-1');
+
+      const result = await sessionService.incrementMessageCount(session.sessionId);
+      const updatedSession = await sessionService.getSession(session.sessionId);
+
+      expect(result).toEqual({ idleGapSeconds: 0, isCacheMiss: false });
+      expect(updatedSession?.messageCount).toBe(1);
+      expect(mockDb.operationLogs).toHaveLength(0);
+    });
+
+    it('treats an idle gap at exactly the cache TTL boundary as a cache hit', async () => {
+      const now = new Date('2026-04-15T12:05:00.000Z');
+      const mockDb = createStatefulSessionDb({ now });
+      const sessionService = new MediationSessionService(mockDb.db);
+      const session = await sessionService.createSession('tenant-1', 'key-1', 'user-1');
+
+      mockDb.sessions.get(session.sessionId)!.lastActivityAt = new Date(now.getTime() - (CACHE_TTL_SECONDS * 1000));
+
+      const result = await sessionService.incrementMessageCount(session.sessionId);
+
+      expect(result).toEqual({ idleGapSeconds: CACHE_TTL_SECONDS, isCacheMiss: false });
+      expect(mockDb.operationLogs).toHaveLength(0);
+    });
+
+    it('keeps maxIdleGapSeconds at the highest observed idle gap across messages', async () => {
+      const baseTime = new Date('2026-04-15T12:00:00.000Z');
+      const mockDb = createStatefulSessionDb({ now: baseTime });
+      const sessionService = new MediationSessionService(mockDb.db);
+      const session = await sessionService.createSession('tenant-1', 'key-1', 'user-1');
+      mockDb.sessions.get(session.sessionId)!.lastActivityAt = baseTime;
+
+      mockDb.setNow(new Date(baseTime.getTime() + 100_000));
+      const first = await sessionService.incrementMessageCount(session.sessionId);
+
+      mockDb.setNow(new Date(baseTime.getTime() + 150_000));
+      const second = await sessionService.incrementMessageCount(session.sessionId);
+
+      mockDb.setNow(new Date(baseTime.getTime() + 350_000));
+      const third = await sessionService.incrementMessageCount(session.sessionId);
+
+      const updatedSession = await sessionService.getSession(session.sessionId);
+
+      expect(first).toEqual({ idleGapSeconds: 100, isCacheMiss: false });
+      expect(second).toEqual({ idleGapSeconds: 50, isCacheMiss: false });
+      expect(third).toEqual({ idleGapSeconds: 200, isCacheMiss: false });
+      expect(updatedSession?.maxIdleGapSeconds).toBe(200);
+      expect(updatedSession?.messageCount).toBe(3);
+    });
+
+    it('resolves two parallel increments with an exact +2 message count increase', async () => {
+      const mockDb = createStatefulSessionDb({
+        now: new Date('2026-04-15T12:00:00.000Z'),
+        barrierTarget: 2,
+      });
+      const sessionService = new MediationSessionService(mockDb.db);
+      const session = await sessionService.createSession('tenant-1', 'key-1', 'user-1');
+      mockDb.sessions.get(session.sessionId)!.lastActivityAt = new Date('2026-04-15T12:00:00.000Z');
+
+      const [first, second] = await Promise.all([
+        sessionService.incrementMessageCount(session.sessionId),
+        sessionService.incrementMessageCount(session.sessionId),
+      ]);
+      const updatedSession = await sessionService.getSession(session.sessionId);
+
+      expect(mockDb.getIncrementEntrants()).toBe(2);
+      expect(first).toEqual({ idleGapSeconds: 0, isCacheMiss: false });
+      expect(second).toEqual({ idleGapSeconds: 0, isCacheMiss: false });
+      expect(updatedSession?.messageCount).toBe(2);
+      expect(mockDb.operationLogs).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Four missing test cases for `incrementMessageCount` not covered by the tests E4 added in #49. Stacked on #49 → #48.

## Cases added
1. **First-message** — never-called session returns `gap=0, isCacheMiss=false`, no cache_miss event
2. **Boundary exactly 300s** — threshold is `>`, not `>=`; exactly-at-TTL does NOT trigger miss
3. **maxIdleGapSeconds tracking** — tracks MAX across messages, not latest (100s → 50s → 200s ⇒ max=200)
4. **Concurrency** — parallel `Promise.all` calls produce exactly `+2` messageCount

## Honest limitation

The concurrency test uses a barriered shared-state mock. It proves two in-flight calls resolve and the test double increments exactly by 2. It does **NOT** exercise a real Postgres race — DB-level atomicity is still inferred from the `UPDATE...RETURNING` shape in #49, not integration-tested. A follow-up DB-level concurrency test is warranted once an integration test harness with a live Postgres is set up (currently deferred to post-merge work).

## Test plan
- [x] `npx vitest run tests/content/integration/mediation.test.ts`
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] Future: live-Postgres concurrency integration test