### PR TITLE
docs: organize manual testing runbooks

### DIFF
--- a/joyus-ai-mcp-server/docs/manual-testing/README.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/README.md
@@ -1,0 +1,75 @@
+# Manual Testing Documents
+
+Manual testing runbooks live in this directory.
+
+## Naming Convention
+
+Use this filename format:
+
+```text
+<feature-or-area>-manual-test.md
+```
+
+Rules:
+
+- Use lowercase kebab-case.
+- Use the product or feature area, not only a PR number.
+- End every runbook with `-manual-test.md`.
+- Keep PR or issue numbers in the document metadata, not as the primary filename.
+
+Examples:
+
+- `content-mediation-manual-test.md`
+- `external-event-adapter-manual-test.md`
+- `inngest-pipeline-trigger-manual-test.md`
+- `profile-isolation-manual-test.md`
+
+## Document Schema
+
+Each manual test runbook should use this structure:
+
+```markdown
+# <Feature Area> Manual Test
+
+| Field | Value |
+| --- | --- |
+| Feature area | <feature or subsystem> |
+| Related PR/issues | <PR/issue/spec links or IDs> |
+| Environment | <local Docker Compose, staging, production, etc.> |
+| Required services | <db, server, inngest, external service, etc.> |
+| Required credentials | <MCP token, API key, JWT, none, etc.> |
+| Last verified | <YYYY-MM-DD or Not yet verified> |
+
+## Purpose
+
+What this validates.
+
+## Prerequisites
+
+Tools, env vars, services, credentials, seed data, and setup assumptions.
+
+## Steps
+
+Numbered commands and actions in the order they should be run.
+
+## Expected Results
+
+Concrete pass criteria.
+
+## Cleanup
+
+Any local data, containers, env vars, test users, or files to remove.
+
+## Troubleshooting
+
+Known failure modes and fixes.
+```
+
+## Current Runbooks
+
+| Runbook | Scope |
+| --- | --- |
+| [content-mediation-manual-test.md](content-mediation-manual-test.md) | `/api/mediation/*` session, JWT/JWKS, and cache-miss flows |
+| [external-event-adapter-manual-test.md](external-event-adapter-manual-test.md) | `/v1/events/*` source, webhook, schedule, automation, health, and admin flows |
+| [inngest-pipeline-trigger-manual-test.md](inngest-pipeline-trigger-manual-test.md) | Inngest local dev server and manual pipeline trigger smoke test |
+| [profile-isolation-manual-test.md](profile-isolation-manual-test.md) | Profile isolation migration, no-engine generation stub, and profile smoke checks |

--- a/joyus-ai-mcp-server/docs/manual-testing/content-mediation-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/content-mediation-manual-test.md
@@ -1,4 +1,15 @@
-# Mediation Manual Testing
+# Content Mediation Manual Test
+
+| Field | Value |
+| --- | --- |
+| Feature area | Content mediation |
+| Related PR/issues | Not specified |
+| Environment | Local Docker Compose |
+| Required services | PostgreSQL, MCP server, local JWT/JWKS helper |
+| Required credentials | Mediation API key and user JWT |
+| Last verified | Not yet verified |
+
+## Purpose
 
 This tests the `/api/mediation/*` flow, including session creation, message
 count increments, idle-gap tracking, and cache-miss logging.

--- a/joyus-ai-mcp-server/docs/manual-testing/external-event-adapter-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/external-event-adapter-manual-test.md
@@ -1,6 +1,19 @@
-# Manual Testing: External Event Adapter (Branch `claude/018-external-event-adapter`)
+# External Event Adapter Manual Test
 
-**Prerequisites**
+| Field | Value |
+| --- | --- |
+| Feature area | External event adapter |
+| Related PR/issues | Spec/branch 018, `claude/018-external-event-adapter` |
+| Environment | Local Docker Compose |
+| Required services | PostgreSQL, MCP server, optional Inngest Dev Server |
+| Required credentials | MCP bearer token |
+| Last verified | Not yet verified |
+
+## Purpose
+
+This validates the `/v1/events/*` external event adapter flow, including event source CRUD, signed webhook ingestion, schedule management, automation callbacks, event log queries, health reporting, Inngest delivery, and the admin UI.
+
+## Prerequisites
 
 - Docker stack running: `docker compose up`
 - MCP bearer token — get it from `http://localhost:3000/auth` after signing in with Google. The token is shown once on login; use the **Regenerate** button if you need to retrieve it again. This is the same token used to connect Claude Desktop to the server.

--- a/joyus-ai-mcp-server/docs/manual-testing/inngest-pipeline-trigger-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/inngest-pipeline-trigger-manual-test.md
@@ -1,4 +1,15 @@
-# PR #33 Manual Testing Steps
+# Inngest Pipeline Trigger Manual Test
+
+| Field | Value |
+| --- | --- |
+| Feature area | Inngest pipeline execution |
+| Related PR/issues | PR #33 |
+| Environment | Local Docker Compose |
+| Required services | PostgreSQL, MCP server, Inngest Dev Server |
+| Required credentials | MCP bearer token |
+| Last verified | Not yet verified |
+
+## Purpose
 
 These steps validate the Inngest migration changes for PR #33, especially manual pipeline triggering through `pipelineId`.
 

--- a/joyus-ai-mcp-server/docs/manual-testing/profile-isolation-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/profile-isolation-manual-test.md
@@ -1,4 +1,15 @@
-# Profile Isolation Manual Steps
+# Profile Isolation Manual Test
+
+| Field | Value |
+| --- | --- |
+| Feature area | Profile isolation and generation |
+| Related PR/issues | PR #43, issue #67 |
+| Environment | Local Docker Compose |
+| Required services | PostgreSQL, MCP server |
+| Required credentials | MCP bearer token |
+| Last verified | 2026-05-11 |
+
+## Purpose
 
 These are the manual follow-up steps for PR #43 after the profile isolation fixes are committed.
 


### PR DESCRIPTION
## Summary
- Move manual testing runbooks into docs/manual-testing/
- Standardize runbook filenames as <feature-or-area>-manual-test.md
- Add docs/manual-testing/README.md with naming rules, metadata schema, and current runbook index
- Add metadata tables to mediation, external event adapter, Inngest, and profile-isolation manual tests

## Test plan
- git diff --cached --check
- find joyus-ai-mcp-server/docs/manual-testing -maxdepth 1 -type f -print
- find joyus-ai-mcp-server -name '*.md' -not -path 'joyus-ai-mcp-server/docs/*' -print
- Verified PR #68 targets main after PR #43 merged