### PR TITLE
feat(content): add AnthropicGenerationProvider

### DIFF
--- a/joyus-ai-mcp-server/package-lock.json
+++ b/joyus-ai-mcp-server/package-lock.json
@@ -1227,7 +1227,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1341,7 +1340,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2952,7 +2950,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3050,7 +3047,6 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3326,7 +3322,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5109,7 +5104,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5631,7 +5625,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5991,7 +5984,6 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8258,7 +8250,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -10068,7 +10059,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10669,7 +10659,6 @@
       "version": "1.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -10969,7 +10958,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/joyus-ai-mcp-server/package-lock.json
+++ b/joyus-ai-mcp-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.61.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@paralleldrive/cuid2": "^3.3.0",
         "axios": "^1.6.7",
@@ -62,6 +63,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.61.0.tgz",
+      "integrity": "sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/joyus-ai-mcp-server/package.json
+++ b/joyus-ai-mcp-server/package.json
@@ -25,6 +25,7 @@
     "ci": "npm run validate"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.61.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@paralleldrive/cuid2": "^3.3.0",
     "axios": "^1.6.7",

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
@@ -1,28 +1,141 @@
-import { describe, expect, it } from 'vitest';
+import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
 
 import { AnthropicGenerationProvider } from '../generator.js';
 
-describe('AnthropicGenerationProvider integration', () => {
-  it('skips clearly when ANTHROPIC_API_KEY is not set', ({ skip }) => {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      skip();
-    }
+const mockMessagesCreate = vi.hoisted(() => vi.fn());
 
-    expect(process.env.ANTHROPIC_API_KEY).toBeTruthy();
+vi.mock('@anthropic-ai/sdk', () => {
+  class RateLimitError extends Error {
+    status = 429;
+    constructor(message: string) { super(message); this.name = 'RateLimitError'; }
+  }
+  class AuthenticationError extends Error {
+    status = 401;
+    constructor(message: string) { super(message); this.name = 'AuthenticationError'; }
+  }
+
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: { create: mockMessagesCreate },
+  }));
+  Object.assign(MockAnthropic, { RateLimitError, AuthenticationError });
+
+  return { default: MockAnthropic };
+});
+
+const makeTextResponse = (text: string, stop_reason = 'end_turn') => ({
+  id: 'msg_test',
+  type: 'message',
+  role: 'assistant',
+  content: [{ type: 'text', text }],
+  model: 'claude-sonnet-4-6',
+  stop_reason,
+  usage: { input_tokens: 10, output_tokens: 5 },
+});
+
+describe('AnthropicGenerationProvider', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(Anthropic).mockImplementation(() => ({
+      messages: { create: mockMessagesCreate },
+    }) as unknown as Anthropic);
   });
 
-  it('returns a non-empty string containing 4 when ANTHROPIC_API_KEY is set', async ({ skip }) => {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      skip();
-    }
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
+  it('returns text from the first text block', async () => {
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('The answer is 42.'));
     const provider = new AnthropicGenerationProvider();
-    const response = await provider.generate(
-      'What is 2+2?',
-      'You are a math tutor. Be concise.',
-    );
+    expect(await provider.generate('What is the answer?', 'Be helpful.')).toBe('The answer is 42.');
+  });
 
