### PR TITLE
[codex] Fix content FTS source filtering for mediation smoke

### DIFF
--- a/joyus-ai-mcp-server/src/content/search/pg-fts-provider.ts
+++ b/joyus-ai-mcp-server/src/content/search/pg-fts-provider.ts
@@ -53,6 +53,8 @@ export class PgFtsProvider implements SearchProvider {
       return [];
     }
 
+    // Bind each source id as a scalar parameter; raw ANY($array) binding is
+    // driver-sensitive and can drift from the multi-source search contract.
     const sourceIdList = sql.join(sourceIds.map((id) => sql`${id}`), sql`, `);
 
     const rows = await this.db.execute<FtsRow>(sql`

--- a/joyus-ai-mcp-server/src/content/search/pg-fts-provider.ts
+++ b/joyus-ai-mcp-server/src/content/search/pg-fts-provider.ts
@@ -53,6 +53,8 @@ export class PgFtsProvider implements SearchProvider {
       return [];
     }
 
+    const sourceIdList = sql.join(sourceIds.map((id) => sql`${id}`), sql`, `);
+
     const rows = await this.db.execute<FtsRow>(sql`
       SELECT
         id,
@@ -68,7 +70,7 @@ export class PgFtsProvider implements SearchProvider {
         metadata,
         is_stale
       FROM content.items
-      WHERE source_id = ANY(${sourceIds})
+      WHERE source_id IN (${sourceIdList})
         AND search_vector @@ plainto_tsquery('english', ${query})
       ORDER BY score DESC
       LIMIT ${options.limit}

--- a/joyus-ai-mcp-server/tests/content/integration/pg-fts-provider.test.ts
+++ b/joyus-ai-mcp-server/tests/content/integration/pg-fts-provider.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PgFtsProvider } from '../../../src/content/search/pg-fts-provider.js';
+
+describe('PgFtsProvider', () => {
+  it('binds accessible source ids as scalar values in an IN list', async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    };
+    const provider = new PgFtsProvider(db as never);
+
+    await provider.search('multi tenant architecture', ['source-a', 'source-b'], {
+      limit: 5,
+      offset: 0,
+    });
+
+    const query = db.execute.mock.calls[0]?.[0];
+    const chunks = query?.queryChunks ?? [];
+    const sqlText = chunks
+      .map((chunk: unknown) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk)) return chunk.join('');
+        if (chunk && typeof chunk === 'object' && 'value' in chunk) {
+          const value = (chunk as { value: unknown }).value;
+          return Array.isArray(value) ? value.join('') : String(value);
+        }
+        return '';
+      })
+      .join('');
+
+    expect(sqlText).toContain('source_id IN (');
+    expect(sqlText).not.toContain('source_id = ANY');
+    expect(db.execute).toHaveBeenCalledOnce();
+  });
+});

--- a/joyus-ai-mcp-server/tests/content/integration/pg-fts-provider.test.ts
+++ b/joyus-ai-mcp-server/tests/content/integration/pg-fts-provider.test.ts
@@ -1,8 +1,80 @@
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it, vi } from 'vitest';
 
 import { PgFtsProvider } from '../../../src/content/search/pg-fts-provider.js';
 
 describe('PgFtsProvider', () => {
+  it('preserves existing empty-input guards without querying the database', async () => {
+    const db = {
+      execute: vi.fn(),
+    };
+    const provider = new PgFtsProvider(db as never);
+
+    await expect(
+      provider.search('   ', ['source-a'], { limit: 5, offset: 0 }),
+    ).resolves.toEqual([]);
+    await expect(
+      provider.search('multi tenant architecture', [], { limit: 5, offset: 0 }),
+    ).resolves.toEqual([]);
+
+    expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing database row mapping for search results', async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            id: 'item-1',
+            source_id: 'source-a',
+            title: 'Architecture Notes',
+            excerpt: null,
+            score: '0.75',
+            metadata: null,
+            is_stale: 0,
+          },
+          {
+            id: 'item-2',
+            source_id: 'source-b',
+            title: 'Tenant Guide',
+            excerpt: 'tenant architecture excerpt',
+            score: 0.5,
+            metadata: { section: 'guides' },
+            is_stale: 1,
+          },
+        ],
+      }),
+    };
+    const provider = new PgFtsProvider(db as never);
+
+    await expect(
+      provider.search('multi tenant architecture', ['source-a', 'source-b'], {
+        limit: 5,
+        offset: 0,
+      }),
+    ).resolves.toEqual([
+      {
+        itemId: 'item-1',
+        sourceId: 'source-a',
+        title: 'Architecture Notes',
+        excerpt: '',
+        score: 0.75,
+        metadata: {},
+        isStale: false,
+      },
+      {
+        itemId: 'item-2',
+        sourceId: 'source-b',
+        title: 'Tenant Guide',
+        excerpt: 'tenant architecture excerpt',
+        score: 0.5,
+        metadata: { section: 'guides' },
+        isStale: true,
+      },
+    ]);
+    expect(db.execute).toHaveBeenCalledOnce();
+  });
+
   it('binds accessible source ids as scalar values in an IN list', async () => {
     const db = {
       execute: vi.fn().mockResolvedValue({ rows: [] }),
@@ -15,21 +87,19 @@ describe('PgFtsProvider', () => {
     });
 
     const query = db.execute.mock.calls[0]?.[0];
-    const chunks = query?.queryChunks ?? [];
-    const sqlText = chunks
-      .map((chunk: unknown) => {
-        if (typeof chunk === 'string') return chunk;
-        if (Array.isArray(chunk)) return chunk.join('');
-        if (chunk && typeof chunk === 'object' && 'value' in chunk) {
-          const value = (chunk as { value: unknown }).value;
-          return Array.isArray(value) ? value.join('') : String(value);
-        }
-        return '';
-      })
-      .join('');
+    const compiled = new PgDialect().sqlToQuery(query);
 
-    expect(sqlText).toContain('source_id IN (');
-    expect(sqlText).not.toContain('source_id = ANY');
+    expect(compiled.sql).toContain('source_id IN ($3, $4)');
+    expect(compiled.sql).not.toContain('source_id = ANY');
+    expect(compiled.params).toEqual([
+      'multi tenant architecture',
+      'multi tenant architecture',
+      'source-a',
+      'source-b',
+      'multi tenant architecture',
+      5,
+      0,
+    ]);
     expect(db.execute).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Fixes PostgreSQL FTS source filtering so content search binds accessible source IDs as scalar values in an `IN (...)` list instead of passing a JavaScript array through `ANY(...)`.

## Why

The private dogfood E8/E9 harness now reaches mediation retrieval. This public-safe patch removes the remaining FTS source-ID binding risk for seeded and entitlement-filtered content retrieval.

## Changes

- Update `PgFtsProvider` to build a parameterized scalar source-ID list.
- Add a regression test that verifies the provider no longer emits the `source_id = ANY(...)` shape.

## Validation

- `npm run validate` passed from `joyus-ai-mcp-server`.
- Private E8 smoke reached `metadata.sourcesUsed: 1` and is now blocked only by placeholder provider wiring.
- Private E9 smoke listed 21 MCP tools, retrieved 1 source through mediation, and is now blocked only by placeholder provider wiring.

## Boundary

This PR contains only a generic platform fix. No internal dogfood seed corpus, generated credentials, run logs, or private readiness workflow are included.
