### PR TITLE
[codex] Add Spec 013 tenant identity resolution plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,11 @@ kitty-specs/**/tasks/*.md
 !kitty-specs/011-inngest-migration/tasks/WP02-update-routes.md
 !kitty-specs/011-inngest-migration/tasks/WP03-delete-custom-plumbing.md
 !kitty-specs/011-inngest-migration/tasks/WP04-integration-tests.md
+!kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
+!kitty-specs/013-tenant-identity-resolution/tasks/WP02-shared-resolver.md
+!kitty-specs/013-tenant-identity-resolution/tasks/WP03-explicit-and-api-key-routes.md
+!kitty-specs/013-tenant-identity-resolution/tasks/WP04-bearer-routes-and-tools.md
+!kitty-specs/013-tenant-identity-resolution/tasks/WP05-admin-cleanup-acceptance.md
 
 # Generated artifacts
 **/tmp/

--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,9 +3,9 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.1.1
+  version: 3.1.8
   initialized_at: '2026-02-11T21:18:53.991526'
-  last_upgraded_at: '2026-04-21T09:48:52.850099'
+  last_upgraded_at: '2026-05-25T08:24:11.286818'
 environment:
   python_version: 3.14.0
   platform: darwin
@@ -404,5 +404,13 @@ migrations:
     notes: 'Added .gitattributes entry: kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log'
   - id: 3.1.1_normalize_status_json
     applied_at: '2026-04-21T09:48:52.839902'
+    result: skipped
+    notes: Not applicable
+  - id: 3.1.1_normalize_status_json
+    applied_at: '2026-05-25T08:24:11.271327'
+    result: success
+    notes: '013-tenant-identity-resolution: normalised status.json'
+  - id: 3.1.2_globalize_commands
+    applied_at: '2026-05-25T08:24:11.279850'
     result: skipped
     notes: Not applicable

--- a/kitty-specs/009-automated-pipelines-framework/tenant-resolution-notes.md
+++ b/kitty-specs/009-automated-pipelines-framework/tenant-resolution-notes.md
@@ -1,3 +1,5 @@
+> **Superseded by Spec 013 (`kitty-specs/013-tenant-identity-resolution/`).** These notes captured the original problem statement; the owning convergence plan now lives in Spec 013.
+
 # Tenant Identity Resolution — Current State
 
 **Date**: 2026-03-19

--- a/kitty-specs/013-tenant-identity-resolution/checklists/requirements.md
+++ b/kitty-specs/013-tenant-identity-resolution/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Tenant Identity Resolution
+
+**Purpose**: Validate specification completeness and quality before implementation
+**Created**: 2026-05-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No client-specific names or details
+- [x] Focused on platform capability and tenant safety
+- [x] All examples use generic names
+- [x] Scope is clearly bounded
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Existing compatibility behavior is specified
+- [x] Admin and operator behavior is explicit
+- [x] API-key behavior is explicitly preserved
+
+## Security Completeness
+
+- [x] Header trust is rejected by default
+- [x] Unauthorized tenant access fails closed
+- [x] Existing 404 non-disclosure behavior is preserved
+- [x] Operator override is role-gated and audited
+- [x] Migration plan includes idempotent compatibility seeding
+
+## Implementation Readiness
+
+- [x] Work packages are defined
+- [x] Data model is defined
+- [x] Test strategy is defined before code changes
+- [x] Acceptance grep is defined for legacy paths
+
+## Notes
+
+Spec 013 is ready for implementation planning and task execution.

--- a/kitty-specs/013-tenant-identity-resolution/data-model.md
+++ b/kitty-specs/013-tenant-identity-resolution/data-model.md
@@ -35,7 +35,10 @@ Constraints:
 - Unique membership on `(user_id, tenant_id)`.
 - Index on `(tenant_id, role)`.
 - Index on `(user_id, status)`.
-- At most one active primary membership per user.
+- At most one active primary membership per user. A plain unique index cannot
+  express this (it would forbid more than one inactive or non-primary row per
+  user). Enforce it with a PARTIAL unique index:
+  `UNIQUE (user_id) WHERE is_primary AND status = 'active'`.
 
 ### TenantContext
 
@@ -77,7 +80,7 @@ Records privileged tenant context changes.
 
 1. Create `tenants`, `tenant_memberships`, and optional `tenant_access_audit`.
 2. For every existing `users` row, create a tenant with `id = users.id` if one does not exist.