-    expect(response.trim().length).toBeGreaterThan(0);
-    expect(response).toContain('4');
+  it('throws when response contains no text block', async () => {
+    mockMessagesCreate.mockResolvedValue({
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'search', input: {} }],
+      stop_reason: 'tool_use',
+    });
+    const provider = new AnthropicGenerationProvider();
+    await expect(provider.generate('query', 'system')).rejects.toThrow(
+      'Anthropic response contained no text block',
+    );
+  });
+
+  it('wraps RateLimitError with retryable: true', async () => {
+    mockMessagesCreate.mockRejectedValue(new (Anthropic as any).RateLimitError('Rate limited'));
+    const provider = new AnthropicGenerationProvider();
+    await expect(provider.generate('query', 'system')).rejects.toMatchObject({
+      message: expect.stringContaining('rate limit'),
+      retryable: true,
+    });
+  });
+
+  it('wraps AuthenticationError with retryable: false', async () => {
+    mockMessagesCreate.mockRejectedValue(
+      new (Anthropic as any).AuthenticationError('Unauthorized'),
+    );
+    const provider = new AnthropicGenerationProvider();
+    await expect(provider.generate('query', 'system')).rejects.toMatchObject({
+      message: expect.stringContaining('authentication failed'),
+      retryable: false,
+    });
+  });
+
+  it('rethrows unknown errors unchanged', async () => {
+    const cause = new Error('Network failure');
+    mockMessagesCreate.mockRejectedValue(cause);
+    const provider = new AnthropicGenerationProvider();
+    await expect(provider.generate('query', 'system')).rejects.toBe(cause);
+  });
+
+  it('logs a warning when stop_reason is max_tokens', async () => {
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('Partial response...', 'max_tokens'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new AnthropicGenerationProvider();
+    await provider.generate('query', 'system');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('truncated'));
+  });
+
+  it('uses JOYUS_ANTHROPIC_MODEL env var as model', async () => {
+    vi.stubEnv('JOYUS_ANTHROPIC_MODEL', 'claude-opus-4-7');
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('ok'));
+    const provider = new AnthropicGenerationProvider();
+    await provider.generate('q', 's');
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-opus-4-7' }),
+    );
+  });
+
+  it('options.model takes precedence over JOYUS_ANTHROPIC_MODEL', async () => {
+    vi.stubEnv('JOYUS_ANTHROPIC_MODEL', 'claude-opus-4-7');
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('ok'));
+    const provider = new AnthropicGenerationProvider({ model: 'claude-haiku-4-5-20251001' });
+    await provider.generate('q', 's');
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }),
+    );
+  });
+
+  it('passes options.maxTokens to the API call', async () => {
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('ok'));
+    const provider = new AnthropicGenerationProvider({ maxTokens: 512 });
+    await provider.generate('q', 's');
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 512 }),
+    );
+  });
+
+  it('sends system prompt with ephemeral cache_control', async () => {
+    mockMessagesCreate.mockResolvedValue(makeTextResponse('ok'));
+    const provider = new AnthropicGenerationProvider();
+    await provider.generate('q', 'You are helpful.');
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: [
+          { type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } },
+        ],
+      }),
+    );
   });
 });

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { AnthropicGenerationProvider } from '../generator.js';
+
+describe('AnthropicGenerationProvider integration', () => {
+  it('skips clearly when ANTHROPIC_API_KEY is not set', ({ skip }) => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      skip();
+    }
+
+    expect(process.env.ANTHROPIC_API_KEY).toBeTruthy();
+  });
+
+  it('returns a non-empty string containing 4 when ANTHROPIC_API_KEY is set', async ({ skip }) => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      skip();
+    }
+
+    const provider = new AnthropicGenerationProvider();
+    const response = await provider.generate(
+      'What is 2+2?',
+      'You are a math tutor. Be concise.',
+    );
+
+    expect(response.trim().length).toBeGreaterThan(0);
+    expect(response).toContain('4');
+  });
+});

--- a/joyus-ai-mcp-server/src/content/generation/generator.ts
+++ b/joyus-ai-mcp-server/src/content/generation/generator.ts
@@ -75,21 +75,56 @@ export class AnthropicGenerationProvider implements GenerationProvider {
   private model: string;
   private maxTokens: number;
 
-  constructor(options?: { model?: string; maxTokens?: number }) {
-    this.client = new Anthropic();
+  constructor(options?: {
+    model?: string;
+    maxTokens?: number;
+    timeoutMs?: number;
+    maxRetries?: number;
+  }) {
+    this.client = new Anthropic({
+      timeout: options?.timeoutMs ?? 60_000,
+      maxRetries: options?.maxRetries ?? 2,
+    });
     this.model = options?.model ?? process.env.JOYUS_ANTHROPIC_MODEL ?? 'claude-sonnet-4-6';
     this.maxTokens = options?.maxTokens ?? 4096;
   }
 
   async generate(prompt: string, systemPrompt: string): Promise<string> {
-    const response = await this.client.messages.create({
-      model: this.model,
-      max_tokens: this.maxTokens,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: prompt }],
-    });
-    const textBlock = response.content.find(block => block.type === 'text');
-    if (!textBlock || textBlock.type !== 'text') {
+    const response = await this.client.messages
+      .create({
+        model: this.model,
+        max_tokens: this.maxTokens,
+        system: [
+          { type: 'text' as const, text: systemPrompt, cache_control: { type: 'ephemeral' as const } },
+        ],
+        messages: [{ role: 'user', content: prompt }],
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Anthropic.RateLimitError) {
+          throw Object.assign(
+            new Error('Anthropic rate limit exceeded — request is retryable'),
+            { retryable: true, cause: err },
+          );
+        }
+        if (err instanceof Anthropic.AuthenticationError) {
+          throw Object.assign(
+            new Error('Anthropic authentication failed — check ANTHROPIC_API_KEY'),
+            { retryable: false, cause: err },
+          );
+        }
+        throw err;
+      });
+
+    if (response.stop_reason === 'max_tokens') {
+      console.warn(
+        `[AnthropicGenerationProvider] Response truncated at max_tokens=${this.maxTokens} for model ${this.model}`,
+      );
+    }
+
+    const textBlock = response.content.find(
+      (block): block is Anthropic.TextBlock => block.type === 'text',
+    );
+    if (!textBlock) {
       throw new Error('Anthropic response contained no text block');
     }
     return textBlock.text;

--- a/joyus-ai-mcp-server/src/content/generation/generator.ts
+++ b/joyus-ai-mcp-server/src/content/generation/generator.ts
@@ -5,6 +5,8 @@
  * system prompt from the retrieved context and optional voice profile.
  */
 
+import Anthropic from '@anthropic-ai/sdk';
+
 import type { RetrievalResult } from './retriever.js';
 
 export interface GenerationProvider {
@@ -65,5 +67,31 @@ export class PlaceholderGenerationProvider implements GenerationProvider {
       `[Generation not configured] Query received: "${prompt}". ` +
       `Configure a GenerationProvider to enable AI responses.`
     );
+  }
+}
+
+export class AnthropicGenerationProvider implements GenerationProvider {
+  private client: Anthropic;
+  private model: string;
+  private maxTokens: number;
+
+  constructor(options?: { model?: string; maxTokens?: number }) {
+    this.client = new Anthropic();
+    this.model = options?.model ?? process.env.JOYUS_ANTHROPIC_MODEL ?? 'claude-sonnet-4-6';
+    this.maxTokens = options?.maxTokens ?? 4096;
+  }
+
+  async generate(prompt: string, systemPrompt: string): Promise<string> {
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: this.maxTokens,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const textBlock = response.content.find(block => block.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      throw new Error('Anthropic response contained no text block');
+    }
+    return textBlock.text;
   }
 }

