### PR TITLE
[codex] Allow duplicate pipeline names

### DIFF
--- a/joyus-ai-mcp-server/drizzle/migrations/0008_pipeline_name_not_unique.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0008_pipeline_name_not_unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "pipelines"."pipelines_tenant_name_unique";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pipelines_tenant_name_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","name");--> statement-breakpoint

--- a/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
+++ b/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778505114111,
       "tag": "0007_coordination_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1779713480527,
+      "tag": "0008_pipeline_name_not_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/joyus-ai-mcp-server/src/pipelines/routes.ts
+++ b/joyus-ai-mcp-server/src/pipelines/routes.ts
@@ -67,6 +67,34 @@ function getTenantId(req: Request): string {
   return '';
 }
 
+function getPgError(err: unknown): { code?: unknown } | null {
+  const cause = err && typeof err === 'object' && 'cause' in err
+    ? (err as { cause?: unknown }).cause
+    : null;
+  const candidate = cause ?? err;
+
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+
+  return candidate as { code?: unknown };
+}
+
+function isPgUniqueViolation(err: unknown): boolean {
+  return getPgError(err)?.code === '23505';
+}
+
+function sendPipelineMutationError(res: Response, err: unknown): Response {
+  if (isPgUniqueViolation(err)) {
+    return res.status(409).json({
+      error: 'Pipeline conflicts with an existing record',
+    });
+  }
+
+  const message = err instanceof Error ? err.message : 'Internal error';
+  return res.status(500).json({ error: message });
+}
+
 // ============================================================
 // ROUTER FACTORY
 // ============================================================
@@ -187,8 +215,7 @@ export function createPipelineRouter(deps: PipelineRouterDeps): Router {
         pipeline: { ...pipeline, steps: stepRecords },
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Internal error';
-      return res.status(500).json({ error: message });
+      return sendPipelineMutationError(res, err);
     }
   });
 
@@ -375,8 +402,7 @@ export function createPipelineRouter(deps: PipelineRouterDeps): Router {
 
       return res.json({ pipeline: { ...updated, steps } });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Internal error';
-      return res.status(500).json({ error: message });
+      return sendPipelineMutationError(res, err);
     }
   });
 

--- a/joyus-ai-mcp-server/src/pipelines/routes.ts
+++ b/joyus-ai-mcp-server/src/pipelines/routes.ts
@@ -67,6 +67,10 @@ function getTenantId(req: Request): string {
   return '';
 }
 
+// Normalizes the two error shapes Drizzle's node-postgres driver can surface:
+// pg v8 sets `code` directly on the top-level DatabaseError, while a wrapped
+// error nests it under `.cause`. Only a single level of `.cause` is inspected;
+// deeper nesting (err.cause.cause) is not expected from the current driver.
 function getPgError(err: unknown): { code?: unknown } | null {
   const cause = err && typeof err === 'object' && 'cause' in err
     ? (err as { cause?: unknown }).cause

--- a/joyus-ai-mcp-server/src/pipelines/schema.ts
+++ b/joyus-ai-mcp-server/src/pipelines/schema.ts
@@ -116,7 +116,7 @@ export const pipelines = pipelinesSchema.table('pipelines', {
   tenantIdIdx: index('pipelines_tenant_id_idx').on(table.tenantId),
   tenantStatusIdx: index('pipelines_tenant_status_idx').on(table.tenantId, table.status),
   tenantTriggerIdx: index('pipelines_tenant_trigger_idx').on(table.tenantId, table.triggerType),
-  tenantNameUnique: uniqueIndex('pipelines_tenant_name_unique').on(table.tenantId, table.name),
+  tenantNameIdx: index('pipelines_tenant_name_idx').on(table.tenantId, table.name),
 }));
 
 // --- PipelineStep ---

--- a/joyus-ai-mcp-server/tests/pipelines/routes.test.ts
+++ b/joyus-ai-mcp-server/tests/pipelines/routes.test.ts
@@ -152,10 +152,28 @@ function makeRes(): Response & { _status: number; _json: unknown; _sent: boolean
   return res as unknown as Response & { _status: number; _json: unknown; _sent: boolean };
 }
 