-3. For every existing `users` row, create an active primary membership with `tenantId = users.id` and role `admin`.
+3. For every existing `users` row, create an active primary membership with `tenantId = users.id` and role `admin`. This seeded `admin` role is tenant-scoped only (administrative authority within the user's own tenant); it never implies the `operator` role and never grants cross-tenant or platform-wide override.
 4. Read `EXPORT_TENANT_ALLOWLIST` only in a one-time migration helper, if needed, to create additional memberships.
 5. Keep existing tenant-scoped data rows unchanged. Their current `tenant_id` values remain valid.
 6. After route migration, remove runtime dependence on `EXPORT_TENANT_ALLOWLIST` and `EXPORT_ALLOW_ANY_TENANT`.
@@ -91,6 +94,8 @@ interface BearerTenantRequest {
   kind: 'bearer';
   userId: string;
   requestedTenantId?: string;
+  // Optional override of the route-class default below. When omitted, the
+  // resolver applies the deterministic default in "Non-Disclosure Default".
   nonDisclosure?: boolean;
 }
 
@@ -116,7 +121,31 @@ interface OperatorTenantRequest {
 | Missing authenticated identity | 401 |
 | No tenant specified and no primary membership | 400 |
 | No tenant specified and multiple active memberships without primary | 400 |
-| Requested tenant without membership | 403 or 404 based on route non-disclosure policy |
+| Requested tenant without membership | 404 for resource routes, 403 for management routes (see "Non-Disclosure Default") |
 | Requested suspended or archived tenant | 403 |
 | Operator override without operator role | 403 |
 | API key inactive or missing tenant | 401 |
+
+## Non-Disclosure Default
+
+`nonDisclosure` is optional on the resolver input, but its effective value is
+never ambiguous. The resolver MUST apply a deterministic, fail-closed default
+when the caller does not set it explicitly:
+
+- Resource routes (routes that expose or operate on a specific tenant-scoped
+  resource, e.g. `/tenants/:tenantId/...` export and content routes) default to
+  `nonDisclosure = true`, yielding **404** for a requested tenant the caller is
+  not a member of. This preserves the existing cross-tenant non-disclosure
+  contract (FR-011).
+- Management routes (administrative/listing surfaces such as the event adapter
+  admin and management routes) default to `nonDisclosure = false`, yielding
+  **403** for an unauthorized requested tenant.
+
+An explicit `nonDisclosure` value on the request always overrides the default.
+This default is a contract: implementations MUST NOT leave the 403-vs-404
+outcome dependent on undefined behavior.
+
+An explicitly AUTHORIZED requested tenant always succeeds regardless of primary
+status — a user with multiple active memberships and no primary tenant who
+requests a tenant they are a member of resolves successfully to that tenant
+(the no-primary 400 in the table above applies only when no tenant is requested).

--- a/kitty-specs/013-tenant-identity-resolution/data-model.md
+++ b/kitty-specs/013-tenant-identity-resolution/data-model.md
@@ -30,15 +30,24 @@ Maps a local user to a tenant.
 | `createdAt` | timestamp | yes | Creation timestamp. |
 | `updatedAt` | timestamp | yes | Last update timestamp. |
 
+Lifecycle: a `(user_id, tenant_id)` pair has exactly one membership row for its
+entire lifetime. `status` mutates in place (`invited` → `active` → `revoked`),
+and reactivation re-uses the same row (`revoked` → `active`) rather than
+inserting a new one. No historical or duplicate rows are retained per pair.
+
 Constraints:
 
-- Unique membership on `(user_id, tenant_id)`.
+- Unique membership on `(user_id, tenant_id)` — a plain unique index. This is
+  safe precisely because reactivation re-uses the existing row, so a pair never
+  has two rows competing for the constraint.
 - Index on `(tenant_id, role)`.
 - Index on `(user_id, status)`.
-- At most one active primary membership per user. A plain unique index cannot
-  express this (it would forbid more than one inactive or non-primary row per
-  user). Enforce it with a PARTIAL unique index:
-  `UNIQUE (user_id) WHERE is_primary AND status = 'active'`.
+- At most one active primary (default) tenant per user. A plain unique index
+  cannot express this, because a user has one row per tenant (many rows) and
+  only one of them may be the active default. Enforce it with a PARTIAL unique
+  index: `UNIQUE (user_id) WHERE is_primary AND status = 'active'`. Scoping to
+  `status = 'active'` also keeps a stale `is_primary` flag on a `revoked` row
+  from blocking the user from setting a new active default.
 
 ### TenantContext
 

--- a/kitty-specs/013-tenant-identity-resolution/data-model.md
+++ b/kitty-specs/013-tenant-identity-resolution/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Tenant Identity Resolution
+
+## Entities
+
+### Tenant
+
+Represents a stable platform tenant.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | text | yes | Stable tenant id. Existing compatibility tenants use the user id. |
+| `displayName` | text | no | Generic display label such as `Example Corp`. |
+| `status` | enum | yes | `active`, `suspended`, or `archived`. |
+| `metadata` | json | no | Platform-generic metadata only. |
+| `createdAt` | timestamp | yes | Creation timestamp. |
+| `updatedAt` | timestamp | yes | Last update timestamp. |
+
+### TenantMembership
+
+Maps a local user to a tenant.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | text | yes | Generated id. |
+| `userId` | text | yes | References `users.id`. |
+| `tenantId` | text | yes | References `tenants.id`. |
+| `role` | enum | yes | `member`, `admin`, or `operator`. |
+| `isPrimary` | boolean | yes | Default tenant flag for this user. |
+| `status` | enum | yes | `active`, `revoked`, or `invited`. |
+| `createdAt` | timestamp | yes | Creation timestamp. |
+| `updatedAt` | timestamp | yes | Last update timestamp. |
+
+Constraints:
+
+- Unique membership on `(user_id, tenant_id)`.
+- Index on `(tenant_id, role)`.
+- Index on `(user_id, status)`.
+- At most one active primary membership per user.
+
+### TenantContext
+
+Runtime object returned by the resolver. This is not stored directly.
+
+```typescript
+type TenantContextSource =
+  | 'bearer_default'
+  | 'bearer_requested'
+  | 'api_key'
+  | 'operator_override';
+
+interface TenantContext {
+  tenantId: string;
+  userId?: string;
+  source: TenantContextSource;
+  role?: 'member' | 'admin' | 'operator';
+  apiKeyId?: string;
+  requestedTenantId?: string;
+  overrideReason?: string;
+}
+```
+
+### TenantAccessAudit
+
+Records privileged tenant context changes.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | text | yes | Generated id. |
+| `actorUserId` | text | yes | Authenticated user. |
+| `targetTenantId` | text | yes | Tenant operated on. |
+| `source` | text | yes | Expected value `operator_override` for this feature. |
+| `reason` | text | yes | Human-readable override reason. |
+| `route` | text | no | Route or tool surface. |
+| `createdAt` | timestamp | yes | Audit timestamp. |
+
+## Migration Strategy
+
+1. Create `tenants`, `tenant_memberships`, and optional `tenant_access_audit`.
+2. For every existing `users` row, create a tenant with `id = users.id` if one does not exist.
+3. For every existing `users` row, create an active primary membership with `tenantId = users.id` and role `admin`.
+4. Read `EXPORT_TENANT_ALLOWLIST` only in a one-time migration helper, if needed, to create additional memberships.
+5. Keep existing tenant-scoped data rows unchanged. Their current `tenant_id` values remain valid.
+6. After route migration, remove runtime dependence on `EXPORT_TENANT_ALLOWLIST` and `EXPORT_ALLOW_ANY_TENANT`.
+
+## Resolver Inputs
+
+The shared resolver accepts the following input shapes:
+
+```typescript
+interface BearerTenantRequest {
+  kind: 'bearer';
+  userId: string;
+  requestedTenantId?: string;
+  nonDisclosure?: boolean;
+}
+
+interface ApiKeyTenantRequest {
+  kind: 'api_key';
+  apiKeyId: string;
+  tenantId: string;
+  userId?: string;
+}
+
+interface OperatorTenantRequest {
+  kind: 'operator_override';
+  userId: string;
+  requestedTenantId: string;
+  reason: string;
+}
+```
+
+## Error Outcomes
+
+| Condition | Outcome |
+|-----------|---------|
+| Missing authenticated identity | 401 |
+| No tenant specified and no primary membership | 400 |
+| No tenant specified and multiple active memberships without primary | 400 |
+| Requested tenant without membership | 403 or 404 based on route non-disclosure policy |
+| Requested suspended or archived tenant | 403 |
+| Operator override without operator role | 403 |
+| API key inactive or missing tenant | 401 |

--- a/kitty-specs/013-tenant-identity-resolution/meta.json
+++ b/kitty-specs/013-tenant-identity-resolution/meta.json
@@ -1,0 +1,17 @@
+{
+  "created_at": "2026-05-25T00:00:00Z",
+  "feature_number": "013",
+  "friendly_name": "Tenant Identity Resolution",
+  "lifecycle_state": "spec-only",
+  "measurement_owner": "Engineering Operations",
+  "mission": "software-dev",
+  "mission_number": "013",
+  "mission_slug": "013-tenant-identity-resolution",
+  "mission_type": "platform",
+  "review_cadence": "weekly",
+  "risk_class": "platform-security",
+  "slug": "013-tenant-identity-resolution",
+  "source_description": "Unify tenant identity resolution across bearer-token, API-key, explicit tenant, and admin routes",
+  "target_branch": "main",
+  "tracking_issue": "https://github.com/zivtech/joyus-ai/issues/37"
+}

--- a/kitty-specs/013-tenant-identity-resolution/plan.md
+++ b/kitty-specs/013-tenant-identity-resolution/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Tenant Identity Resolution
+
+**Branch**: `codex/tenant-identity-resolution-37` | **Date**: 2026-05-25 | **Spec**: [spec.md](spec.md)
+**Input**: GitHub issue #37 and `kitty-specs/009-automated-pipelines-framework/tenant-resolution-notes.md`
+
+## Summary
+
+Add a shared tenant identity layer that replaces route-local tenant derivation with membership-backed authorization. The work starts with schema and resolver tests, then ports existing surfaces in stages while preserving `userId === tenantId` compatibility through seeded memberships.
+
+**5 work packages**: WP01 schema and migration, WP02 resolver module, WP03 exports and content mediation, WP04 bearer-token routes and tools, WP05 event adapter admin and cleanup.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 20+
+**Primary Dependencies**: Express, Drizzle ORM, Postgres, vitest
+**Storage**: PostgreSQL through Drizzle migrations
+**Testing**: vitest unit and route tests
+**Target Platform**: Existing `joyus-ai-mcp-server/`
+**Security Constraint**: Tenant identity must never be authorized by a request header alone
+**Compatibility Constraint**: Existing single-tenant users must keep working through seeded memberships
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Multi-tenant from day one | PASS | First-class tenant memberships replace per-user tenant assumptions |
+| Security as platform boundary | PASS | Resolver fails closed and rejects header trust |
+| Monitor everything | PASS | Operator override emits audit events |
+| Client-informed, platform-generic | PASS | All examples are generic and no client details are included |
+| Open source by default | PASS | Public platform capability only |
+
+No known constitution violations.
+
+## Project Structure
+
+### Documentation
+
+```
+kitty-specs/013-tenant-identity-resolution/
++-- meta.json
++-- status.json
++-- spec.md
++-- plan.md
++-- research.md
++-- data-model.md
++-- quickstart.md
++-- tasks.md
++-- checklists/
+|   +-- requirements.md
++-- tasks/
+    +-- WP01-schema-memberships.md
+    +-- WP02-shared-resolver.md
+    +-- WP03-explicit-and-api-key-routes.md
+    +-- WP04-bearer-routes-and-tools.md
+    +-- WP05-admin-cleanup-acceptance.md
+```
+
+### Source Code Targets
+
+```
+joyus-ai-mcp-server/
++-- drizzle/migrations/
++-- src/
+|   +-- auth/
+|   |   +-- tenant-context.ts
+|   |   +-- tenant-context.test.ts
+|   +-- db/schemas.ts
+|   +-- db/schema.ts
+|   +-- exports/
+|   +-- content/mediation/
+|   +-- pipelines/
+|   +-- orchestrator/
+|   +-- event-adapter/
+|   +-- tools/
++-- tests/
+```
+
+## Work Package Summary
+
+| WP | Title | Deliverables | Dependencies |
+|----|-------|--------------|--------------|
+| WP01 | Schema and Compatibility Migration | Tenant tables, seed migration, schema exports, migration tests | None |
+| WP02 | Shared Resolver | `TenantContext` types, resolver service, Express middleware adapters, unit tests | WP01 |
+| WP03 | Explicit Tenant and API-Key Routes | Exports route migration, content mediation adapter, compatibility tests | WP02 |
+| WP04 | Bearer Routes and Tool Execution | Pipeline, orchestrator, event adapter management, MCP tool ports | WP02, WP03 |
+| WP05 | Admin UI Cleanup and Acceptance | Admin tenant selector, remove allowlist runtime path, full acceptance suite | WP04 |
+
+## Implementation Strategy
+
+### WP01: Schema and Compatibility Migration
+
+- Add `tenants`, `tenant_memberships`, and `tenant_access_audit` to the shared schema.
+- Generate a Drizzle migration.
+- Seed every existing user into an active primary membership where `tenantId === userId`.
+- Add a migration helper for optional `EXPORT_TENANT_ALLOWLIST` backfill.
+- Add tests that prove seed idempotency.
+
+### WP02: Shared Resolver
+
+- Add `joyus-ai-mcp-server/src/auth/tenant-context.ts`.
+- Implement pure resolver functions around repository interfaces before Express middleware.
+- Add Express adapters for bearer-token, API-key, explicit tenant, and operator override sources.
+- Add tests for all error outcomes in `data-model.md`.
+
+### WP03: Explicit Tenant and API-Key Routes
+
+- Port `joyus-ai-mcp-server/src/exports/router.ts` and `joyus-ai-mcp-server/src/exports/service.ts`.
+- Keep existing export response shapes.
+- Port `joyus-ai-mcp-server/src/content/mediation/auth.ts` through the API-key resolver path without requiring local user membership.
+- Add tests for valid API key, inactive API key, authorized export tenant, and unauthorized export tenant.
+
+### WP04: Bearer Routes and Tool Execution
+
+- Replace route-local `getTenantId` helpers in pipeline routes and event adapter management routes.
+- Replace `joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts` internals with the shared resolver.
+- Add a tenant context parameter to MCP tool execution where needed.
+- Preserve `userId === tenantId` compatibility via memberships, not direct assignment.
+
+### WP05: Admin UI Cleanup and Acceptance
+
+- Replace event adapter admin `x-tenant-id` behavior with a membership-backed tenant selector or explicit operator override path.
+- Remove runtime use of `EXPORT_TENANT_ALLOWLIST` and `EXPORT_ALLOW_ANY_TENANT`.
+- Add acceptance tests for default tenant, explicit authorized tenant, explicit unauthorized tenant, non-disclosure 404, API-key tenant, operator override, and non-operator impersonation denial.
+- Run TypeScript and targeted vitest suites.
+
+## Test Strategy
+
+Required tests before implementation is complete:
+
+- Resolver unit tests for default, requested, API-key, and operator override sources.
+- Migration tests for idempotent user-to-tenant seeding.
+- Exports route tests for authorized and unauthorized explicit tenants.
+- Content mediation auth tests proving API-key tenant compatibility.
+- Pipeline and orchestrator route tests proving bearer-token default tenant resolution.
+- Event adapter admin tests proving header-only tenant selection no longer authorizes access.
+- Non-disclosure tests for routes that currently return 404 on cross-tenant access.
+
+## Rollout Notes
+
+The compatibility migration makes current behavior equivalent before route ports begin. Once all ports use the shared resolver, environment allowlists can be removed from runtime authorization. If a production deployment still needs temporary allowlist import, run the migration helper before disabling the env vars.
+
+## Acceptance Gates
+
+1. `npm run typecheck` or equivalent TypeScript check in `joyus-ai-mcp-server/`.
+2. Targeted vitest suites for auth, exports, content mediation, pipelines, orchestrator, and event adapter.
+3. `rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|userId === tenantId|tenantId = userId|req.mcpUser\\.id"` confirms remaining matches are tests, docs, or explicit compatibility comments.
+4. `scripts/check-client-abstraction.sh` passes from repository root.

--- a/kitty-specs/013-tenant-identity-resolution/plan.md
+++ b/kitty-specs/013-tenant-identity-resolution/plan.md
@@ -64,8 +64,8 @@ joyus-ai-mcp-server/
 |   +-- auth/
 |   |   +-- tenant-context.ts
 |   |   +-- tenant-context.test.ts
-|   +-- db/schemas.ts
-|   +-- db/schema.ts
+|   +-- db/schemas.ts   # aggregator (registry that combines all domain schemas)
+|   +-- db/schema.ts    # core schema module (consumed by the aggregator)
 |   +-- exports/
 |   +-- content/mediation/
 |   +-- pipelines/
@@ -143,5 +143,5 @@ The compatibility migration makes current behavior equivalent before route ports
 
 1. `npm run typecheck` or equivalent TypeScript check in `joyus-ai-mcp-server/`.
 2. Targeted vitest suites for auth, exports, content mediation, pipelines, orchestrator, and event adapter.
-3. `rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|userId === tenantId|tenantId = userId|req.mcpUser\\.id"` confirms remaining matches are tests, docs, or explicit compatibility comments.
+3. Canonical acceptance grep (identical to `quickstart.md` step 3): `rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|userId === tenantId|tenantId = userId|req.mcpUser\\.id" joyus-ai-mcp-server/src joyus-ai-mcp-server/tests kitty-specs/013-tenant-identity-resolution` confirms remaining matches are tests, docs, or explicit compatibility comments.
 4. `scripts/check-client-abstraction.sh` passes from repository root.

--- a/kitty-specs/013-tenant-identity-resolution/quickstart.md
+++ b/kitty-specs/013-tenant-identity-resolution/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Tenant Identity Resolution
+
+This quickstart describes how to validate Spec 013 after implementation.
+
+## 1. Apply schema migrations
+
+```bash
+cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity/joyus-ai-mcp-server
+npm run db:migrate
+```
+
+Expected result:
+
+- `tenants` exists.
+- `tenant_memberships` exists.
+- Every existing user has an active primary membership where `tenant_id` matches the current compatibility tenant.
+
+## 2. Run targeted tests
+
+```bash
+cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity/joyus-ai-mcp-server
+npm test -- --run tests/auth tests/exports.test.ts tests/content/integration/mediation-auth.test.ts tests/pipelines/routes.test.ts tests/event-adapter
+```
+
+Expected result:
+
+- Default tenant resolution succeeds for a single-membership user.
+- Explicit authorized tenant succeeds.
+- Explicit unauthorized tenant fails closed.
+- API-key mediation still resolves tenant from the key record.
+- Operator override succeeds only for an operator role and records an audit event.
+
+## 3. Check for legacy runtime paths
+
+```bash
+cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity
+rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|tenantId = userId|userId === tenantId|req.mcpUser\\.id" joyus-ai-mcp-server/src joyus-ai-mcp-server/tests kitty-specs/013-tenant-identity-resolution
+```
+
+Expected result:
+
+- Remaining source matches are only documented compatibility comments, migration helpers, or tests.
+- No production route authorizes tenant access from a request header alone.
+
+## 4. Run platform checks
+
+```bash
+cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity
+scripts/check-client-abstraction.sh
+git diff --check
+```
+
+Expected result:
+
+- No client-specific terms are introduced.
+- No whitespace or encoding issues are introduced.

--- a/kitty-specs/013-tenant-identity-resolution/quickstart.md
+++ b/kitty-specs/013-tenant-identity-resolution/quickstart.md
@@ -5,7 +5,7 @@ This quickstart describes how to validate Spec 013 after implementation.
 ## 1. Apply schema migrations
 
 ```bash
-cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity/joyus-ai-mcp-server
+cd joyus-ai-mcp-server
 npm run db:migrate
 ```
 
@@ -18,7 +18,7 @@ Expected result:
 ## 2. Run targeted tests
 
 ```bash
-cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity/joyus-ai-mcp-server
+cd joyus-ai-mcp-server
 npm test -- --run tests/auth tests/exports.test.ts tests/content/integration/mediation-auth.test.ts tests/pipelines/routes.test.ts tests/event-adapter
 ```
 
@@ -33,8 +33,8 @@ Expected result:
 ## 3. Check for legacy runtime paths
 
 ```bash
-cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity
-rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|tenantId = userId|userId === tenantId|req.mcpUser\\.id" joyus-ai-mcp-server/src joyus-ai-mcp-server/tests kitty-specs/013-tenant-identity-resolution
+# Run from the repository root. Canonical acceptance grep (matches plan.md Acceptance Gate 3).
+rg -n "x-tenant-id|EXPORT_TENANT_ALLOWLIST|EXPORT_ALLOW_ANY_TENANT|userId === tenantId|tenantId = userId|req.mcpUser\\.id" joyus-ai-mcp-server/src joyus-ai-mcp-server/tests kitty-specs/013-tenant-identity-resolution
 ```
 
 Expected result:
@@ -45,7 +45,7 @@ Expected result:
 ## 4. Run platform checks
 
 ```bash
-cd /Users/AlexUA_1/claude/joyus-ai-tenant-identity
+# Run from the repository root.
 scripts/check-client-abstraction.sh
 git diff --check
 ```

--- a/kitty-specs/013-tenant-identity-resolution/research.md
+++ b/kitty-specs/013-tenant-identity-resolution/research.md
@@ -1,0 +1,42 @@
+# Research: Tenant Identity Resolution
+
+## Decision: Membership-backed tenant authorization
+
+**Decision**: Add `tenants` and `tenant_memberships` as shared platform tables. Use `tenant_memberships` as the authorization source for bearer-token users and operator override checks.
+
+**Rationale**: The current `userId === tenantId` convention cannot represent a user who belongs to multiple tenants. The exports allowlist can represent that case only through environment configuration. A membership table provides a durable, auditable, queryable policy source.
+
+**Evidence**: Issue #37 and `kitty-specs/009-automated-pipelines-framework/tenant-resolution-notes.md` both identify the missing user-to-tenant mapping as the central architectural gap.
+
+## Decision: API-key tenant remains authoritative
+
+**Decision**: Content mediation keeps the API key record as the source of tenant id. The shared resolver accepts an API-key source and returns a `TenantContext` without requiring the external end-user subject to exist in the local `users` table.
+
+**Rationale**: API keys are issued per tenant and already decouple integration identity from local user identity. Requiring all external subjects to be local users would break the mediation model and force a new identity provider integration that is out of scope.
+
+## Decision: Explicit requested tenant must be authorized
+
+**Decision**: Explicit path or query tenant selection is modeled as `requestedTenantId`. The resolver authorizes it against memberships unless the request is API-key scoped or an operator override.
+
+**Rationale**: This preserves exports route semantics while replacing `EXPORT_TENANT_ALLOWLIST` with a first-class database policy.
+
+## Decision: Primary tenant default
+
+**Decision**: Requests without an explicit tenant use the user's primary membership. If no primary exists and multiple memberships are active, the resolver fails closed with a 400 error.
+
+**Rationale**: Silent selection among multiple tenants is unsafe. A primary tenant preserves simple user flows without allowing ambiguous tenant context.
+
+## Decision: Operator override is separate from membership
+
+**Decision**: Operators need an explicit override path with role gating and audit logging. Override is not treated as ordinary membership.
+
+**Rationale**: Operational support needs are real, but silent all-tenant access would erase the authorization boundary. Keeping override separate makes privileged actions visible and testable.
+
+## Alternatives Considered
+
+| Alternative | Rejected because |
+|-------------|-----------------|
+| Keep `userId === tenantId` permanently | Cannot support multi-tenant users or operator workflows |
+| Expand `EXPORT_TENANT_ALLOWLIST` to all modules | Env configuration is not auditable enough and does not scale to route logic |
+| Trust `x-tenant-id` headers after bearer auth | Headers identify requested context, not authorization; they must not be trusted by themselves |
+| Require API-key end users to be local users | Breaks content mediation integrations and expands scope into identity provider federation |

--- a/kitty-specs/013-tenant-identity-resolution/spec.md
+++ b/kitty-specs/013-tenant-identity-resolution/spec.md
@@ -1,0 +1,169 @@
+# Spec 013: Tenant Identity Resolution
+
+## Overview
+
+Joyus AI currently resolves tenant identity through three coexisting patterns:
+
+1. Bearer-token routes use the authenticated user id as the tenant id.
+2. Content mediation routes derive tenant id from an API key record.
+3. Export routes accept an explicit tenant path parameter and authorize it with an environment allowlist.
+
+These patterns are locally safe, but they do not provide a single platform contract for users who belong to more than one tenant, for service integrations scoped by API key, or for operators who need explicit tenant override behavior. This spec creates that contract.
+
+**Outcome**: Every platform surface resolves tenant context through one shared tenant identity layer, using membership-backed authorization, safe defaults, and explicit override semantics.
+
+## Goals
+
+1. Define a first-class user-to-tenant membership model with roles and primary tenant behavior.
+2. Provide a shared tenant resolution contract for bearer-token routes, API-key routes, explicit tenant path routes, and admin UI routes.
+3. Preserve current single-tenant behavior during migration by seeding each existing user into a tenant matching their user id.
+4. Replace route-local tenant allowlists and header trust with membership-backed authorization.
+5. Define tests that prove authorized, unauthorized, default, non-disclosure, and operator override paths.
+
+## Non-Goals
+
+- Client-specific tenant names, examples, roles, or domain vocabulary.
+- A new external identity provider or single sign-on integration.
+- Billing, subscription, or entitlement policy beyond tenant access authorization.
+- Changing tenant-scoped data tables other than adding the shared tenant and membership records needed for resolution.
+- Reworking every domain query; existing tenant filters remain the data isolation boundary.
+
+## Current State
+
+The codebase already filters tenant data by `tenantId` or `tenant_id` at the data layer. The gap is request-time identity resolution.
+
+| Surface | Current source of tenant id | Current authorization |
+|---------|-----------------------------|-----------------------|
+| MCP tool execution | `userId` | Bearer token identity only |
+| Pipeline REST routes | `req.mcpUser.id` or session user id | Bearer token or session identity only |
+| Orchestrator routes | `req.mcpUser.id` via `joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts` | Bearer token identity only |
+| Event adapter management routes | `req.mcpUser.id` in most routes | Bearer token identity only |
+| Event adapter admin UI | `x-tenant-id` header or null platform view | Authenticated session, no tenant membership check |
+| Content mediation routes | `content_api_keys.tenant_id` | API key plus optional end-user JWT |
+| Export routes | `/tenants/:tenantId` | `EXPORT_TENANT_ALLOWLIST`, `EXPORT_ALLOW_ANY_TENANT`, or `tenantId === userId` |
+
+The current notes live in `kitty-specs/009-automated-pipelines-framework/tenant-resolution-notes.md`. This spec supersedes those notes as the owning convergence plan.
+
+## Functional Requirements
+
+### Shared Tenant Model
+
+- FR-001: The platform MUST store tenants as first-class records with stable `tenant_id` values.
+- FR-002: The platform MUST store user memberships in `tenant_memberships` with `userId`, `tenantId`, `role`, and `isPrimary`.
+- FR-003: A user MAY belong to multiple tenants.
+- FR-004: A user MUST have at most one primary tenant.
+- FR-005: Existing users MUST receive a backward-compatible default membership where `tenantId` equals `userId`.
+
+### Resolution Contract
+
+- FR-006: The platform MUST expose one shared tenant resolution module used by route handlers and tool execution.
+- FR-007: The shared resolver MUST return a typed `TenantContext` containing `tenantId`, `userId` when present, `source`, `role`, and `overrideReason` when applicable.
+- FR-008: If a request does not specify a tenant and the authenticated user has one primary membership, the resolver MUST use that primary tenant.
+- FR-009: If a request does not specify a tenant and the authenticated user has multiple memberships but no primary tenant, the resolver MUST fail closed with a 400 response.
+- FR-010: If a request specifies a tenant, the resolver MUST authorize the authenticated user against `tenant_memberships` before attaching tenant context.
+- FR-011: Unauthorized explicit tenant requests MUST fail without exposing protected resource existence. Existing route contracts that return 404 for cross-tenant resource access MUST keep returning 404.
+
+### Auth Surface Behavior
+
+- FR-012: Bearer-token routes MUST derive user identity from `req.mcpUser` and tenant authorization from memberships.
+- FR-013: API-key mediation routes MUST continue to derive tenant id from the API key record, then bind end-user identity when a user token is present.
+- FR-014: Explicit tenant path routes MUST treat the path tenant as a requested tenant and authorize it through the shared resolver.
+- FR-015: Event adapter admin UI routes MUST stop using `x-tenant-id` as an authorization source. Any tenant selector or requested tenant must flow through the shared resolver.
+- FR-016: Header-based tenant selection MUST be rejected unless the caller path is explicitly documented as an internal, authenticated operator-only path.
+
+### Operator Override
+
+- FR-017: Operator override MUST be explicit and role-gated.
+- FR-018: Operator override MUST record the authenticated user, target tenant, reason, source, and timestamp in an audit event.
+- FR-019: Non-operator users MUST NOT be able to impersonate or override tenant context.
+- FR-020: Environment variables such as `EXPORT_ALLOW_ANY_TENANT` MUST NOT bypass membership checks in production mode.
+
+### Compatibility and Rollout
+
+- FR-021: During migration, existing `userId === tenantId` behavior MUST remain valid through seeded memberships.
+- FR-022: Export tenant allowlist behavior MAY remain as a temporary compatibility input only long enough to seed memberships.
+- FR-023: The final runtime path MUST not depend on `EXPORT_TENANT_ALLOWLIST` for tenant authorization.
+- FR-024: Existing API key records MUST continue working without key rotation.
+- FR-025: Existing tenant-scoped tables MUST continue to use current tenant filters.
+
+## User Scenarios
+
+### Scenario 1: Default tenant for single-tenant user
+
+1. An authenticated user calls a bearer-token route without specifying a tenant.
+2. The resolver finds exactly one primary membership.
+3. The route operates under that tenant context.
+
+### Scenario 2: Explicit authorized tenant
+
+1. An authenticated user calls an export route with `/tenants/tenant_a/...`.
+2. The resolver checks membership for `tenant_a`.
+3. The route succeeds only if the user has an active membership for `tenant_a`.
+
+### Scenario 3: Explicit unauthorized tenant
+
+1. An authenticated user requests `/tenants/tenant_b/...`.
+2. The resolver finds no active membership for `tenant_b`.
+3. The route fails with the existing non-disclosure response contract.
+
+### Scenario 4: API-key scoped mediation
+
+1. A service integration sends a valid API key.
+2. The resolver derives tenant context from the API key record.
+3. If an end-user token is supplied, the request binds that user identity for audit without changing the API-key tenant.
+
+### Scenario 5: Operator override
+
+1. An operator requests a target tenant and supplies an override reason.
+2. The resolver verifies an operator role.
+3. The route operates under the target tenant and emits an audit event.
+
+## Success Criteria
+
+1. All runtime surfaces listed in Current State use the shared resolver or an approved adapter around it.
+2. Existing single-tenant users continue to operate with no request changes.
+3. A user with two memberships can select either authorized tenant.
+4. Unauthorized tenant selection fails closed and preserves existing 404 non-disclosure contracts.
+5. Content mediation API keys continue to resolve their configured tenant.
+6. Operator override is role-gated and audited.
+7. TypeScript compilation and targeted tenant-resolution tests pass.
+
+## Security and Governance
+
+- Tenant identity is a security boundary. Resolver failures are treated as authorization failures, not validation warnings.
+- Request headers are never trusted for tenant authorization by default.
+- All examples in this spec use generic tenant ids such as `tenant_a`, `tenant_b`, and `Example Corp`.
+- This spec follows the client abstraction rule in `AGENTS.md`; no client names or client-specific terminology are introduced.
+
+## Dependencies
+
+- Existing auth middleware in `joyus-ai-mcp-server/src/auth/middleware.ts`.
+- Existing user records in `joyus-ai-mcp-server/src/db/schema.ts`.
+- Existing tenant-scoped data tables in content, pipeline, event adapter, profile, export, and orchestrator modules.
+- Existing API-key table in `joyus-ai-mcp-server/src/content/schema.ts`.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Breaking existing single-tenant routes | High | Seed `tenant_memberships` with `tenantId === userId` and test default resolution |
+| Accidental header trust remains | High | Search and test every route-local `resolveTenantId` and `x-tenant-id` path |
+| API-key mediation changes tenant semantics | Medium | Treat API key tenant as authoritative and add compatibility tests |
+| Operator override becomes too broad | High | Require role, explicit reason, and audit event |
+| Route status codes drift | Medium | Preserve 404 non-disclosure tests for cross-tenant resource access |
+
+## Adoption Plan
+
+1. Add schema and compatibility migration.
+2. Add shared resolver with tests before porting routes.
+3. Port exports first because it already has explicit tenant semantics.
+4. Port bearer-token routes and tool execution.
+5. Port event adapter admin UI and management routes.
+6. Remove export allowlist bypass from the runtime path after migration tests pass.
+
+## Measurement
+
+- Owner: Engineering Operations.
+- Review cadence: weekly until all route-local tenant resolution helpers are removed.
+- Primary metric: count of tenant resolution call sites using shared resolver.
+- Secondary metric: count of route-local tenant header or `userId === tenantId` fallbacks remaining.

--- a/kitty-specs/013-tenant-identity-resolution/spec.md
+++ b/kitty-specs/013-tenant-identity-resolution/spec.md
@@ -62,6 +62,7 @@ The current notes live in `kitty-specs/009-automated-pipelines-framework/tenant-
 - FR-009: If a request does not specify a tenant and the authenticated user has multiple memberships but no primary tenant, the resolver MUST fail closed with a 400 response.
 - FR-010: If a request specifies a tenant, the resolver MUST authorize the authenticated user against `tenant_memberships` before attaching tenant context.
 - FR-011: Unauthorized explicit tenant requests MUST fail without exposing protected resource existence. Existing route contracts that return 404 for cross-tenant resource access MUST keep returning 404.
+- FR-027: The 403-vs-404 outcome for an unauthorized requested tenant MUST be deterministic and fail-closed, not dependent on an unset option. When a route does not set non-disclosure explicitly, resource routes default to 404 and management routes default to 403. See the "Non-Disclosure Default" contract in `data-model.md`. An explicitly AUTHORIZED requested tenant MUST always succeed, including for a multi-membership user with no primary tenant.
 
 ### Auth Surface Behavior
 
@@ -70,6 +71,7 @@ The current notes live in `kitty-specs/009-automated-pipelines-framework/tenant-
 - FR-014: Explicit tenant path routes MUST treat the path tenant as a requested tenant and authorize it through the shared resolver.
 - FR-015: Event adapter admin UI routes MUST stop using `x-tenant-id` as an authorization source. Any tenant selector or requested tenant must flow through the shared resolver.
 - FR-016: Header-based tenant selection MUST be rejected unless the caller path is explicitly documented as an internal, authenticated operator-only path.
+- FR-026: Platform-admin / no-tenant-scope privilege MUST derive from a membership role (`operator`, or `admin` where a route documents admin-level scope), NEVER from the absence of an `x-tenant-id` header or any other missing request input. Routes that currently treat a missing `x-tenant-id` header as platform-admin context (for example `joyus-ai-mcp-server/src/event-adapter/routes/schedules.ts` and `joyus-ai-mcp-server/src/event-adapter/routes/admin.ts`) MUST migrate this inverted trust so that a header-less request resolves to the caller's membership-derived role, and a header-less request from a non-operator MUST NOT receive platform-admin privileges.
 
 ### Operator Override
 

--- a/kitty-specs/013-tenant-identity-resolution/status.json
+++ b/kitty-specs/013-tenant-identity-resolution/status.json
@@ -1,0 +1,56 @@
+{
+  "event_count": 0,
+  "last_event_id": null,
+  "materialized_at": "",
+  "mission_number": "013",
+  "mission_slug": "013-tenant-identity-resolution",
+  "mission_type": "platform",
+  "summary": {
+    "approved": 0,
+    "blocked": 0,
+    "canceled": 0,
+    "claimed": 0,
+    "done": 0,
+    "for_review": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "planned": 5
+  },
+  "work_packages": {
+    "WP01": {
+      "actor": null,
+      "force_count": 0,
+      "lane": "planned",
+      "last_event_id": null,
+      "last_transition_at": null
+    },
+    "WP02": {
+      "actor": null,
+      "force_count": 0,
+      "lane": "planned",
+      "last_event_id": null,
+      "last_transition_at": null
+    },
+    "WP03": {
+      "actor": null,
+      "force_count": 0,
+      "lane": "planned",
+      "last_event_id": null,
+      "last_transition_at": null
+    },
+    "WP04": {
+      "actor": null,
+      "force_count": 0,
+      "lane": "planned",
+      "last_event_id": null,
+      "last_transition_at": null
+    },
+    "WP05": {
+      "actor": null,
+      "force_count": 0,
+      "lane": "planned",
+      "last_event_id": null,
+      "last_transition_at": null
+    }
+  }
+}

--- a/kitty-specs/013-tenant-identity-resolution/tasks.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks.md
@@ -1,0 +1,97 @@
+# Tasks: Tenant Identity Resolution (Spec 013)
+
+**Feature**: 013-tenant-identity-resolution
+**Plan**: [plan.md](plan.md)
+**Total subtasks**: 31 across 5 work packages
+
+## Subtask Inventory
+
+| ID | Description | WP |
+|----|-------------|----|
+| T001 | Add `tenants` table to Drizzle schema | WP01 |
+| T002 | Add `tenant_memberships` table with role, status, and primary flag | WP01 |
+| T003 | Add `tenant_access_audit` table for override events | WP01 |
+| T004 | Generate Drizzle migration | WP01 |
+| T005 | Add idempotent compatibility seed for `tenantId === userId` | WP01 |
+| T006 | Add optional allowlist import helper for export memberships | WP01 |
+| T007 | Add schema and seed tests | WP01 |
+| T008 | Define `TenantContext` and resolver input types | WP02 |
+| T009 | Implement membership lookup repository | WP02 |
+| T010 | Implement bearer default resolution | WP02 |
+| T011 | Implement explicit requested tenant authorization | WP02 |
+| T012 | Implement API-key tenant context adapter | WP02 |
+| T013 | Implement operator override with audit event | WP02 |
+| T014 | Add Express middleware helpers | WP02 |
+| T015 | Add resolver unit tests for success and failure paths | WP02 |
+| T016 | Port exports route and service to shared resolver | WP03 |
+| T017 | Preserve export response contracts and non-disclosure behavior | WP03 |
+| T018 | Port content mediation auth through API-key resolver adapter | WP03 |
+| T019 | Add exports route tests | WP03 |
+| T020 | Add content mediation auth compatibility tests | WP03 |
+| T021 | Port pipeline routes to shared resolver | WP04 |
+| T022 | Port orchestrator tenant middleware to shared resolver | WP04 |
+| T023 | Port event adapter management routes to shared resolver | WP04 |
+| T024 | Pass tenant context into MCP tool execution | WP04 |
+| T025 | Replace direct `userId === tenantId` assignments with resolver output | WP04 |
+| T026 | Add bearer route and tool tests | WP04 |
+| T027 | Replace event adapter admin header-only tenant selection | WP05 |
+| T028 | Add admin tenant selector or explicit operator override path | WP05 |
+| T029 | Remove runtime use of export allowlist env vars | WP05 |
+| T030 | Run acceptance grep and client abstraction checks | WP05 |
+| T031 | Run TypeScript and targeted vitest suites | WP05 |
+
+## Work Packages
+
+### WP01 - Schema and Compatibility Migration
+
+**Goal**: Create first-class tenant and membership tables while preserving current behavior.
+**Priority**: High
+**Dependencies**: None
+**Prompt**: [tasks/WP01-schema-memberships.md](tasks/WP01-schema-memberships.md)
+
+### WP02 - Shared Resolver
+
+**Goal**: Implement the reusable tenant context resolver and middleware adapters.
+**Priority**: High
+**Dependencies**: WP01
+**Prompt**: [tasks/WP02-shared-resolver.md](tasks/WP02-shared-resolver.md)
+
+### WP03 - Explicit Tenant and API-Key Routes
+
+**Goal**: Port the two surfaces with existing non-user tenant semantics: exports and content mediation.
+**Priority**: High
+**Dependencies**: WP02
+**Prompt**: [tasks/WP03-explicit-and-api-key-routes.md](tasks/WP03-explicit-and-api-key-routes.md)
+
+### WP04 - Bearer Routes and Tool Execution
+
+**Goal**: Port bearer-token APIs and MCP tools away from direct `userId === tenantId` assignment.
+**Priority**: High
+**Dependencies**: WP02, WP03
+**Prompt**: [tasks/WP04-bearer-routes-and-tools.md](tasks/WP04-bearer-routes-and-tools.md)
+
+### WP05 - Admin Cleanup and Acceptance
+
+**Goal**: Replace header-only admin tenant selection, remove runtime allowlists, and complete acceptance tests.
+**Priority**: High
+**Dependencies**: WP04
+**Prompt**: [tasks/WP05-admin-cleanup-acceptance.md](tasks/WP05-admin-cleanup-acceptance.md)
+
+## MVP Scope
+
+WP01 through WP03 produce a usable resolver for explicit tenant and API-key paths. WP04 and WP05 are required before issue #37 can close because route-local fallbacks and admin header selection still remain until then.
+
+## Parallelization Opportunities
+
+- T008 through T014 can be developed with pure unit tests before route ports begin.
+- T019 and T020 can be written in parallel after WP03 route ports.
+- Event adapter management route ports in T023 can be split by route file after the shared middleware is available.
+
+<!-- status-model:start -->
+## Canonical Status (Generated)
+- WP01: planned
+- WP02: planned
+- WP03: planned
+- WP04: planned
+- WP05: planned
+<!-- status-model:end -->

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
@@ -14,7 +14,12 @@ Create first-class tenant and membership tables while preserving existing single
 ## Scope
 
 - Add `tenants`, `tenant_memberships`, and `tenant_access_audit`.
-- Export the schemas through `joyus-ai-mcp-server/src/db/schemas.ts`.
+- Enforce "at most one active primary membership per user" (FR-004) with a
+  PARTIAL unique index `UNIQUE (user_id) WHERE is_primary AND status = 'active'`,
+  not a plain unique index. If the target Postgres/Drizzle setup cannot express
+  the partial index, fall back to documented app-level enforcement plus a test
+  that asserts a second active primary membership is rejected.
+- Export the schemas through `joyus-ai-mcp-server/src/db/schemas.ts` (the aggregator registry; `db/schema.ts` is the core schema module the aggregator consumes).
 - Generate a Drizzle migration.
 - Add idempotent compatibility seeding where each current user gets a primary membership with `tenantId === userId`.
 - Add an optional helper to import `EXPORT_TENANT_ALLOWLIST` into memberships.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
@@ -1,0 +1,33 @@
+---
+work_package_id: WP01
+title: Schema and Compatibility Migration
+status: planned
+depends_on: []
+---
+
+# WP01: Schema and Compatibility Migration
+
+## Goal
+
+Create first-class tenant and membership tables while preserving existing single-tenant behavior.
+
+## Scope
+
+- Add `tenants`, `tenant_memberships`, and `tenant_access_audit`.
+- Export the schemas through `joyus-ai-mcp-server/src/db/schemas.ts`.
+- Generate a Drizzle migration.
+- Add idempotent compatibility seeding where each current user gets a primary membership with `tenantId === userId`.
+- Add an optional helper to import `EXPORT_TENANT_ALLOWLIST` into memberships.
+
+## Tests
+
+- Schema migration applies cleanly.
+- Compatibility seed can run twice without duplicate rows.
+- A seeded user has one active primary membership.
+- Allowlist import creates additional memberships without changing primary membership.
+
+## Done When
+
+- TypeScript compiles for new schema exports.
+- Migration and seed tests pass.
+- No client-specific tenant examples are introduced.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP01-schema-memberships.md
@@ -14,9 +14,15 @@ Create first-class tenant and membership tables while preserving existing single
 ## Scope
 
 - Add `tenants`, `tenant_memberships`, and `tenant_access_audit`.
+- Enforce one membership row per `(user_id, tenant_id)` with a plain unique
+  index. Membership lifecycle mutates `status` in place
+  (`invited` → `active` → `revoked`); reactivation re-uses the existing row
+  (`revoked` → `active`) rather than inserting a new one, so the pair is never
+  duplicated.
 - Enforce "at most one active primary membership per user" (FR-004) with a
   PARTIAL unique index `UNIQUE (user_id) WHERE is_primary AND status = 'active'`,
-  not a plain unique index. If the target Postgres/Drizzle setup cannot express
+  not a plain unique index — a user has one row per tenant and only one may be
+  the active default. If the target Postgres/Drizzle setup cannot express
   the partial index, fall back to documented app-level enforcement plus a test
   that asserts a second active primary membership is rejected.
 - Export the schemas through `joyus-ai-mcp-server/src/db/schemas.ts` (the aggregator registry; `db/schema.ts` is the core schema module the aggregator consumes).
@@ -29,6 +35,8 @@ Create first-class tenant and membership tables while preserving existing single
 - Schema migration applies cleanly.
 - Compatibility seed can run twice without duplicate rows.
 - A seeded user has one active primary membership.
+- Reactivating a `revoked` membership re-uses the existing row (no second row is
+  inserted for the same `(user_id, tenant_id)` pair).
 - Allowlist import creates additional memberships without changing primary membership.
 
 ## Done When

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP02-shared-resolver.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP02-shared-resolver.md
@@ -1,0 +1,36 @@
+---
+work_package_id: WP02
+title: Shared Resolver
+status: planned
+depends_on: [WP01]
+---
+
+# WP02: Shared Resolver
+
+## Goal
+
+Implement the shared tenant context resolver used by all route families.
+
+## Scope
+
+- Add `joyus-ai-mcp-server/src/auth/tenant-context.ts`.
+- Define `TenantContext`, resolver input types, and typed resolver errors.
+- Implement bearer default, bearer requested tenant, API-key tenant, and operator override resolution.
+- Add Express middleware helpers that attach `req.tenantContext` and `req.tenantId`.
+- Emit tenant access audit events for operator override.
+
+## Tests
+
+- Missing auth identity returns 401.
+- Single primary membership defaults successfully.
+- Multiple memberships without primary fail with 400.
+- Explicit authorized tenant succeeds.
+- Explicit unauthorized tenant fails with the configured disclosure mode.
+- API-key tenant context succeeds without requiring local user membership.
+- Operator override requires operator role and reason.
+
+## Done When
+
+- Resolver unit tests pass.
+- Route code can call the resolver without importing route-specific policy.
+- Failure responses are typed and consistent.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP03-explicit-and-api-key-routes.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP03-explicit-and-api-key-routes.md
@@ -1,0 +1,35 @@
+---
+work_package_id: WP03
+title: Explicit Tenant and API-Key Routes
+status: planned
+depends_on: [WP02]
+---
+
+# WP03: Explicit Tenant and API-Key Routes
+
+## Goal
+
+Port route surfaces that already have explicit tenant semantics to the shared resolver.
+
+## Scope
+
+- Port `joyus-ai-mcp-server/src/exports/router.ts`.
+- Replace `canAccessTenant()` runtime authorization in `joyus-ai-mcp-server/src/exports/service.ts`.
+- Keep existing export response shapes and signed URL behavior.
+- Port `joyus-ai-mcp-server/src/content/mediation/auth.ts` through the API-key resolver adapter.
+- Preserve existing API key behavior and last-used updates.
+
+## Tests
+
+- Export request for an authorized tenant succeeds.
+- Export request for an unauthorized tenant fails closed.
+- Export download lookup preserves existing contract.
+- Valid content mediation API key resolves tenant from key record.
+- Inactive content mediation API key still fails.
+- User JWT validation continues to attach user id for audit context.
+
+## Done When
+
+- Exports no longer authorize through `EXPORT_TENANT_ALLOWLIST` at runtime.
+- Content mediation remains API-key compatible.
+- Targeted exports and mediation tests pass.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP04-bearer-routes-and-tools.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP04-bearer-routes-and-tools.md
@@ -1,0 +1,34 @@
+---
+work_package_id: WP04
+title: Bearer Routes and Tool Execution
+status: planned
+depends_on: [WP02, WP03]
+---
+
+# WP04: Bearer Routes and Tool Execution
+
+## Goal
+
+Replace bearer-token route and MCP tool tenant derivation with shared tenant context.
+
+## Scope
+
+- Port `joyus-ai-mcp-server/src/pipelines/routes.ts`.
+- Port `joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts`.
+- Port event adapter management routes under `joyus-ai-mcp-server/src/event-adapter/routes/`.
+- Pass resolved tenant context into `joyus-ai-mcp-server/src/tools/executor.ts`.
+- Preserve route-specific non-disclosure behavior for cross-tenant resources.
+
+## Tests
+
+- Pipeline routes use primary membership by default.
+- Orchestrator routes receive `req.tenantId` from shared resolver.
+- Event adapter management routes use shared resolver instead of local helper functions.
+- Content, profile, and pipeline tools receive resolver tenant context.
+- Direct `userId === tenantId` assignments are removed or limited to compatibility tests.
+
+## Done When
+
+- Bearer-token surfaces no longer implement their own tenant resolver.
+- Targeted route and tool tests pass.
+- Acceptance grep shows no production direct fallback assignments remain.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP05-admin-cleanup-acceptance.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP05-admin-cleanup-acceptance.md
@@ -1,0 +1,35 @@
+---
+work_package_id: WP05
+title: Admin Cleanup and Acceptance
+status: planned
+depends_on: [WP04]
+---
+
+# WP05: Admin Cleanup and Acceptance
+
+## Goal
+
+Finish the migration by replacing header-only admin tenant selection and removing runtime allowlist bypasses.
+
+## Scope
+
+- Replace event adapter admin `x-tenant-id` behavior with a membership-backed selector or explicit operator override.
+- Require operator override reason when crossing ordinary membership boundaries.
+- Remove runtime dependence on `EXPORT_TENANT_ALLOWLIST`.
+- Remove runtime dependence on `EXPORT_ALLOW_ANY_TENANT`.
+- Run final acceptance checks.
+
+## Tests
+
+- Admin user sees only authorized tenants by default.
+- Operator override can access a target tenant only with operator role and reason.
+- Non-operator override fails.
+- Override emits a tenant access audit event.
+- Legacy env allowlist no longer authorizes runtime access.
+
+## Done When
+
+- `npm run typecheck` or equivalent passes in `joyus-ai-mcp-server/`.
+- Targeted vitest suites pass.
+- `scripts/check-client-abstraction.sh` passes.
+- `git diff --check` passes.

--- a/kitty-specs/013-tenant-identity-resolution/tasks/WP05-admin-cleanup-acceptance.md
+++ b/kitty-specs/013-tenant-identity-resolution/tasks/WP05-admin-cleanup-acceptance.md
@@ -26,6 +26,7 @@ Finish the migration by replacing header-only admin tenant selection and removin
 - Non-operator override fails.
 - Override emits a tenant access audit event.
 - Legacy env allowlist no longer authorizes runtime access.
+- A header-less, non-operator request does NOT receive platform-admin privileges (verifies FR-026: platform-admin derives from membership role, never from `x-tenant-id` header absence).
 
 ## Done When
 

--- a/scripts/check-client-abstraction.sh
+++ b/scripts/check-client-abstraction.sh
@@ -30,11 +30,19 @@ scan_text() {
 
   # Specific failures we have hit before: real reviewer names and internal
   # checkpoint metadata leaking into public specs, docs, or commit messages.
+  #
+  # Absolute home-directory paths (e.g. /Users/<name>/... or /home/<name>/...)
+  # leak a developer's real username and a machine-local layout. Repo artifacts
+  # MUST use repo-relative invocations instead. We match the home root followed
+  # by a username segment and a trailing slash so generic mentions of "/home"
+  # or "/Users" without a user segment do not trip the guard.
   local patterns=(
     'reviewed_by:[[:space:]]*["'"'"']?[A-Z][A-Za-z]+[[:space:]][A-Z][A-Za-z-]+'
     'agent:[[:space:]]*["'"'"']?c[l]aude[-_a-zA-Z0-9]*'
     '–[[:space:]]*c[l]aude[-_a-zA-Z0-9]*[[:space:]]*–'
     'Entire[-]Checkpoint:'
+    '/Users/[A-Za-z0-9._-]+/'
+    '/home/[A-Za-z0-9._-]+/'
   )
 
   for pattern in "${patterns[@]}"; do


### PR DESCRIPTION
## Summary

- adds `kitty-specs/013-tenant-identity-resolution` as the owning platform spec for issue #37
- defines membership-backed tenant resolution across bearer-token, API-key, explicit tenant, and admin routes
- adds implementation work packages, data model, research notes, quickstart, and requirements checklist
- upgrades Spec Kitty project metadata to 3.1.8 so current CLI validation no longer fails on version mismatch

## Validation

- `git diff --cached --check` before commit
- `scripts/check-client-abstraction.sh --staged` before commit
- raw ASCII scan for `kitty-specs/013-tenant-identity-resolution`
- `git diff --check origin/main..HEAD`
- `spec-kitty upgrade --dry-run`

Refs #37.