--- a/joyus-ai-mcp-server/src/content/generation/index.ts
+++ b/joyus-ai-mcp-server/src/content/generation/index.ts
@@ -115,8 +115,8 @@ export {
   type RetrievedItem,
 } from './retriever.js';
 export {
-  ContentGenerator,
   AnthropicGenerationProvider,
+  ContentGenerator,
   PlaceholderGenerationProvider,
   type GenerationProvider,
   type GenerationOutput,

--- a/joyus-ai-mcp-server/src/content/generation/index.ts
+++ b/joyus-ai-mcp-server/src/content/generation/index.ts
@@ -116,6 +116,7 @@ export {
 } from './retriever.js';
 export {
   ContentGenerator,
+  AnthropicGenerationProvider,
   PlaceholderGenerationProvider,
   type GenerationProvider,
   type GenerationOutput,

--- a/joyus-ai-mcp-server/src/content/index.ts
+++ b/joyus-ai-mcp-server/src/content/index.ts
@@ -11,7 +11,12 @@ import type { DrizzleClient } from './types.js';
 import { connectorRegistry } from './connectors/index.js';
 import { PgFtsProvider, SearchService } from './search/index.js';
 import { EntitlementCache, EntitlementService, HttpEntitlementResolver } from './entitlements/index.js';
-import { GenerationService, PlaceholderGenerationProvider, type SearchService as GenSearchService } from './generation/index.js';
+import {
+  AnthropicGenerationProvider,
+  GenerationService,
+  PlaceholderGenerationProvider,
+  type SearchService as GenSearchService,
+} from './generation/index.js';
 import { SyncEngine, initializeSyncScheduler } from './sync/index.js';
 import { HealthChecker } from './monitoring/health.js';
 import { MetricsCollector } from './monitoring/metrics.js';
@@ -51,7 +56,9 @@ export async function initializeContentModule(
     const entitlementService = new EntitlementService(entitlementResolver, entitlementCache, db);
 
     // 3. Generation (bridge search service to generation's expected interface)
-    const generationProvider = new PlaceholderGenerationProvider();
+    const generationProvider = process.env.ANTHROPIC_API_KEY
+      ? new AnthropicGenerationProvider()
+      : new PlaceholderGenerationProvider();
     const generationService = new GenerationService(
       searchService as unknown as GenSearchService,
       generationProvider,

--- a/joyus-ai-mcp-server/src/content/index.ts
+++ b/joyus-ai-mcp-server/src/content/index.ts
@@ -56,9 +56,11 @@ export async function initializeContentModule(
     const entitlementService = new EntitlementService(entitlementResolver, entitlementCache, db);
 
     // 3. Generation (bridge search service to generation's expected interface)
-    const generationProvider = process.env.ANTHROPIC_API_KEY
+    const hasAnthropicKey = (process.env.ANTHROPIC_API_KEY ?? '').trim().length > 0;
+    const generationProvider = hasAnthropicKey
       ? new AnthropicGenerationProvider()
       : new PlaceholderGenerationProvider();
+    console.log(`[content] Generation provider: ${hasAnthropicKey ? 'Anthropic' : 'Placeholder'}`);
     const generationService = new GenerationService(
       searchService as unknown as GenSearchService,
       generationProvider,


### PR DESCRIPTION
## Summary

Wires `@anthropic-ai/sdk` (pinned `^0.61.0`) as a real `GenerationProvider` that activates when `ANTHROPIC_API_KEY` is set. `PlaceholderGenerationProvider` remains the fallback.

Model ID configurable via `JOYUS_ANTHROPIC_MODEL` env var (default: `claude-sonnet-4-6`).

## Changes
- `package.json`: add `@anthropic-ai/sdk` dep
- `src/content/generation/generator.ts`: add `AnthropicGenerationProvider` class
- `src/content/generation/index.ts`: re-export
- `src/content/index.ts`: env-gated provider swap
- `src/content/generation/__tests__/anthropic-provider.test.ts`: gated integration test

## Test plan
- [x] typecheck passes
- [x] 372 tests pass
- [ ] Manual smoke test with real API key