+// Drizzle's node-postgres driver may surface the underlying DatabaseError
+// nested under `.cause` (e.g. when wrapped by an outer Error).
 function makePgUniqueViolation(constraint = 'some_unique_constraint'): Error {
   return new Error('duplicate key value violates unique constraint', {
     cause: { code: '23505', constraint },
   });
+}
+
+// pg v8 throws a DatabaseError with `code` set directly on the top-level error
+// object (no `.cause` wrapper). This is the shape real traffic hits, so the 409
+// mapping must handle it too.
+function makePgUniqueViolationTopLevel(constraint = 'some_unique_constraint'): Error {
+  const err = new Error('duplicate key value violates unique constraint');
+  Object.assign(err, { code: '23505', constraint });
+  return err;
+}
+
+// A non-unique-violation database error must fall through to a 500, not 409.
+function makePgGenericError(): Error {
+  const err = new Error('connection terminated unexpectedly');
+  Object.assign(err, { code: '08006' });
+  return err;
 }
 
 // ============================================================
@@ -330,6 +348,71 @@ describe('Pipeline Routes', () => {
       expect((res._json as { error: string }).error).toContain('conflicts');
     });
 
+    it('returns 409 when the unique violation code is on the top-level error (pg v8 shape)', async () => {
+      const handler = getHandler(router, 'post', '/pipelines');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([[], [], []]);
+      db._setInsertError(makePgUniqueViolationTopLevel());
+
+      const req = makeReq({
+        body: {
+          name: 'Test Pipeline',
+          triggerType: 'manual_request',
+          triggerConfig: { type: 'manual_request' },
+          steps: [
+            {
+              name: 'Notify',
+              stepType: 'notification',
+              config: {
+                type: 'notification',
+                channel: 'email',
+                message: 'Pipeline complete',
+              },
+            },
+          ],
+        },
+      });
+
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(409);
+      expect((res._json as { error: string }).error).toContain('conflicts');
+    });
+
+    it('returns 500 for non-unique-violation database errors', async () => {
+      const handler = getHandler(router, 'post', '/pipelines');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([[], [], []]);
+      db._setInsertError(makePgGenericError());
+
+      const req = makeReq({
+        body: {
+          name: 'Test Pipeline',
+          triggerType: 'manual_request',
+          triggerConfig: { type: 'manual_request' },
+          steps: [
+            {
+              name: 'Notify',
+              stepType: 'notification',
+              config: {
+                type: 'notification',
+                channel: 'email',
+                message: 'Pipeline complete',
+              },
+            },
+          ],
+        },
+      });
+
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(500);
+    });
+
     it('returns 400 for invalid input', async () => {
       const handler = getHandler(router, 'post', '/pipelines');
       expect(handler).toBeDefined();
@@ -407,6 +490,31 @@ describe('Pipeline Routes', () => {
         }],
       ]);
       db._setUpdateError(makePgUniqueViolation());
