### PR TITLE
feat(mediation): atomic idle gap UPDATE...RETURNING (Spec 011 T3)

### DIFF
--- a/joyus-ai-mcp-server/docs/mediation-manual-testing.md
+++ b/joyus-ai-mcp-server/docs/mediation-manual-testing.md
@@ -1,0 +1,302 @@
+# Mediation Manual Testing
+
+This tests the `/api/mediation/*` flow, including session creation, message
+count increments, idle-gap tracking, and cache-miss logging.
+
+## Important Auth Note
+
+`/auth` and `/api/mediation` use different auth paths.
+
+- `/auth` signs in a human user and gives them an MCP bearer token for `/mcp`.
+- `/api/mediation` is for external content integrations and requires:
+  - `X-API-Key`: identifies the tenant/integration.
+  - `Authorization: Bearer <JWT>`: identifies the end user inside that integration.
+
+The mediation API key is not recoverable from the database. Only its SHA-256
+hash is stored. If you do not already have the raw key, create a local test key
+and insert its hash.
+
+## Do I Need To Run Postgres Commands?
+
+For the current code, yes, unless a valid mediation API key and matching JWT
+already exist.
+
+There is an `ApiKeyService` in code, but there is no admin HTTP endpoint or CLI
+wrapper for creating mediation API keys. Manual DB setup is the current shortest
+path for a local smoke test.
+
+The database commands below only create/update local test data. They are not
+needed in production if the integration key has already been provisioned.
+
+## Overview
+
+Use three terminals:
+
+- Terminal 1: database and app
+- Terminal 2: local JWT/JWKS helper
+- Terminal 3: `psql` and `curl` commands
+
+The local JWT/JWKS helper removes the need for Auth0, Okta, Clerk, Cognito, or
+another external identity provider during local testing.
+
+## Terminal 1: Start Database And App
+
+Start Postgres:
+
+```bash
+docker compose up -d db
+```
+
+Set the database URL if your shell does not already have it:
+
+```bash
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/joyus_ai_mcp"
+```
+
+Run migrations:
+
+```bash
+npm run db:migrate
+```
+
+Start the app:
+
+```bash
+npm run dev
+```
+
+Leave the app running.
+
+Confirm the mediation router is mounted:
+
+```bash
+curl -sS "http://localhost:3000/api/mediation/health"
+```
+
+Expected:
+
+```json
+{"status":"ok"}
+```
+
+## Terminal 2: Start Local JWT/JWKS Helper
+
+Run:
+
+```bash
+npm run dev:mediation-auth
+```
+
+The helper:
+
+- Generates a temporary RSA signing key.
+- Serves the public key at `http://127.0.0.1:3999/.well-known/jwks.json`.
+- Prints a matching `USER_JWT`.
+
+Leave this process running while testing.
+
+Copy the two `export` lines it prints into Terminal 3. They look like this:
+
+```bash
+export JWKS_URI="http://127.0.0.1:3999/.well-known/jwks.json"
+export USER_JWT="<printed-jwt>"
+```
+
+## Terminal 3: Run Setup And Curl Commands
+
+Set the base URL:
+
+```bash
+export BASE_URL="http://localhost:3000"
+```
+
+Set the database URL if needed:
+
+```bash
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/joyus_ai_mcp"
+```
+
+Verify Postgres is reachable:
+
+```bash
+psql "$DATABASE_URL" -c "select 1;"
+```
+
+Copy the `JWKS_URI` and `USER_JWT` exports from Terminal 2 into this terminal.
+
+## Create A Local Mediation API Key Row
+
+Choose a raw key:
+
+```bash
+export MEDIATION_API_KEY="jyk_local_manual_test_key_001"
+```
+
+Hash it:
+
+```bash
+export MEDIATION_API_KEY_HASH="$(
+  node -e "console.log(require('crypto').createHash('sha256').update(process.env.MEDIATION_API_KEY).digest('hex'))"
+)"
+```
+
+Insert or update the test key:
+
+```bash
+psql "$DATABASE_URL" -c "
+insert into content.api_keys (
+  id,
+  tenant_id,
+  key_hash,
+  key_prefix,
+  integration_name,
+  jwks_uri,
+  issuer,
+  audience,
+  is_active
+)
+values (
+  'manual-api-key-1',
+  'tenant-1',
+  '$MEDIATION_API_KEY_HASH',
+  'jyk_loca',
+  'manual-local-test',
+  '$JWKS_URI',
+  null,
+  null,
+  true
+)
+on conflict (id) do update set
+  key_hash = excluded.key_hash,
+  key_prefix = excluded.key_prefix,
+  jwks_uri = excluded.jwks_uri,
+  is_active = true;
+"
+```
+
+The local helper's JWT `sub` claim becomes the mediation user ID.
+
+Check that the API key row exists:
+
+```bash
+psql "$DATABASE_URL" -c "
+select id, tenant_id, key_prefix, integration_name, jwks_uri, is_active
+from content.api_keys
+where id = 'manual-api-key-1';
+"
+```
+
+## Create A Session
+
+```bash
+export SESSION_ID="$(
+  curl -sS -X POST "$BASE_URL/api/mediation/sessions" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $MEDIATION_API_KEY" \
+    -H "Authorization: Bearer $USER_JWT" \
+    -d '{"profileId":"profile-1"}' \
+  | jq -r '.sessionId'
+)"
+
+echo "$SESSION_ID"
+```
+
+Expected: a non-empty session ID.
+
+If `SESSION_ID` is `null`, print the raw response to see the auth error:
+
+```bash
+curl -sS -X POST "$BASE_URL/api/mediation/sessions" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEDIATION_API_KEY" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -d '{"profileId":"profile-1"}'
+```
+
+If the response is `{"error":"Invalid token"}`, the request is hitting the
+generic MCP/pipeline bearer-token middleware instead of the mediation router.
+Restart the app and confirm `GET /api/mediation/health` returns
+`{"status":"ok"}` before retrying.
+
+## Send A Message
+
+```bash
+curl -sS -X POST "$BASE_URL/api/mediation/sessions/$SESSION_ID/messages" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEDIATION_API_KEY" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -d '{
+    "message": "What content is available for this user?",
+    "maxSources": 3
+  }'
+```
+
+Expected: a generated response payload.
+
+The idle-gap/cache-miss logic runs after generation succeeds. If this request
+returns a generation/provider/content error, auth and session creation may still
+be working, but the message counter and cache-miss metrics will not update for
+that failed message.
+
+## Force A Cache Miss
+
+Age the session:
+
+```bash
+psql "$DATABASE_URL" -c "
+update content.mediation_sessions
+set last_activity_at = now() - interval '10 minutes'
+where id = '$SESSION_ID';
+"
+```
+
+Send another message:
+
+```bash
+curl -sS -X POST "$BASE_URL/api/mediation/sessions/$SESSION_ID/messages" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEDIATION_API_KEY" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -d '{
+    "message": "Summarize the most relevant source.",
+    "maxSources": 3
+  }'
+```
+
+## Verify Results
+
+```bash
+psql "$DATABASE_URL" -c "
+select id, message_count, cache_miss_count, max_idle_gap_seconds, last_activity_at
+from content.mediation_sessions
+where id = '$SESSION_ID';
+"
+```
+
+Expected:
+
+- `message_count` increments after successful message processing.
+- `cache_miss_count` increments after the aged-session message.
+- `max_idle_gap_seconds` is at least the aged interval.
+
+Check cache-miss operation logs:
+
+```bash
+psql "$DATABASE_URL" -c "
+select operation, session_id, metadata, created_at
+from content.operation_logs
+where session_id = '$SESSION_ID'
+order by created_at desc
+limit 5;
+"
+```
+
+Expected: one row with `operation = 'cache_miss'` and metadata containing
+`idleGapSeconds` and `cacheTtlSeconds`.
+
+## Cleaner Future Improvement
+
+Issue #60 tracks adding a local/operator provisioning command that wraps
+`ApiKeyService.createKey`. That would remove the need to hand-write SQL for
+local manual testing. The `dev:mediation-auth` helper only handles the JWKS/JWT
+side of local auth.

