### PR TITLE
[codex] Harden event adapter ownership checks

### DIFF
--- a/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
@@ -11,6 +11,7 @@ import { eq, and } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { pipelines } from '../../pipelines/schema.js';
 import { eventSources, platformSubscriptions } from '../schema.js';
 
 // ============================================================
@@ -74,6 +75,7 @@ function subscribeHandler(deps: SubscriptionsRouterDeps) {
       res.status(400).json({ error: 'validation_error', details: 'target_pipeline_id is required' });
       return;
     }
+    const trimmedTargetPipelineId = targetPipelineId.trim();
 
     try {
       // Verify source exists and is platform-wide
@@ -92,9 +94,16 @@ function subscribeHandler(deps: SubscriptionsRouterDeps) {
         return;
       }
 
-      // TODO(WP11): Verify target_pipeline_id belongs to tenant — requires pipelines table access
-      // This ownership check is deferred: the pipelines table lives outside this module boundary.
-      // Consistent with WP08/WP10 approach — caller is responsible for passing a valid pipeline id.
+      const [pipeline] = await deps.db
+        .select({ id: pipelines.id })
+        .from(pipelines)
+        .where(and(eq(pipelines.id, trimmedTargetPipelineId), eq(pipelines.tenantId, tenantId)))
+        .limit(1);
+
+      if (!pipeline) {
+        res.status(404).json({ error: 'pipeline_not_found' });
+        return;
+      }
 
       // Insert subscription
       const [created] = await deps.db
@@ -102,7 +111,7 @@ function subscribeHandler(deps: SubscriptionsRouterDeps) {
         .values({
           tenantId,
           eventSourceId: id,
-          targetPipelineId: targetPipelineId.trim(),
+          targetPipelineId: trimmedTargetPipelineId,
           isActive: true,
         })
         .returning();

--- a/joyus-ai-mcp-server/tests/event-adapter/integration/automation.test.ts
+++ b/joyus-ai-mcp-server/tests/event-adapter/integration/automation.test.ts
@@ -552,6 +552,20 @@ describe('POST /trigger', () => {
     expect(res.status).toHaveBeenCalledWith(401);
   });
 
+  it('returns 401 when the destination credential has been revoked', async () => {
+    const { db } = makeTriggerDb({ id: 'pipe-001' }, makeWebhookEvent(), { authSecretRef: null });
+    const handler = getTriggerHandler(db);
+    const req = mockReq({
+      headers: { authorization: 'Bearer valid-token-123' },
+      body: { triggerType: 'corpus-change', pipelineId: 'pipe-001', metadata: {} },
+    });
+    const res = mockRes();
+
+    await handler?.(req, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
   it('returns 202 and event_id when token matches destination secret', async () => {
     const insertedEvent = makeWebhookEvent({ id: 'evt-999' });
     const { db } = makeTriggerDb({ id: 'pipe-001' }, insertedEvent);

--- a/joyus-ai-mcp-server/tests/event-adapter/integration/platform-subscriptions.test.ts
+++ b/joyus-ai-mcp-server/tests/event-adapter/integration/platform-subscriptions.test.ts
@@ -275,6 +275,7 @@ function buildMockDb() {
     _deleteResults: [] as unknown[],
     _updateResults: [] as unknown[],
     _insertedValues: null as unknown,
+    _selectResultsQueue: null as unknown[][] | null,
 
     select: vi.fn(),
     insert: vi.fn(),
@@ -284,16 +285,22 @@ function buildMockDb() {
 
   // select().from().where().limit().offset() -> rows
   // select().from().where() -> rows (for plain queries)
+  const nextSelectResults = (): unknown[] => db._selectResultsQueue?.shift() ?? db._selectResults;
   db.select.mockImplementation(() => ({
     from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(() => ({
-          offset: vi.fn(() => Promise.resolve(db._selectResults)),
-        })),
-        // awaitable for plain .where() calls
-        then: (resolve: (v: unknown) => void) => resolve(db._selectResults),
-        ...Promise.resolve(db._selectResults),
-      })),
+      where: vi.fn(() => {
+        const rows = nextSelectResults();
+        return {
+          limit: vi.fn(() => ({
+            offset: vi.fn(() => Promise.resolve(rows)),
+            then: (resolve: (v: unknown) => void) => resolve(rows),
+            ...Promise.resolve(rows),
+          })),
+          // awaitable for plain .where() calls
+          then: (resolve: (v: unknown) => void) => resolve(rows),
+          ...Promise.resolve(rows),
+        };
+      }),
     })),
   }));
 
@@ -443,7 +450,7 @@ describe('POST /sources/:id/subscribe', () => {
     const source = makeSource();
     const sub = makeSubscription();
 
-    db._selectResults = [source];
+    db._selectResultsQueue = [[source], [{ id: 'pipe-abc' }]];
     db._insertResults = [sub];
 
     const result = await invokeSubscriptionsRoute(db, 'post', '/sources/src-platform-001/subscribe', {
@@ -453,6 +460,35 @@ describe('POST /sources/:id/subscribe', () => {
 
     expect(result.status).toBe(201);
     expect((result.body as Record<string, unknown>)['id']).toBe('sub-001');
+  });
+
+  it('trims target_pipeline_id before ownership check and insert', async () => {
+    const db = buildMockDb();
+    db._selectResultsQueue = [[makeSource()], [{ id: 'pipe-abc' }]];
+    db._insertResults = [makeSubscription()];
+
+    const result = await invokeSubscriptionsRoute(db, 'post', '/sources/src-platform-001/subscribe', {
+      headers: { 'x-tenant-id': 'tenant-abc' },
+      body: { target_pipeline_id: '  pipe-abc  ' },
+    });
+
+    expect(result.status).toBe(201);
+    const inserted = db._insertedValues as Record<string, unknown>;
+    expect(inserted['targetPipelineId']).toBe('pipe-abc');
+  });
+
+  it('returns 404 when target pipeline is missing or belongs to another tenant', async () => {
+    const db = buildMockDb();
+    db._selectResultsQueue = [[makeSource()], []];
+
+    const result = await invokeSubscriptionsRoute(db, 'post', '/sources/src-platform-001/subscribe', {
+      headers: { 'x-tenant-id': 'tenant-abc' },
+      body: { target_pipeline_id: 'pipe-other-tenant' },
+    });
+
+    expect(result.status).toBe(404);
+    expect((result.body as Record<string, unknown>)['error']).toBe('pipeline_not_found');
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it('returns 404 when source does not exist', async () => {
@@ -523,7 +559,7 @@ describe('POST /sources/:id/subscribe', () => {
     const existingSub = makeSubscription({ id: 'sub-existing' });
 
     // First select: source lookup succeeds
-    db._selectResults = [source];
+    db._selectResultsQueue = [[source], [{ id: 'pipe-abc' }]];
 
     // Insert throws unique violation
     db.insert.mockImplementation(() => ({
@@ -534,13 +570,14 @@ describe('POST /sources/:id/subscribe', () => {
       })),
     }));
 
-    // Second select for existing subscription lookup
+    // Select order: source lookup, pipeline ownership lookup, existing subscription lookup.
     let selectCount = 0;
     db.select.mockImplementation(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => {
           selectCount++;
           if (selectCount === 1) return Promise.resolve([source]);
+          if (selectCount === 2) return { limit: vi.fn(() => Promise.resolve([{ id: 'pipe-abc' }])) };
           return Promise.resolve([existingSub]);
         }),
       })),


### PR DESCRIPTION
## Summary

- Verify platform subscription `target_pipeline_id` values against the `pipelines` table for the resolved tenant before inserting subscriptions.
- Return `pipeline_not_found` for missing or cross-tenant subscription targets instead of accepting caller-supplied pipeline IDs.
- Add subscription ownership/normalization coverage and a revoked trigger credential test.

## Validation

- `npm test -- tests/event-adapter/integration/automation.test.ts tests/event-adapter/integration/platform-subscriptions.test.ts`
- `npm run build`
- `npm run lint`
- `npm test` — 1481 passed, 50 skipped

Closes #73.