+
+      const req = makeReq({
+        params: { id: 'pipe-1' },
+        body: { name: 'Renamed Pipeline' },
+      });
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(409);
+      expect((res._json as { error: string }).error).toContain('conflicts');
+    });
+
+    it('returns 409 when the unique violation code is on the top-level error (pg v8 shape)', async () => {
+      const handler = getHandler(router, 'put', '/pipelines/:id');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([
+        [{
+          id: 'pipe-1',
+          tenantId: 'tenant-a',
+          name: 'Original Pipeline',
+          triggerType: 'manual_request',
+        }],
+      ]);
+      db._setUpdateError(makePgUniqueViolationTopLevel());
 
       const req = makeReq({
         params: { id: 'pipe-1' },

--- a/joyus-ai-mcp-server/tests/pipelines/routes.test.ts
+++ b/joyus-ai-mcp-server/tests/pipelines/routes.test.ts
@@ -23,6 +23,8 @@ function makeMockDb() {
   const updatedRows: Record<string, unknown>[] = [];
   let selectResults: unknown[][] = [[]];
   let selectCallIndex = 0;
+  let insertError: unknown;
+  let updateError: unknown;
 
   /**
    * Create a chainable query result that is also a real array.
@@ -46,9 +48,22 @@ function makeMockDb() {
       selectResults = results;
       selectCallIndex = 0;
     },
+    _setInsertError(error: unknown) {
+      insertError = error;
+    },
+    _setUpdateError(error: unknown) {
+      updateError = error;
+    },
     insert: vi.fn().mockImplementation(() => ({
       values: vi.fn().mockImplementation((rows) => {
         const arr = Array.isArray(rows) ? rows : [rows];
+        if (insertError) {
+          const error = insertError;
+          insertError = undefined;
+          return {
+            returning: vi.fn().mockRejectedValue(error),
+          };
+        }
         insertedRows.push(...arr);
         return {
           returning: vi.fn().mockResolvedValue(arr),
@@ -58,6 +73,11 @@ function makeMockDb() {
     update: vi.fn().mockImplementation(() => ({
       set: vi.fn().mockImplementation((data: Record<string, unknown>) => ({
         where: vi.fn().mockImplementation(() => {
+          if (updateError) {
+            const error = updateError;
+            updateError = undefined;
+            return Promise.reject(error);
+          }
           updatedRows.push(data);
           return Promise.resolve();
         }),
@@ -130,6 +150,12 @@ function makeRes(): Response & { _status: number; _json: unknown; _sent: boolean
     },
   };
   return res as unknown as Response & { _status: number; _json: unknown; _sent: boolean };
+}
+
+function makePgUniqueViolation(constraint = 'some_unique_constraint'): Error {
+  return new Error('duplicate key value violates unique constraint', {
+    cause: { code: '23505', constraint },
+  });
 }
 
 // ============================================================
@@ -233,6 +259,77 @@ describe('Pipeline Routes', () => {
       expect(data.pipeline.name).toBe('Test Pipeline');
     });
 
+    it('creates a distinct pipeline when an existing pipeline has the same display name', async () => {
+      const handler = getHandler(router, 'post', '/pipelines');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([
+        [{ id: 'pipe-existing', tenantId: 'tenant-a', name: 'Reusable Pipeline' }],
+        [],
+        [],
+      ]);
+
+      const req = makeReq({
+        body: {
+          name: 'Reusable Pipeline',
+          triggerType: 'manual_request',
+          triggerConfig: { type: 'manual_request' },
+          steps: [
+            {
+              name: 'Notify',
+              stepType: 'notification',
+              config: {
+                type: 'notification',
+                channel: 'email',
+                message: 'Pipeline complete',
+              },
+            },
+          ],
+        },
+      });
+
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(201);
+      const data = res._json as { pipeline: Record<string, unknown> };
+      expect(data.pipeline.id).not.toBe('pipe-existing');
+      expect(data.pipeline.name).toBe('Reusable Pipeline');
+    });
+
+    it('returns 409 for database unique constraint violations', async () => {
+      const handler = getHandler(router, 'post', '/pipelines');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([[], [], []]);
+      db._setInsertError(makePgUniqueViolation());
+
+      const req = makeReq({
+        body: {
+          name: 'Test Pipeline',
+          triggerType: 'manual_request',
+          triggerConfig: { type: 'manual_request' },
+          steps: [
+            {
+              name: 'Notify',
+              stepType: 'notification',
+              config: {
+                type: 'notification',
+                channel: 'email',
+                message: 'Pipeline complete',
+              },
+            },
+          ],
+        },
+      });
+
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(409);
+      expect((res._json as { error: string }).error).toContain('conflicts');
+    });
+
     it('returns 400 for invalid input', async () => {
       const handler = getHandler(router, 'post', '/pipelines');
       expect(handler).toBeDefined();
@@ -293,6 +390,33 @@ describe('Pipeline Routes', () => {
       await handler!(req, res);
 
       expect(res._status).toBe(401);
+    });
+  });
+
+  describe('PUT /pipelines/:id', () => {
+    it('returns 409 for database unique constraint violations', async () => {
+      const handler = getHandler(router, 'put', '/pipelines/:id');
+      expect(handler).toBeDefined();
+
+      db._setSelectResults([
+        [{
+          id: 'pipe-1',
+          tenantId: 'tenant-a',
+          name: 'Original Pipeline',
+          triggerType: 'manual_request',
+        }],
+      ]);
+      db._setUpdateError(makePgUniqueViolation());
+
+      const req = makeReq({
+        params: { id: 'pipe-1' },
+        body: { name: 'Renamed Pipeline' },
+      });
+      const res = makeRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(409);
+      expect((res._json as { error: string }).error).toContain('conflicts');
     });
   });
 

--- a/joyus-ai-mcp-server/tests/pipelines/schema.test.ts
+++ b/joyus-ai-mcp-server/tests/pipelines/schema.test.ts
@@ -1,0 +1,21 @@
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import { pipelines } from '../../src/pipelines/schema.js';
+
+describe('Pipeline schema', () => {
+  it('indexes tenant and name without treating name as a natural key', () => {
+    const config = getTableConfig(pipelines);
+    const indexes = config.indexes.map((index) => index.config);
+
+    expect(indexes.some((index) => index.name === 'pipelines_tenant_name_unique')).toBe(false);
+
+    const tenantNameIndex = indexes.find((index) => index.name === 'pipelines_tenant_name_idx');
+    expect(tenantNameIndex).toBeDefined();
+    expect(tenantNameIndex?.unique).toBe(false);
+    expect(tenantNameIndex?.columns.map((column) => column.name)).toEqual([
+      'tenant_id',
+      'name',
+    ]);
+  });
+});

--- a/kitty-specs/009-automated-pipelines-framework/data-model.md
+++ b/kitty-specs/009-automated-pipelines-framework/data-model.md
@@ -125,7 +125,7 @@ export const pipelines = pipelinesSchema.table('pipelines', {
   tenantIdIdx: index('pipelines_tenant_id_idx').on(table.tenantId),
   tenantStatusIdx: index('pipelines_tenant_status_idx').on(table.tenantId, table.status),
   tenantTriggerIdx: index('pipelines_tenant_trigger_idx').on(table.tenantId, table.triggerType),
-  tenantNameUnique: uniqueIndex('pipelines_tenant_name_unique').on(table.tenantId, table.name),
+  tenantNameIdx: index('pipelines_tenant_name_idx').on(table.tenantId, table.name),
 }));
 ```
 

--- a/kitty-specs/009-automated-pipelines-framework/tasks/WP01-schema-foundation.md
+++ b/kitty-specs/009-automated-pipelines-framework/tasks/WP01-schema-foundation.md
@@ -100,7 +100,7 @@ This WP adds a third schema spread: `...pipelinesSchema`.
 
 **Important implementation details**:
 - All tables use CUID2 for primary keys (matching existing pattern in `src/db/schema.ts` and `src/content/schema.ts`)
-- `pipelines.(tenantId, name)` must have a UNIQUE composite index
+- `pipelines.(tenantId, name)` should have a non-unique composite index; pipeline identity is `id`
 - `pipeline_steps.(pipelineId, position)` must have a UNIQUE composite index
 - `execution_steps.(executionId, position)` must have a UNIQUE composite index
 - `pipeline_templates.name` must be UNIQUE


### PR DESCRIPTION
## Summary

- Drop the tenant/name unique index for pipelines and replace it with a non-unique lookup index.
- Add a migration so existing databases remove `pipelines_tenant_name_unique` and keep tenant/name query support.
- Map PostgreSQL unique constraint violations during pipeline create/update to `409 Conflict` instead of returning a generic `500`.
- Add focused route/schema regression coverage and update the public pipeline data-model guidance so name is no longer treated as the pipeline natural key.

## Root cause

Pipeline `id` is the primary key and the value referenced by dependent records, but the schema also treated `(tenant_id, name)` as unique. That made the human-readable display name behave like an identifier and blocked distinct pipeline records from sharing a label.

## Validation

- `npm test -- tests/pipelines/routes.test.ts tests/pipelines/schema.test.ts`
- `npm run build`
- `npm run lint`
- `npm test`
- `npm run db:check`
- `git diff --check`

`npm run format:check` still fails on pre-existing repo-wide formatting drift outside this patch.

Closes #65