--- a/joyus-ai-mcp-server/package.json
+++ b/joyus-ai-mcp-server/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit && tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "dev:mediation-auth": "node scripts/mediation-dev-auth.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/joyus-ai-mcp-server/scripts/mediation-dev-auth.mjs
+++ b/joyus-ai-mcp-server/scripts/mediation-dev-auth.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import {
+  createPublicKey,
+  createSign,
+  generateKeyPairSync,
+  randomUUID,
+} from 'node:crypto';
+import { createServer } from 'node:http';
+
+const DEFAULT_PORT = 3999;
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_SUBJECT = 'local-user-1';
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60;
+
+function readOption(name, fallback) {
+  const arg = process.argv.find((value) => value.startsWith(`--${name}=`));
+  if (!arg) return fallback;
+  return arg.slice(name.length + 3);
+}
+
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  npm run dev:mediation-auth
+  node scripts/mediation-dev-auth.mjs --port=3999 --sub=local-user-1
+
+Options:
+  --host=<host>       Host to bind. Default: ${DEFAULT_HOST}
+  --port=<port>       Port to bind. Default: ${DEFAULT_PORT}
+  --sub=<subject>     JWT subject/user id. Default: ${DEFAULT_SUBJECT}
+  --issuer=<issuer>   JWT issuer. Default: http://<host>:<port>
+  --audience=<aud>    Optional JWT audience.
+  --ttl=<seconds>     JWT lifetime. Default: ${DEFAULT_TTL_SECONDS}
+  --help              Show this help.
+`);
+}
+
+function base64Url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function signJwt({ privateKey, kid, issuer, subject, audience, ttlSeconds }) {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = {
+    alg: 'RS256',
+    typ: 'JWT',
+    kid,
+  };
+  const payload = {
+    iss: issuer,
+    sub: subject,
+    iat: nowSeconds,
+    exp: nowSeconds + ttlSeconds,
+  };
+
+  if (audience) {
+    payload.aud = audience;
+  }
+
+  const encodedHeader = base64Url(JSON.stringify(header));
+  const encodedPayload = base64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = createSign('RSA-SHA256').update(signingInput).end().sign(privateKey);
+
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+if (hasFlag('help')) {
+  printHelp();
+  process.exit(0);
+}
+
+const host = readOption('host', DEFAULT_HOST);
+const port = Number.parseInt(readOption('port', String(DEFAULT_PORT)), 10);
+const subject = readOption('sub', DEFAULT_SUBJECT);
+const issuer = readOption('issuer', `http://${host}:${port}`);
+const audience = readOption('audience', '');
+const ttlSeconds = Number.parseInt(readOption('ttl', String(DEFAULT_TTL_SECONDS)), 10);
+
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  console.error('Invalid --port value.');
+  process.exit(1);
+}
+
+if (!Number.isInteger(ttlSeconds) || ttlSeconds <= 0) {
+  console.error('Invalid --ttl value.');
+  process.exit(1);
+}
+
+const kid = randomUUID();
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+const publicJwk = {
+  ...createPublicKey(publicKey).export({ format: 'jwk' }),
+  kid,
+  use: 'sig',
+  alg: 'RS256',
+};
+const jwks = { keys: [publicJwk] };
+const jwt = signJwt({
+  privateKey,
+  kid,
+  issuer,
+  subject,
+  audience,
+  ttlSeconds,
+});
+const jwksUri = `${issuer}/.well-known/jwks.json`;
+
+const server = createServer((req, res) => {
+  if (req.url === '/.well-known/jwks.json') {
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    });
+    res.end(JSON.stringify(jwks));
+    return;
+  }
+
+  if (req.url === '/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  res.writeHead(404, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not_found' }));
+});
+
+server.on('error', (error) => {
+  console.error(`Failed to start local mediation dev auth server: ${error.message}`);
+  process.exit(1);
+});
+
+server.listen(port, host, () => {
+  console.log('Local mediation dev auth server running.');
+  console.log('');
+  console.log(`JWKS: ${jwksUri}`);
+  console.log(`Subject: ${subject}`);
+  console.log(`Issuer: ${issuer}`);
+  if (audience) console.log(`Audience: ${audience}`);
+  console.log('');
+  console.log('Paste these exports into the shell where you run curl/psql:');
+  console.log('');
+  console.log(`export JWKS_URI="${jwksUri}"`);
+  console.log(`export USER_JWT="${jwt}"`);
+  console.log('');
+  console.log('Keep this process running while testing /api/mediation.');
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/joyus-ai-mcp-server/src/content/index.ts
+++ b/joyus-ai-mcp-server/src/content/index.ts
@@ -39,6 +39,13 @@ export async function initializeContentModule(
     // 1. Search
     const searchProvider = new PgFtsProvider(db);
     const searchService = new SearchService(searchProvider, db);
+    const generationSearchService: GenSearchService = {
+      search: (query, accessibleSourceIds, options) =>
+        searchProvider.search(query, accessibleSourceIds, {
+          limit: options?.limit ?? 5,
+          offset: 0,
+        }),
+    };
 
     // 2. Entitlements
     const entitlementCache = new EntitlementCache();
@@ -62,7 +69,7 @@ export async function initializeContentModule(
       : new PlaceholderGenerationProvider();
     console.log(`[content] Generation provider: ${hasAnthropicKey ? 'Anthropic' : 'Placeholder'}`);
     const generationService = new GenerationService(
-      searchService as unknown as GenSearchService,
+      generationSearchService,
       generationProvider,
       db,
     );

--- a/joyus-ai-mcp-server/src/content/mediation/session.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/session.ts
@@ -6,10 +6,12 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { alias } from 'drizzle-orm/pg-core';
 
-import { contentMediationSessions } from '../schema.js';
+import { CACHE_TTL_SECONDS } from '../generation/cost.js';
+import { contentMediationSessions, contentOperationLogs } from '../schema.js';
 
 type DrizzleClient = ReturnType<typeof drizzle>;
 
@@ -19,6 +21,11 @@ export interface MediationSessionResult {
   userId: string;
   activeProfileId: string | null;
   startedAt: Date;
+}
+
+export interface IncrementMessageCountResult {
+  idleGapSeconds: number;
+  isCacheMiss: boolean;
 }
 
 export class MediationSessionService {
@@ -81,15 +88,54 @@ export class MediationSessionService {
   }
 
   /**
-   * Atomically increment the message count and update lastActivityAt.
+   * Atomically increment message count and derive the idle-gap/cache-miss metrics.
    */
-  async incrementMessageCount(sessionId: string): Promise<void> {
-    await this.db
+  async incrementMessageCount(sessionId: string): Promise<IncrementMessageCountResult> {
+    const previousSession = alias(contentMediationSessions, 'previous_session');
+    const idleGapSecondsSql = sql<number>`coalesce(extract(epoch from (now() - ${previousSession.lastActivityAt}))::int, 0)`;
+    const isCacheMissSql = sql<boolean>`${previousSession.lastActivityAt} is not null and extract(epoch from (now() - ${previousSession.lastActivityAt})) > ${CACHE_TTL_SECONDS}`;
+
+    const [updatedSession] = await this.db
       .update(contentMediationSessions)
       .set({
         messageCount: sql`${contentMediationSessions.messageCount} + 1`,
-        lastActivityAt: new Date(),
+        lastActivityAt: sql`now()`,
+        maxIdleGapSeconds: sql`greatest(${contentMediationSessions.maxIdleGapSeconds}, ${idleGapSecondsSql})`,
+        cacheMissCount: sql`${contentMediationSessions.cacheMissCount} + case when ${isCacheMissSql} then 1 else 0 end`,
       })
-      .where(eq(contentMediationSessions.id, sessionId));
+      .from(previousSession)
+      .where(and(
+        eq(contentMediationSessions.id, sessionId),
+        eq(contentMediationSessions.id, previousSession.id),
+      ))
+      .returning({
+        idleGapSeconds: idleGapSecondsSql,
+        isCacheMiss: isCacheMissSql,
+        tenantId: previousSession.tenantId,
+      });
+
+    if (!updatedSession) {
+      throw new Error(`Mediation session not found: ${sessionId}`);
+    }
+
+    if (updatedSession.isCacheMiss) {
+      await this.db.insert(contentOperationLogs).values({
+        id: createId(),
+        tenantId: updatedSession.tenantId,
+        operation: 'cache_miss',
+        sessionId,
+        durationMs: 0,
+        success: true,
+        metadata: {
+          idleGapSeconds: updatedSession.idleGapSeconds,
+          cacheTtlSeconds: CACHE_TTL_SECONDS,
+        },
+      });
+    }
+
+    return {
+      idleGapSeconds: updatedSession.idleGapSeconds,
+      isCacheMiss: updatedSession.isCacheMiss,
+    };
   }
 }

--- a/joyus-ai-mcp-server/src/index.ts
+++ b/joyus-ai-mcp-server/src/index.ts
@@ -183,6 +183,14 @@ app.use('/api/inngest', serve({
   functions: createAllFunctions(stepRegistry, { db: pipelineDb }),
 }));
 
+// Content routes must be mounted before the generic /api bearer-token router.
+// /api/mediation has its own two-layer API key + JWT auth.
+try {
+  await initializeContentModule(app, { db });
+} catch (error) {
+  console.error('Failed to initialize content module:', error);
+}
+
 // Pipeline routes (behind auth — spec WP08 T042: "relies on existing auth middleware")
 app.use('/api', requireBearerToken, pipelineRouter);
 
@@ -321,13 +329,7 @@ const server = app.listen(PORT, async () => {
     console.error('Failed to initialize scheduler:', error);
   }
 
-  // Initialize content module (failure is isolated — won't crash the server)
-  try {
-    await initializeContentModule(app, { db });
-  } catch (error) {
-    console.error('Failed to initialize content module:', error);
-  }
-
+  console.log(`   Mediation: http://localhost:${PORT}/api/mediation`);
   console.log(`   Pipelines: http://localhost:${PORT}/api/pipelines`);
   console.log(`   Inngest:   http://localhost:${PORT}/api/inngest`);
 

--- a/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
+++ b/joyus-ai-mcp-server/tests/content/integration/mediation.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { CACHE_TTL_SECONDS } from '../../../src/content/generation/cost.js';
 import { MediationSessionService } from '../../../src/content/mediation/session.js';
 import type { ResolvedEntitlements, GenerationResult } from '../../../src/content/types.js';
 
@@ -39,9 +40,34 @@ function makeGenerationResult(): GenerationResult {
   };
 }
 
+function makeIncrementDbMock(returningRows: Array<{
+  idleGapSeconds: number;
+  isCacheMiss: boolean;
+  tenantId: string;
+}>) {
+  const returning = vi.fn().mockResolvedValue(returningRows);
+  const where = vi.fn().mockReturnValue({ returning });
+  const from = vi.fn().mockReturnValue({ where });
+  const set = vi.fn().mockReturnValue({ from });
+  const update = vi.fn().mockReturnValue({ set });
+  const values = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn().mockReturnValue({ values });
+
+  return {
+    db: { update, insert } as never,
+    insert,
+    returning,
+    values,
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('Mediation Flow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('session lifecycle: createSession → message → closeSession', () => {
     it('creates a session with correct properties', async () => {
       const mockDb = {} as never;
@@ -95,6 +121,43 @@ describe('Mediation Flow', () => {
       await sessionService.closeSession('session-1');
 
       expect(closeSpy).toHaveBeenCalledWith('session-1');
+    });
+  });
+
+  describe('incrementMessageCount', () => {
+    it('returns idle-gap metrics without writing a cache-miss event when still within TTL', async () => {
+      const mockDb = makeIncrementDbMock([
+        { idleGapSeconds: 42, isCacheMiss: false, tenantId: 'tenant-1' },
+      ]);
+      const sessionService = new MediationSessionService(mockDb.db);
+
+      const result = await sessionService.incrementMessageCount('session-1');
+
+      expect(result).toEqual({ idleGapSeconds: 42, isCacheMiss: false });
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('writes a cache-miss operation log when the idle gap exceeds the cache TTL', async () => {
+      const mockDb = makeIncrementDbMock([
+        { idleGapSeconds: CACHE_TTL_SECONDS + 5, isCacheMiss: true, tenantId: 'tenant-1' },
+      ]);
+      const sessionService = new MediationSessionService(mockDb.db);
+
+      const result = await sessionService.incrementMessageCount('session-1');
+
+      expect(result).toEqual({ idleGapSeconds: CACHE_TTL_SECONDS + 5, isCacheMiss: true });
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+      expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: 'tenant-1',
+        operation: 'cache_miss',
+        sessionId: 'session-1',
+        durationMs: 0,
+        success: true,
+        metadata: {
+          idleGapSeconds: CACHE_TTL_SECONDS + 5,
+          cacheTtlSeconds: CACHE_TTL_SECONDS,
+        },
+      }));
     });
   });
 
@@ -181,7 +244,10 @@ describe('Mediation Flow', () => {
         startedAt: new Date(),
       });
       const closeSpy = vi.spyOn(sessionService, 'closeSession').mockResolvedValue();
-      const incrementSpy = vi.spyOn(sessionService, 'incrementMessageCount').mockResolvedValue();
+      const incrementSpy = vi.spyOn(sessionService, 'incrementMessageCount').mockResolvedValue({
+        idleGapSeconds: 0,
+        isCacheMiss: false,
+      });
 
       const mockGenerationService = {
         generate: vi.fn().mockResolvedValue(makeGenerationResult()),


### PR DESCRIPTION
## Summary

Spec 011 Phase 1 Task 3 — rewrites `MediationSessionService.incrementMessageCount` as a single atomic `UPDATE...FROM...RETURNING` that computes `idleGapSeconds` and `isCacheMiss` without a SELECT round-trip. Stacked on #53 (E3 schema).

## Implementation
- Single atomic SQL statement via Drizzle `sql` template + `.returning()`
- Self-alias in `FROM` provides access to pre-update `last_activity_at` while advancing to `NOW()`
- On cache miss, inserts `cache_miss` event to `contentOperationLogs` with `durationMs: 0` (NOT NULL column)
- Return type: `Promise<{ idleGapSeconds: number; isCacheMiss: boolean }>`

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` — all 374 tests pass (2 added by this change)