### PR TITLE
Keep Spec Kitty dashboard on the project CLI version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Dependencies
 node_modules/
+.venv/
 
 # Build output
 **/dist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+spec-kitty-cli==3.1.1

--- a/scripts/setup-python-env.sh
+++ b/scripts/setup-python-env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${VENV_DIR:-$ROOT_DIR/.venv}"
+PYTHON_BIN="${PYTHON:-python3}"
+
+if [ ! -d "$VENV_DIR" ]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+"$VENV_DIR/bin/python" -m pip install --upgrade pip
+"$VENV_DIR/bin/python" -m pip install -r "$ROOT_DIR/requirements.txt"
+
+cat <<EOF
+Python environment ready: $VENV_DIR
+
+Activate it with:
+  source "$VENV_DIR/bin/activate"
+
+Verify Spec Kitty with:
+  spec-kitty --version
+EOF


### PR DESCRIPTION
## Summary
- Pin spec-kitty-cli to the project metadata version in requirements.txt
- Add a setup script that creates a local Python virtual environment and installs the pinned CLI
- Ignore the repo-local .venv directory

## Testing
- bash -n scripts/setup-python-env.sh
- VENV_DIR=/tmp/joyus-ai-venv-test scripts/setup-python-env.sh
- /tmp/joyus-ai-venv-test/bin/spec-kitty --version