### PR TITLE
[codex] Unify tenant resolution

### DIFF
--- a/joyus-ai-mcp-server/drizzle/migrations/0009_tenant_memberships.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0009_tenant_memberships.sql
@@ -1,0 +1,35 @@
+-- Tenant memberships
+-- Shared user-to-tenant grants for tenant resolution.
+-- Generated: 2026-05-25
+
+CREATE TYPE "public"."tenant_role" AS ENUM(
+  'member',
+  'admin',
+  'operator'
+);
+
+CREATE TABLE "tenant_memberships" (
+  "id"         TEXT PRIMARY KEY,
+  "user_id"    TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "tenant_id"  TEXT NOT NULL,
+  "role"       "tenant_role" NOT NULL DEFAULT 'member',
+  "is_default" BOOLEAN NOT NULL DEFAULT FALSE,
+  "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX "tenant_memberships_user_tenant_unique"
+  ON "tenant_memberships" ("user_id", "tenant_id");
+
+CREATE INDEX "tenant_memberships_tenant_id_idx"
+  ON "tenant_memberships" ("tenant_id");
+
+CREATE INDEX "tenant_memberships_user_default_idx"
+  ON "tenant_memberships" ("user_id", "is_default");
+
+CREATE INDEX "tenant_memberships_user_role_idx"
+  ON "tenant_memberships" ("user_id", "role");
+
+CREATE UNIQUE INDEX "tenant_memberships_user_default_unique"
+  ON "tenant_memberships" ("user_id")
+  WHERE "is_default" = TRUE;

--- a/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
+++ b/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779713480527,
       "tag": "0008_pipeline_name_not_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1779710400000,
+      "tag": "0009_tenant_memberships",
+      "breakpoints": true
     }
   ]
 }

--- a/joyus-ai-mcp-server/src/db/schema.ts
+++ b/joyus-ai-mcp-server/src/db/schema.ts
@@ -5,7 +5,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   pgTable,
   pgEnum,
@@ -46,6 +46,12 @@ export const taskRunStatusEnum = pgEnum('task_run_status', [
   'SKIPPED'
 ]);
 
+export const tenantRoleEnum = pgEnum('tenant_role', [
+  'member',
+  'admin',
+  'operator'
+]);
+
 // ============================================================
 // TABLES
 // ============================================================
@@ -59,6 +65,26 @@ export const users = pgTable('users', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });
+
+// User-to-tenant authorization grants. tenantId is intentionally a text
+// identifier because tenant-scoped domain tables already store tenant_id as text.
+export const tenantMemberships = pgTable('tenant_memberships', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  tenantId: text('tenant_id').notNull(),
+  role: tenantRoleEnum('role').notNull().default('member'),
+  isDefault: boolean('is_default').notNull().default(false),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull()
+}, (table) => ({
+  userTenantUnique: uniqueIndex('tenant_memberships_user_tenant_unique').on(table.userId, table.tenantId),
+  tenantIdIdx: index('tenant_memberships_tenant_id_idx').on(table.tenantId),
+  userDefaultIdx: index('tenant_memberships_user_default_idx').on(table.userId, table.isDefault),
+  userRoleIdx: index('tenant_memberships_user_role_idx').on(table.userId, table.role),
+  userDefaultUnique: uniqueIndex('tenant_memberships_user_default_unique')
+    .on(table.userId)
+    .where(sql`${table.isDefault} = true`)
+}));
 
 // OAuth tokens for connected services
 export const connections = pgTable('connections', {
@@ -166,10 +192,18 @@ export const taskRuns = pgTable('task_runs', {
 // ============================================================
 
 export const usersRelations = relations(users, ({ many }) => ({
+  tenantMemberships: many(tenantMemberships),
   connections: many(connections),
   auditLogs: many(auditLogs),
   scheduledTasks: many(scheduledTasks),
   taskRuns: many(taskRuns)
+}));
+
+export const tenantMembershipsRelations = relations(tenantMemberships, ({ one }) => ({
+  user: one(users, {
+    fields: [tenantMemberships.userId],
+    references: [users.id]
+  })
 }));
 
 export const connectionsRelations = relations(connections, ({ one }) => ({
@@ -211,6 +245,10 @@ export const taskRunsRelations = relations(taskRuns, ({ one }) => ({
 
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
+
+export type TenantMembership = typeof tenantMemberships.$inferSelect;
+export type NewTenantMembership = typeof tenantMemberships.$inferInsert;
+export type TenantRole = 'member' | 'admin' | 'operator';
 
 export type Connection = typeof connections.$inferSelect;
 export type NewConnection = typeof connections.$inferInsert;

--- a/joyus-ai-mcp-server/src/db/schema/orchestrator.ts
+++ b/joyus-ai-mcp-server/src/db/schema/orchestrator.ts
@@ -12,8 +12,8 @@
  *
  * tenantId note:
  *   No 'tenants' table exists yet — tenantId is an opaque text reference.
- *   In the current single-tenant world, tenantId == userId (see tools/executor.ts).
- *   Multi-tenant resolution is deferred to a future WP (WP12 per executor.ts comments).
+ *   Request-time authorization is resolved through the shared tenant resolver
+ *   and tenant_memberships table.
  */
 
 import { createId } from '@paralleldrive/cuid2';

--- a/joyus-ai-mcp-server/src/event-adapter/index.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/index.ts
@@ -6,7 +6,9 @@
  */
 
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { Router } from 'express';
+import { Router, type NextFunction, type Request, type Response } from 'express';
+
+import { resolveTenantContext, sendTenantResolutionError } from '../tenancy/resolver.js';
 
 import { createAdminRouter } from './routes/admin.js';
 import { createAutomationRouter } from './routes/automation.js';
@@ -135,6 +137,21 @@ export function createEventAdapterRouter(deps?: EventAdapterRouterDeps): Router 
   const router = Router();
 
   if (deps) {
+    router.use(async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        await resolveTenantContext(req, {
+          db: deps.db,
+          allowPlatformWide: true,
+          lookupDefaultTenant: true,
+          tenantHeaderNames: ['x-tenant-id'],
+          tenantQueryKeys: ['tenant_id', 'tenantId'],
+        });
+        next();
+      } catch (error) {
+        sendTenantResolutionError(res, error);
+      }
+    });
+
     const sourcesRouter = createSourcesRouter({ db: deps.db });
     router.use(sourcesRouter);
 

--- a/joyus-ai-mcp-server/src/event-adapter/index.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/index.ts
@@ -137,6 +137,13 @@ export function createEventAdapterRouter(deps?: EventAdapterRouterDeps): Router 
   const router = Router();
 
   if (deps) {
+    // Tenant selection for event-adapter routes: a multi-tenant user may target
+    // a specific tenant via the `x-tenant-id` header or `tenant_id` query param,
+    // and an operator may request the platform-wide view via `?all_tenants=true`.
+    // This is membership-gated — the shared resolver only honors a requested
+    // tenant the actor belongs to (or is an operator for) and otherwise fails
+    // closed with 403, so a selector can never widen access. The EXPORT_*
+    // environment allowlist is intentionally NOT opted into here.
     router.use(async (req: Request, res: Response, next: NextFunction) => {
       try {
         await resolveTenantContext(req, {

--- a/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
@@ -59,13 +59,12 @@ function escapeHtml(str: string): string {
 // ============================================================
 
 /**
- * Resolve tenant id from x-tenant-id header.
- * Returns null if missing (platform admin context).
+ * Resolve tenant id from the authenticated tenant context.
+ * Returns null only for explicit platform-operator context.
  */
 function resolveTenantId(req: Request): string | null {
-  const header = req.headers['x-tenant-id'];
-  if (Array.isArray(header)) return header[0] ?? null;
-  return header ?? null;
+  if (req.tenantContext) return req.tenantContext.tenantId;
+  return req.tenantId ?? null;
 }
 
 /**
@@ -111,8 +110,8 @@ function eventStatusBadge(status: string): string {
 function platformAdminBanner(): string {
   return `
 <div class="alert alert-warning">
-  <strong>Platform admin view.</strong>
-  Add the <code>x-tenant-id</code> header to scope data to a specific tenant.
+  <strong>Platform operator view.</strong>
+  Tenant-scoped data is controlled by the authenticated tenant context.
   Showing all tenants.
 </div>`;
 }
@@ -635,7 +634,7 @@ function automationPageHandler(deps: AdminRouterDeps) {
       const content = `
         ${platformAdminBanner()}
         <div class="card">
-          <p>Select a specific tenant (via <code>x-tenant-id</code> header) to manage automation destinations.</p>
+          <p>Select a specific tenant through the authenticated tenant context to manage automation destinations.</p>
         </div>`;
       res.status(200).send(renderLayout('Automation', content, 'automation'));
       return;

--- a/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
@@ -22,6 +22,7 @@ import { eq, and, or, desc } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import {
   eventSources,
   eventScheduledTasks,
@@ -60,11 +61,10 @@ function escapeHtml(str: string): string {
 
 /**
  * Resolve tenant id from the authenticated tenant context.
- * Returns null only for explicit platform-operator context.
+ * Returns null only for explicit platform-operator context (all-tenants view).
  */
 function resolveTenantId(req: Request): string | null {
-  if (req.tenantContext) return req.tenantContext.tenantId;
-  return req.tenantId ?? null;
+  return tenantIdFromRequest(req);
 }
 
 /**

--- a/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/admin.ts
@@ -1,5 +1,5 @@
 /**
- * Event Adapter — Admin Panel Routes (WP12)
+ * Event Adapter — Admin Panel Routes
  *
  * Minimal, embedded web-based admin panel served at /event-adapter/admin.
  * Server-rendered HTML using template literals — no npm templating dependency.

--- a/joyus-ai-mcp-server/src/event-adapter/routes/automation.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/automation.ts
@@ -14,6 +14,7 @@ import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import { automationDestinations } from '../schema.js';
 import type { AutomationForwarder } from '../services/automation-forwarder.js';
 import { encryptSecret } from '../services/secret-store.js';
@@ -37,7 +38,7 @@ export interface AutomationRouterDeps {
  * Returns null when no authenticated user is present.
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 /**

--- a/joyus-ai-mcp-server/src/event-adapter/routes/automation.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/automation.ts
@@ -33,12 +33,11 @@ export interface AutomationRouterDeps {
 // ============================================================
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present.
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 /**

--- a/joyus-ai-mcp-server/src/event-adapter/routes/events.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/events.ts
@@ -5,7 +5,7 @@
  *   GET  /events          — paginated event query with filters (T046)
  *   POST /events/:id/replay — replay a failed or dead-lettered event (T047)
  *
- * Tenant context: resolved from x-tenant-id header.
+ * Tenant context: resolved by the shared tenant resolver before these routes run.
  * Payload and headers are NOT returned in list responses (can be large).
  * Cross-tenant access returns 404, not 403.
  */
@@ -51,12 +51,11 @@ interface EventSummary {
 // ============================================================
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present.
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 /**

--- a/joyus-ai-mcp-server/src/event-adapter/routes/events.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/events.ts
@@ -13,6 +13,7 @@
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import type { WebhookEvent } from '../schema.js';
 import { queryEvents, getEventById, replayEvent } from '../services/event-buffer.js';
 import { EventQueryInput } from '../validation.js';
@@ -51,11 +52,11 @@ interface EventSummary {
 // ============================================================
 
 /**
- * Resolve tenant id from the shared tenant context or authenticated MCP user.
- * Returns null when no authenticated user is present.
+ * Resolve tenant id from the shared tenant context. A `null` result means an
+ * operator authorized for platform-wide access (no tenant filter), not "missing".
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 /**

--- a/joyus-ai-mcp-server/src/event-adapter/routes/health.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/health.ts
@@ -20,12 +20,11 @@ import type { SchedulerService } from '../services/scheduler.js';
 // ============================================================
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present.
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 // ============================================================

--- a/joyus-ai-mcp-server/src/event-adapter/routes/health.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/health.ts
@@ -12,6 +12,7 @@ import { eq, and, count, sql, gte, lt } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import { webhookEvents, eventScheduledTasks } from '../schema.js';
 import type { SchedulerService } from '../services/scheduler.js';
 
@@ -24,7 +25,7 @@ import type { SchedulerService } from '../services/scheduler.js';
  * Returns null when no authenticated user is present.
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 // ============================================================

--- a/joyus-ai-mcp-server/src/event-adapter/routes/schedules.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/schedules.ts
@@ -16,6 +16,7 @@ import { eq, and, count } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import { eventScheduledTasks } from '../schema.js';
 import {
   validateCronExpression,
@@ -41,7 +42,7 @@ export interface SchedulesRouterDeps {
  * Returns null when no authenticated user is present (platform-admin context).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 /** Shape returned for each schedule in list/create/update responses. */

--- a/joyus-ai-mcp-server/src/event-adapter/routes/schedules.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/schedules.ts
@@ -7,7 +7,7 @@
  *   PATCH  /schedules/:id          — update with cron re-evaluation
  *   DELETE /schedules/:id          — soft delete (archive)
  *
- * Tenant context: resolved from x-tenant-id header (same pattern as sources.ts).
+ * Tenant context: resolved by the shared tenant resolver before these routes run.
  * Cron validation: uses validateCronExpression and isValidTimezone from scheduler service.
  * nextFireAt: computed on create, recomputed on cron/timezone/lifecycle changes.
  */
@@ -37,12 +37,11 @@ export interface SchedulesRouterDeps {
 // ============================================================
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present (platform-admin context).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 /** Shape returned for each schedule in list/create/update responses. */

--- a/joyus-ai-mcp-server/src/event-adapter/routes/sources.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/sources.ts
@@ -7,7 +7,7 @@
  *   PATCH  /sources/:id          — update config, lifecycle; slug is immutable (T037)
  *   DELETE /sources/:id          — soft delete (archive); blocked if active subscriptions exist (T038)
  *
- * Tenant context: resolved from x-tenant-id header (auth middleware not yet implemented).
+ * Tenant context: resolved by the shared tenant resolver before these routes run.
  * Secrets: authConfig.secretRef stores AES-256-GCM encrypted ciphertext via secret-store.
  * Response: authConfig is never returned; hasSecret: boolean is returned instead.
  */
@@ -105,12 +105,11 @@ function toPublicSource(row: typeof eventSources.$inferSelect) {
 }
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present (platform-wide callers).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 async function pipelineExists(

--- a/joyus-ai-mcp-server/src/event-adapter/routes/sources.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/sources.ts
@@ -19,6 +19,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
 import { pipelines } from '../../pipelines/schema.js';
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import { eventSources, platformSubscriptions } from '../schema.js';
 import { encryptSecret } from '../services/secret-store.js';
 import { CreateEventSourceInput, UpdateEventSourceInput } from '../validation.js';
@@ -109,7 +110,7 @@ function toPublicSource(row: typeof eventSources.$inferSelect) {
  * Returns null when no authenticated user is present (platform-wide callers).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 async function pipelineExists(

--- a/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
@@ -27,12 +27,11 @@ export interface SubscriptionsRouterDeps {
 // ============================================================
 
 /**
- * Resolve tenant id from the authenticated MCP user.
- * userId === tenantId until formal tenant resolution exists (see #37).
+ * Resolve tenant id from the shared tenant context or authenticated MCP user.
  * Returns null when no authenticated user is present (platform-admin context).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.mcpUser?.id ?? null;
+  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 // ============================================================

--- a/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
+++ b/joyus-ai-mcp-server/src/event-adapter/routes/subscriptions.ts
@@ -12,6 +12,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type Request, type Response } from 'express';
 
 import { pipelines } from '../../pipelines/schema.js';
+import { tenantIdFromRequest } from '../../tenancy/resolver.js';
 import { eventSources, platformSubscriptions } from '../schema.js';
 
 // ============================================================
@@ -31,7 +32,7 @@ export interface SubscriptionsRouterDeps {
  * Returns null when no authenticated user is present (platform-admin context).
  */
 function resolveTenantId(req: Request): string | null {
-  return req.tenantContext?.tenantId ?? req.tenantId ?? req.mcpUser?.id ?? null;
+  return tenantIdFromRequest(req);
 }
 
 // ============================================================

--- a/joyus-ai-mcp-server/src/exports/router.ts
+++ b/joyus-ai-mcp-server/src/exports/router.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 
 import { requireBearerToken } from '../auth/middleware.js';
 import { db, auditLogs } from '../db/client.js';
+import { resolveTenantContext, sendTenantResolutionError, TenantResolutionError } from '../tenancy/resolver.js';
 
 import { createExcelExportJob, getExcelExportJobForUser, resolveDownloadToken } from './service.js';
 import { ExcelExportRequest } from './types.js';
@@ -37,7 +38,6 @@ export const exportRouter = Router();
 exportRouter.post('/tenants/:tenantId/exports/excel', requireBearerToken, async (req: Request, res: Response) => {
   const startedAt = Date.now();
   const user = req.mcpUser;
-  const tenantId = req.params.tenantId;
 
   if (!user) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -45,13 +45,25 @@ exportRouter.post('/tenants/:tenantId/exports/excel', requireBearerToken, async 
   }
 
   const body = (req.body && typeof req.body === 'object' ? req.body : {}) as ExcelExportRequest;
+  let tenantId = req.params.tenantId;
 
   try {
+    const tenantContext = await resolveTenantContext(req, {
+      db,
+      requestedTenantId: tenantId,
+    });
+    if (!tenantContext.tenantId) {
+      res.status(403).json({ error: 'tenant_required', message: 'Tenant-scoped export requests require a tenant' });
+      return;
+    }
+    tenantId = tenantContext.tenantId;
+
     const { job, downloadUrl } = await createExcelExportJob({
       userId: user.id,
       tenantId,
       request: body,
       baseUrl: inferredBaseUrl(req),
+      tenantAccessPreResolved: true,
     });
 
     await writeAudit(
@@ -81,6 +93,11 @@ exportRouter.post('/tenants/:tenantId/exports/excel', requireBearerToken, async 
       file_size_bytes: job.fileSizeBytes,
     });
   } catch (error) {
+    if (error instanceof TenantResolutionError) {
+      sendTenantResolutionError(res, error);
+      return;
+    }
+
     const message = error instanceof Error ? error.message : 'Export generation failed';
 
     await writeAudit(
@@ -107,7 +124,7 @@ exportRouter.post('/tenants/:tenantId/exports/excel', requireBearerToken, async 
 
 exportRouter.get('/tenants/:tenantId/exports/:exportId', requireBearerToken, async (req: Request, res: Response) => {
   const user = req.mcpUser;
-  const { tenantId, exportId } = req.params;
+  const { exportId } = req.params;
 
   if (!user) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -115,7 +132,18 @@ exportRouter.get('/tenants/:tenantId/exports/:exportId', requireBearerToken, asy
   }
 
   try {
-    const job = getExcelExportJobForUser(user.id, tenantId, exportId);
+    const tenantContext = await resolveTenantContext(req, {
+      db,
+      requestedTenantId: req.params.tenantId,
+    });
+    if (!tenantContext.tenantId) {
+      res.status(403).json({ error: 'tenant_required', message: 'Tenant-scoped export requests require a tenant' });
+      return;
+    }
+
+    const job = getExcelExportJobForUser(user.id, tenantContext.tenantId, exportId, {
+      tenantAccessPreResolved: true,
+    });
     if (!job) {
       res.status(404).json({ error: 'Export not found' });
       return;

--- a/joyus-ai-mcp-server/src/exports/router.ts
+++ b/joyus-ai-mcp-server/src/exports/router.ts
@@ -51,6 +51,9 @@ exportRouter.post('/tenants/:tenantId/exports/excel', requireBearerToken, async 
     const tenantContext = await resolveTenantContext(req, {
       db,
       requestedTenantId: tenantId,
+      // Exports honor the EXPORT_* environment allowlist; the shared resolver
+      // only applies it when a caller opts in (see resolver.ts).
+      allowEnvironmentAllowlist: true,
     });
     if (!tenantContext.tenantId) {
       res.status(403).json({ error: 'tenant_required', message: 'Tenant-scoped export requests require a tenant' });
@@ -135,6 +138,9 @@ exportRouter.get('/tenants/:tenantId/exports/:exportId', requireBearerToken, asy
     const tenantContext = await resolveTenantContext(req, {
       db,
       requestedTenantId: req.params.tenantId,
+      // Exports honor the EXPORT_* environment allowlist; the shared resolver
+      // only applies it when a caller opts in (see resolver.ts).
+      allowEnvironmentAllowlist: true,
     });
     if (!tenantContext.tenantId) {
       res.status(403).json({ error: 'tenant_required', message: 'Tenant-scoped export requests require a tenant' });
@@ -163,6 +169,11 @@ exportRouter.get('/tenants/:tenantId/exports/:exportId', requireBearerToken, asy
       error: job.error,
     });
   } catch (error) {
+    if (error instanceof TenantResolutionError) {
+      sendTenantResolutionError(res, error);
+      return;
+    }
+
     const message = error instanceof Error ? error.message : 'Unable to fetch export';
     if (message.includes('not authorized')) {
       res.status(403).json({ error: message });

--- a/joyus-ai-mcp-server/src/exports/service.ts
+++ b/joyus-ai-mcp-server/src/exports/service.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { createId } from '@paralleldrive/cuid2';
 
-import { canAccessTenantFromEnvironment } from '../tenancy/resolver.js';
+import { canAccessTenant } from '../tenancy/resolver.js';
 
 import { buildWorkbookFile } from './excel-builder.js';
 import {
@@ -51,10 +51,10 @@ export function normalizeExportLocations(value: string | undefined): ExcelExport
   return value === 'all_accessible' ? 'all_accessible' : 'current';
 }
 
-export function canAccessTenant(userId: string, tenantId: string): boolean {
-  if (tenantId === userId) return true;
-  return canAccessTenantFromEnvironment(userId, tenantId);
-}
+// Re-exported from the shared tenancy resolver so the self/allowlist access
+// rule has a single source of truth. Kept exported here for the exports module's
+// public surface and existing test imports.
+export { canAccessTenant };
 
 function assertTenantAccess(userId: string, tenantId: string): void {
   if (!canAccessTenant(userId, tenantId)) {

--- a/joyus-ai-mcp-server/src/exports/service.ts
+++ b/joyus-ai-mcp-server/src/exports/service.ts
@@ -4,6 +4,8 @@ import path from 'path';
 
 import { createId } from '@paralleldrive/cuid2';
 
+import { canAccessTenantFromEnvironment } from '../tenancy/resolver.js';
+
 import { buildWorkbookFile } from './excel-builder.js';
 import {
   CreateExportJobParams,
@@ -49,29 +51,9 @@ export function normalizeExportLocations(value: string | undefined): ExcelExport
   return value === 'all_accessible' ? 'all_accessible' : 'current';
 }
 
-function parseTenantAllowlist(raw: string): Map<string, Set<string>> {
-  const result = new Map<string, Set<string>>();
-  raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .forEach((entry) => {
-      const [userId, tenantId] = entry.split(':').map((part) => part.trim());
-      if (!userId || !tenantId) return;
-      const existing = result.get(userId) || new Set<string>();
-      existing.add(tenantId);
-      result.set(userId, existing);
-    });
-  return result;
-}
-
 export function canAccessTenant(userId: string, tenantId: string): boolean {
-  if (process.env.EXPORT_ALLOW_ANY_TENANT === 'true') return true;
   if (tenantId === userId) return true;
-
-  const allowlist = parseTenantAllowlist(process.env.EXPORT_TENANT_ALLOWLIST || '');
-  const allowedTenants = allowlist.get(userId);
-  return Boolean(allowedTenants && allowedTenants.has(tenantId));
+  return canAccessTenantFromEnvironment(userId, tenantId);
 }
 
 function assertTenantAccess(userId: string, tenantId: string): void {
@@ -164,7 +146,9 @@ function buildDownloadUrl(baseUrl: string, token: string): string {
 }
 
 export async function createExcelExportJob(params: CreateExportJobParams): Promise<{ job: ExcelExportJob; downloadUrl: string }> {
-  assertTenantAccess(params.userId, params.tenantId);
+  if (!params.tenantAccessPreResolved) {
+    assertTenantAccess(params.userId, params.tenantId);
+  }
 
   const scope = normalizeExportScope(params.request.scope);
   const locations = normalizeExportLocations(params.request.locations);
@@ -236,8 +220,15 @@ export async function createExcelExportJob(params: CreateExportJobParams): Promi
   }
 }
 
-export function getExcelExportJobForUser(userId: string, tenantId: string, exportId: string): ExcelExportJob | null {
-  assertTenantAccess(userId, tenantId);
+export function getExcelExportJobForUser(
+  userId: string,
+  tenantId: string,
+  exportId: string,
+  options: { tenantAccessPreResolved?: boolean } = {},
+): ExcelExportJob | null {
+  if (!options.tenantAccessPreResolved) {
+    assertTenantAccess(userId, tenantId);
+  }
   const job = exportJobs.get(exportId);
   if (!job) return null;
   if (job.userId !== userId || job.tenantId !== tenantId) return null;
@@ -254,4 +245,3 @@ export function resolveDownloadToken(token: string): { job: ExcelExportJob; file
   if (!job || !job.filePath || job.status !== 'completed') return null;
   return { job, filePath: job.filePath };
 }
-

--- a/joyus-ai-mcp-server/src/exports/types.ts
+++ b/joyus-ai-mcp-server/src/exports/types.ts
@@ -48,5 +48,5 @@ export interface CreateExportJobParams {
   tenantId: string;
   request: ExcelExportRequest;
   baseUrl: string;
+  tenantAccessPreResolved?: boolean;
 }
-

--- a/joyus-ai-mcp-server/src/index.ts
+++ b/joyus-ai-mcp-server/src/index.ts
@@ -58,6 +58,7 @@ import { createStepRegistry } from './pipelines/steps/registry.js';
 import { initializeProfiles } from './profiles/index.js';
 import { initializeScheduler } from './scheduler/index.js';
 import { taskRouter } from './scheduler/routes.js';
+import { resolveTenantContext, sendTenantResolutionError } from './tenancy/resolver.js';
 import { executeTool, setPipelineContext } from './tools/executor.js';
 import { getAllTools } from './tools/index.js';
 
@@ -367,18 +368,34 @@ app.use(
 // against automationDestinations.authSecretRef inside the route handler.
 app.use('/v1/events', createTriggerRouter({ db: pipelineDb }));
 
-// Admin UI — accepts any authenticated org user (Google OAuth session) or
-// a one-time ?token= exchange for CLI/API access.
-// TODO(#37): tighten to tenant-scoped view once multi-tenant identity is unified.
+// Admin UI — accepts an authenticated Google OAuth session or a one-time
+// ?token= exchange for CLI/API access. Authenticated users default to their
+// resolved tenant; platform-wide view requires an operator membership and
+// ?all_tenants=true.
 app.use('/event-adapter/admin', async (req: Request, res: Response, next: NextFunction) => {
   const session = req.session as { userId?: string; adminUserId?: string };
+  const attachTenantContext = async (): Promise<void> => {
+    await resolveTenantContext(req, {
+      db,
+      allowPlatformWide: true,
+      lookupDefaultTenant: true,
+      tenantHeaderNames: ['x-tenant-id'],
+      tenantQueryKeys: ['tenant_id', 'tenantId'],
+    });
+  };
 
   // Primary: Google OAuth session (set by /auth after login)
   if (session.userId) {
     const [user] = await db.select().from(users).where(eqOp(users.id, session.userId)).limit(1);
     if (user) {
       req.mcpUser = { ...user, connections: [] };
-      return next();
+      try {
+        await attachTenantContext();
+        return next();
+      } catch (error) {
+        sendTenantResolutionError(res, error);
+        return;
+      }
     }
   }
 
@@ -398,7 +415,13 @@ app.use('/event-adapter/admin', async (req: Request, res: Response, next: NextFu
     const [user] = await db.select().from(users).where(eqOp(users.id, session.adminUserId)).limit(1);
     if (!user) { res.status(401).send('Session expired. <a href="/event-adapter/admin">Log in again</a>.'); return; }
     req.mcpUser = { ...user, connections: [] };
-    return next();
+    try {
+      await attachTenantContext();
+      return next();
+    } catch (error) {
+      sendTenantResolutionError(res, error);
+      return;
+    }
   }
 
   res.status(401).send('Please <a href="/auth">sign in</a> first, or append <code>?token=&lt;your MCP token&gt;</code>.');

--- a/joyus-ai-mcp-server/src/orchestrator/agent-loop.service.ts
+++ b/joyus-ai-mcp-server/src/orchestrator/agent-loop.service.ts
@@ -159,6 +159,7 @@ export interface ToolRouter {
     toolName: string,
     toolInput: Record<string, unknown>,
     tenantId: string,
+    actorUserId?: string,
   ): Promise<ToolExecutionResult>;
 }
 
@@ -176,6 +177,7 @@ export class StubToolRouter implements ToolRouter {
     toolName: string,
     _toolInput: Record<string, unknown>,
     _tenantId: string,
+    _actorUserId?: string,
   ): Promise<ToolExecutionResult> {
     // WP05 will route to real MCP tool servers
     return {
@@ -575,6 +577,7 @@ export class AgentLoopService {
           toolCall.name,
           toolCall.input,
           tenantId,
+          session.userId,
         );
 
         // Notify client of the tool result

--- a/joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts
+++ b/joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts
@@ -13,9 +13,14 @@
  *   tenantId behavior for backward compatibility.
  *
  * Security contract:
- *   tenantId is never read from the request body, query params, or custom
- *   headers for orchestrator routes. It is derived from the verified auth
- *   context and tenant membership state.
+ *   This middleware derives tenantId solely from the verified auth context
+ *   (req.mcpUser) and the user's tenant membership state — it passes no
+ *   header/query tenant selectors to the resolver. Surfaces that DO allow an
+ *   explicit tenant selector (e.g. the pipelines and event-adapter routers pass
+ *   `tenantHeaderNames` / `tenantQueryKeys`) are not a spoofing vector: the
+ *   shared resolver only honors a requested tenant the actor is a member of (or
+ *   an operator for), and otherwise fails closed with 403. A selector can never
+ *   widen access beyond the caller's membership.
  */
 
 import { Request, Response, NextFunction } from 'express';

--- a/joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts
+++ b/joyus-ai-mcp-server/src/orchestrator/middleware/tenant.ts
@@ -1,27 +1,28 @@
 /**
  * Tenant Scoping Middleware — WP01
  *
- * Extracts tenantId from the authenticated MCP user and attaches it
- * to the request object for use by all orchestrator handlers.
+ * Resolves tenantId from the authenticated MCP user and attaches it to the
+ * request object for use by all orchestrator handlers.
  *
  * This middleware MUST run after requireBearerToken (from src/auth/middleware.ts),
  * which populates req.mcpUser.
  *
  * tenantId derivation:
- *   In the current single-tenant world, tenantId == userId (req.mcpUser.id).
- *   This is consistent with the comment in src/tools/executor.ts:
- *     "tenant resolution deferred to WP12; use userId as tenantId for now"
- *   When multi-tenancy ships, this file is the single place to update.
+ *   Shared tenancy resolver first checks the user's default membership.
+ *   If no membership is present, it falls back to the historical userId ==
+ *   tenantId behavior for backward compatibility.
  *
  * Security contract:
- *   tenantId is NEVER read from the request body, query params, or custom headers.
- *   It is derived ONLY from the verified auth context (req.mcpUser), which was
- *   validated against the database by the upstream bearer-token middleware.
+ *   tenantId is never read from the request body, query params, or custom
+ *   headers for orchestrator routes. It is derived from the verified auth
+ *   context and tenant membership state.
  */
 
 import { Request, Response, NextFunction } from 'express';
 
 import type { UserWithConnections } from '../../auth/verify.js';
+import { db } from '../../db/client.js';
+import { resolveTenantContext, sendTenantResolutionError } from '../../tenancy/resolver.js';
 import { MissingTenantError } from '../types.js';
 
 // ============================================================
@@ -61,9 +62,12 @@ export function resolveTenantId(req: Request, res: Response, next: NextFunction)
     return;
   }
 
-  // tenantId = userId until multi-tenant resolution is implemented (WP12)
-  req.tenantId = user.id;
-  next();
+  resolveTenantContext(req, {
+    db,
+    lookupDefaultTenant: true,
+  })
+    .then(() => next())
+    .catch((error) => sendTenantResolutionError(res, error));
 }
 
 // ============================================================

--- a/joyus-ai-mcp-server/src/orchestrator/tool-router.service.ts
+++ b/joyus-ai-mcp-server/src/orchestrator/tool-router.service.ts
@@ -11,7 +11,7 @@
  *   yet (see orchestrator.ts schema). When that table ships, swap in a DB-backed
  *   registry without changing callers.
  * - T035: Dispatch calls through the existing executeTool() infrastructure with
- *   tenantId as userId (deferred to WP12 — see executor.ts convention).
+ *   the authenticated actor user id and resolved tenant id in tool input.
  * - T037: Transient failures retry with exponential backoff (200/800/3200ms).
  *   Semantic failures pass through to the agent immediately. Circuit breaker
  *   tracks consecutive failures in-memory (resets on process restart is acceptable).
@@ -185,6 +185,7 @@ export class ToolRouterService implements ToolRouter {
     toolName: string,
     toolInput: Record<string, unknown>,
     tenantId: string,
+    actorUserId?: string,
   ): Promise<ToolExecutionResult> {
     // Check circuit breaker before dispatching
     if (this.isCircuitOpen(tenantId, toolName)) {
@@ -205,7 +206,7 @@ export class ToolRouterService implements ToolRouter {
     const startMs = Date.now();
 
     // T037: dispatch with retry/timeout
-    const result = await this.dispatchWithRetry(toolName, toolInput, tenantId);
+    const result = await this.dispatchWithRetry(toolName, toolInput, tenantId, actorUserId ?? tenantId);
 
     const durationMs = Date.now() - startMs;
 
@@ -282,12 +283,13 @@ export class ToolRouterService implements ToolRouter {
     toolName: string,
     toolInput: Record<string, unknown>,
     tenantId: string,
+    actorUserId: string,
   ): Promise<ToolExecutionResult> {
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
       try {
-        const result = await this.dispatchWithTimeout(toolName, toolInput, tenantId);
+        const result = await this.dispatchWithTimeout(toolName, toolInput, tenantId, actorUserId);
 
         // Success: reset circuit breaker
         this.recordSuccess(tenantId, toolName);
@@ -338,10 +340,9 @@ export class ToolRouterService implements ToolRouter {
     toolName: string,
     toolInput: Record<string, unknown>,
     tenantId: string,
+    actorUserId: string,
   ): Promise<string> {
-    // The existing executeTool uses userId — tenantId is userId in single-tenant world.
-    // Multi-tenant resolution is deferred to WP12.
-    const userId = tenantId;
+    const scopedInput = { ...toolInput, tenant_id: tenantId };
 
     const timeoutPromise = new Promise<never>((_, reject) => {
       const timer = setTimeout(() => {
@@ -351,7 +352,7 @@ export class ToolRouterService implements ToolRouter {
       if (typeof timer.unref === 'function') timer.unref();
     });
 
-    const toolPromise = executeTool(userId, toolName, toolInput).then((rawResult) => {
+    const toolPromise = executeTool(actorUserId, toolName, scopedInput).then((rawResult) => {
       if (typeof rawResult === 'string') return rawResult;
       return JSON.stringify(rawResult);
     });

--- a/joyus-ai-mcp-server/src/pipelines/routes.ts
+++ b/joyus-ai-mcp-server/src/pipelines/routes.ts
@@ -14,7 +14,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Router, type NextFunction, type Request, type Response } from 'express';
 
 import { inngest } from '../inngest/client.js';
-import { resolveTenantContext, sendTenantResolutionError } from '../tenancy/resolver.js';
+import { resolveTenantContext, sendTenantResolutionError, tenantIdFromRequest } from '../tenancy/resolver.js';
 
 import { validateNoCycle } from './graph/cycle-detector.js';
 import type { DecisionRecorder } from './review/decision.js';
@@ -59,19 +59,7 @@ export interface PipelineRouterDeps {
  * user id for direct route tests that invoke handlers without Express middleware.
  */
 function getTenantId(req: Request): string {
-  if (req.tenantContext?.tenantId) {
-    return req.tenantContext.tenantId;
-  }
-  if (req.tenantId) {
-    return req.tenantId;
-  }
-  if (req.mcpUser?.id) {
-    return req.mcpUser.id;
-  }
-  if (req.session?.userId) {
-    return req.session.userId as string;
-  }
-  return '';
+  return tenantIdFromRequest(req) ?? (req.session?.userId as string | undefined) ?? '';
 }
 
 // Normalizes the two error shapes Drizzle's node-postgres driver can surface:

--- a/joyus-ai-mcp-server/src/pipelines/routes.ts
+++ b/joyus-ai-mcp-server/src/pipelines/routes.ts
@@ -11,9 +11,10 @@
 import { createId } from '@paralleldrive/cuid2';
 import { eq, and, desc, inArray } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { Router, type Request, type Response } from 'express';
+import { Router, type NextFunction, type Request, type Response } from 'express';
 
 import { inngest } from '../inngest/client.js';
+import { resolveTenantContext, sendTenantResolutionError } from '../tenancy/resolver.js';
 
 import { validateNoCycle } from './graph/cycle-detector.js';
 import type { DecisionRecorder } from './review/decision.js';
@@ -54,10 +55,16 @@ export interface PipelineRouterDeps {
 
 /**
  * Extract tenantId from the authenticated request context.
- * userId === tenantId until formal tenant resolution exists (see #37).
- * Never trust request headers for tenant identity.
+ * Prefer the shared tenant resolver context; fall back to the authenticated
+ * user id for direct route tests that invoke handlers without Express middleware.
  */
 function getTenantId(req: Request): string {
+  if (req.tenantContext?.tenantId) {
+    return req.tenantContext.tenantId;
+  }
+  if (req.tenantId) {
+    return req.tenantId;
+  }
   if (req.mcpUser?.id) {
     return req.mcpUser.id;
   }
@@ -106,6 +113,20 @@ function sendPipelineMutationError(res: Response, err: unknown): Response {
 export function createPipelineRouter(deps: PipelineRouterDeps): Router {
   const { db, stepRegistry, decisionRecorder } = deps;
   const router = Router();
+
+  router.use(async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await resolveTenantContext(req, {
+        db,
+        lookupDefaultTenant: true,
+        tenantHeaderNames: ['x-tenant-id'],
+        tenantQueryKeys: ['tenant_id', 'tenantId'],
+      });
+      next();
+    } catch (error) {
+      sendTenantResolutionError(res, error);
+    }
+  });
 
   // ----------------------------------------------------------
   // PIPELINE CRUD

--- a/joyus-ai-mcp-server/src/tenancy/resolver.ts
+++ b/joyus-ai-mcp-server/src/tenancy/resolver.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, type SQLWrapper } from 'drizzle-orm';
 import type { Request, Response } from 'express';
 
 import { tenantMemberships, type TenantMembership, type TenantRole } from '../db/schema.js';
@@ -23,6 +23,15 @@ export interface ResolveTenantForUserOptions {
   lookupDefaultTenant?: boolean;
   allowPlatformWide?: boolean;
   platformWideRequested?: boolean;
+  /**
+   * Opt-in to the environment allowlist (EXPORT_ALLOW_ANY_TENANT /
+   * EXPORT_TENANT_ALLOWLIST) as a cross-tenant access path. These flags are
+   * scoped to the exports feature, so the shared resolver only honors them when
+   * a caller explicitly asks (the exports router). Orchestrator, admin, and
+   * tool-execution callers leave this off so an export-scoped escape hatch can
+   * never silently widen their tenant access.
+   */
+  allowEnvironmentAllowlist?: boolean;
 }
 
 export interface ResolveTenantRequestOptions extends ResolveTenantForUserOptions {
@@ -73,7 +82,16 @@ function firstRequestValue(value: unknown): string | null {
   return normalizeTenantId(value);
 }
 
+// Memoize the parsed allowlist keyed on the raw env string. The allowlist is
+// read on every export request / cross-tenant resolution but only changes when
+// the env var changes, so caching avoids rebuilding the Map+Sets each call.
+let allowlistCache: { raw: string; parsed: Map<string, Set<string>> } | null = null;
+
 export function parseTenantAllowlist(raw: string): Map<string, Set<string>> {
+  if (allowlistCache && allowlistCache.raw === raw) {
+    return allowlistCache.parsed;
+  }
+
   const result = new Map<string, Set<string>>();
   raw
     .split(',')
@@ -86,6 +104,8 @@ export function parseTenantAllowlist(raw: string): Map<string, Set<string>> {
       existing.add(tenantId);
       result.set(userId, existing);
     });
+
+  allowlistCache = { raw, parsed: result };
   return result;
 }
 
@@ -111,41 +131,36 @@ function asMembershipDb(db: unknown): TenantMembershipLookupDb | null {
   return db as TenantMembershipLookupDb;
 }
 
-async function findDefaultMembership(
+// Single membership lookup parametrized by the discriminating condition. The
+// three call sites (default / direct / operator) differ only in that extra
+// predicate, so they share one query shape here.
+async function findMembership(
   db: TenantMembershipLookupDb,
   userId: string,
+  extraCondition: SQLWrapper,
 ): Promise<TenantMembership | null> {
   const [membership] = await db
     .select()
     .from(tenantMemberships)
-    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.isDefault, true)))
+    .where(and(eq(tenantMemberships.userId, userId), extraCondition))
     .limit(1);
   return membership ?? null;
 }
 
-async function findDirectMembership(
+function findDefaultMembership(db: TenantMembershipLookupDb, userId: string): Promise<TenantMembership | null> {
+  return findMembership(db, userId, eq(tenantMemberships.isDefault, true));
+}
+
+function findDirectMembership(
   db: TenantMembershipLookupDb,
   userId: string,
   requestedTenantId: string,
 ): Promise<TenantMembership | null> {
-  const [membership] = await db
-    .select()
-    .from(tenantMemberships)
-    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.tenantId, requestedTenantId)))
-    .limit(1);
-  return membership ?? null;
+  return findMembership(db, userId, eq(tenantMemberships.tenantId, requestedTenantId));
 }
 
-async function findOperatorMembership(
-  db: TenantMembershipLookupDb,
-  userId: string,
-): Promise<TenantMembership | null> {
-  const [membership] = await db
-    .select()
-    .from(tenantMemberships)
-    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.role, 'operator')))
-    .limit(1);
-  return membership ?? null;
+function findOperatorMembership(db: TenantMembershipLookupDb, userId: string): Promise<TenantMembership | null> {
+  return findMembership(db, userId, eq(tenantMemberships.role, 'operator'));
 }
 
 export async function resolveTenantContextForUser(
@@ -212,7 +227,7 @@ export async function resolveTenantContextForUser(
     return { actorUserId, tenantId: requestedTenantId, source: 'self' };
   }
 
-  if (canAccessTenantFromEnvironment(actorUserId, requestedTenantId)) {
+  if (options.allowEnvironmentAllowlist && canAccessTenantFromEnvironment(actorUserId, requestedTenantId)) {
     return { actorUserId, tenantId: requestedTenantId, source: 'env_allowlist' };
   }
 
@@ -273,6 +288,26 @@ function platformWideRequested(req: Request, options: ResolveTenantRequestOption
   if (options.platformWideRequested) return true;
   const allTenants = firstRequestValue(req.query?.all_tenants);
   return allTenants === 'true' || allTenants === '1';
+}
+
+/**
+ * Read the resolved tenant id from a request for use by route handlers.
+ *
+ * When the resolver middleware has attached a tenant context, that context is
+ * authoritative — *including* an intentional `null`, which means an operator
+ * was authorized for platform-wide access. Callers must treat `null` as "all
+ * tenants / no tenant filter" and must NOT fall back to the user id, or the
+ * operator's platform-wide read silently collapses to their own scope.
+ *
+ * Only when no context is present (e.g. a direct handler unit test invoked
+ * without the middleware) do we fall back to req.tenantId, then the
+ * authenticated user id.
+ */
+export function tenantIdFromRequest(req: Request): string | null {
+  if (req.tenantContext) {
+    return req.tenantContext.tenantId;
+  }
+  return req.tenantId ?? req.mcpUser?.id ?? null;
 }
 
 export function attachTenantContext(req: Request, context: TenantContext): void {

--- a/joyus-ai-mcp-server/src/tenancy/resolver.ts
+++ b/joyus-ai-mcp-server/src/tenancy/resolver.ts
@@ -1,0 +1,305 @@
+import { and, eq, or } from 'drizzle-orm';
+import type { Request, Response } from 'express';
+
+import { tenantMemberships, type TenantMembership, type TenantRole } from '../db/schema.js';
+
+export type TenantResolutionSource =
+  | 'api_key'
+  | 'env_allowlist'
+  | 'membership'
+  | 'operator'
+  | 'self';
+
+export interface TenantContext {
+  actorUserId?: string;
+  tenantId: string | null;
+  role?: TenantRole;
+  source: TenantResolutionSource;
+}
+
+export interface ResolveTenantForUserOptions {
+  requestedTenantId?: string | null;
+  db?: unknown;
+  lookupDefaultTenant?: boolean;
+  allowPlatformWide?: boolean;
+  platformWideRequested?: boolean;
+}
+
+export interface ResolveTenantRequestOptions extends ResolveTenantForUserOptions {
+  tenantParamKeys?: string[];
+  tenantQueryKeys?: string[];
+  tenantHeaderNames?: string[];
+}
+
+type TenantMembershipLookupDb = {
+  select: () => {
+    from: (table: typeof tenantMemberships) => {
+      where: (condition: unknown) => {
+        limit: (limit: number) => Promise<TenantMembership[]>;
+      };
+    };
+  };
+};
+
+declare global {
+  namespace Express {
+    interface Request {
+      tenantContext?: TenantContext;
+    }
+  }
+}
+
+export class TenantResolutionError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'TenantResolutionError';
+  }
+}
+
+function normalizeTenantId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstRequestValue(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    return normalizeTenantId(value[0]);
+  }
+  return normalizeTenantId(value);
+}
+
+export function parseTenantAllowlist(raw: string): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .forEach((entry) => {
+      const [userId, tenantId] = entry.split(':').map((part) => part.trim());
+      if (!userId || !tenantId) return;
+      const existing = result.get(userId) || new Set<string>();
+      existing.add(tenantId);
+      result.set(userId, existing);
+    });
+  return result;
+}
+
+export function canAccessTenantFromEnvironment(userId: string, tenantId: string): boolean {
+  if (process.env.EXPORT_ALLOW_ANY_TENANT === 'true') return true;
+  const allowlist = parseTenantAllowlist(process.env.EXPORT_TENANT_ALLOWLIST || '');
+  const allowedTenants = allowlist.get(userId);
+  return Boolean(allowedTenants && allowedTenants.has(tenantId));
+}
+
+function asMembershipDb(db: unknown): TenantMembershipLookupDb | null {
+  if (!db || typeof db !== 'object' || !('select' in db)) return null;
+  return db as TenantMembershipLookupDb;
+}
+
+async function findDefaultMembership(
+  db: TenantMembershipLookupDb,
+  userId: string,
+): Promise<TenantMembership | null> {
+  const [membership] = await db
+    .select()
+    .from(tenantMemberships)
+    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.isDefault, true)))
+    .limit(1);
+  return membership ?? null;
+}
+
+async function findMembershipOrOperator(
+  db: TenantMembershipLookupDb,
+  userId: string,
+  requestedTenantId: string,
+): Promise<TenantMembership | null> {
+  const [membership] = await db
+    .select()
+    .from(tenantMemberships)
+    .where(
+      and(
+        eq(tenantMemberships.userId, userId),
+        or(
+          eq(tenantMemberships.tenantId, requestedTenantId),
+          eq(tenantMemberships.role, 'operator'),
+        ),
+      ),
+    )
+    .limit(1);
+  return membership ?? null;
+}
+
+async function findOperatorMembership(
+  db: TenantMembershipLookupDb,
+  userId: string,
+): Promise<TenantMembership | null> {
+  const [membership] = await db
+    .select()
+    .from(tenantMemberships)
+    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.role, 'operator')))
+    .limit(1);
+  return membership ?? null;
+}
+
+export async function resolveTenantContextForUser(
+  userId: string | undefined | null,
+  options: ResolveTenantForUserOptions = {},
+): Promise<TenantContext> {
+  const actorUserId = normalizeTenantId(userId);
+  if (!actorUserId) {
+    throw new TenantResolutionError(401, 'tenant_auth_required', 'Authentication required to resolve tenant context');
+  }
+
+  const requestedTenantId = normalizeTenantId(options.requestedTenantId);
+  const membershipDb = asMembershipDb(options.db);
+
+  if (options.platformWideRequested) {
+    if (!options.allowPlatformWide) {
+      throw new TenantResolutionError(403, 'tenant_platform_forbidden', 'Platform-wide tenant access is not allowed here');
+    }
+    if (!membershipDb) {
+      throw new TenantResolutionError(403, 'tenant_platform_forbidden', 'Operator membership is required for platform-wide access');
+    }
+
+    try {
+      const operatorMembership = await findOperatorMembership(membershipDb, actorUserId);
+      if (operatorMembership) {
+        return {
+          actorUserId,
+          tenantId: null,
+          role: operatorMembership.role,
+          source: 'operator',
+        };
+      }
+    } catch {
+      throw new TenantResolutionError(503, 'tenant_lookup_unavailable', 'Tenant authorization lookup failed');
+    }
+
+    throw new TenantResolutionError(403, 'tenant_platform_forbidden', 'Operator membership is required for platform-wide access');
+  }
+
+  if (!requestedTenantId) {
+    if (options.lookupDefaultTenant && membershipDb) {
+      try {
+        const defaultMembership = await findDefaultMembership(membershipDb, actorUserId);
+        if (defaultMembership) {
+          return {
+            actorUserId,
+            tenantId: defaultMembership.tenantId,
+            role: defaultMembership.role,
+            source: 'membership',
+          };
+        }
+      } catch {
+        return { actorUserId, tenantId: actorUserId, source: 'self' };
+      }
+    }
+
+    return { actorUserId, tenantId: actorUserId, source: 'self' };
+  }
+
+  if (requestedTenantId === actorUserId) {
+    return { actorUserId, tenantId: requestedTenantId, source: 'self' };
+  }
+
+  if (canAccessTenantFromEnvironment(actorUserId, requestedTenantId)) {
+    return { actorUserId, tenantId: requestedTenantId, source: 'env_allowlist' };
+  }
+
+  if (membershipDb) {
+    try {
+      const membership = await findMembershipOrOperator(membershipDb, actorUserId, requestedTenantId);
+      if (membership) {
+        return {
+          actorUserId,
+          tenantId: requestedTenantId,
+          role: membership.role,
+          source: membership.role === 'operator' ? 'operator' : 'membership',
+        };
+      }
+    } catch {
+      throw new TenantResolutionError(503, 'tenant_lookup_unavailable', 'Tenant authorization lookup failed');
+    }
+  }
+
+  throw new TenantResolutionError(403, 'tenant_forbidden', `User ${actorUserId} is not authorized for tenant ${requestedTenantId}`);
+}
+
+function requestedTenantFromRequest(req: Request, options: ResolveTenantRequestOptions): string | null {
+  for (const key of options.tenantParamKeys ?? ['tenantId', 'tenant_id']) {
+    const value = firstRequestValue(req.params?.[key]);
+    if (value) return value;
+  }
+
+  for (const key of options.tenantQueryKeys ?? []) {
+    const value = firstRequestValue(req.query?.[key]);
+    if (value) return value;
+  }
+
+  for (const name of options.tenantHeaderNames ?? []) {
+    const value = firstRequestValue(req.headers[name.toLowerCase()]);
+    if (value) return value;
+  }
+
+  return null;
+}
+
+function platformWideRequested(req: Request, options: ResolveTenantRequestOptions): boolean {
+  if (options.platformWideRequested) return true;
+  const allTenants = firstRequestValue(req.query?.all_tenants);
+  return allTenants === 'true' || allTenants === '1';
+}
+
+export function attachTenantContext(req: Request, context: TenantContext): void {
+  req.tenantContext = context;
+  if (context.tenantId) {
+    req.tenantId = context.tenantId;
+  } else {
+    delete req.tenantId;
+  }
+}
+
+export async function resolveTenantContext(
+  req: Request,
+  options: ResolveTenantRequestOptions = {},
+): Promise<TenantContext> {
+  if (!req.mcpUser?.id && req.apiKeyRecord && req.tenantId) {
+    const context: TenantContext = {
+      actorUserId: req.userId,
+      tenantId: req.tenantId,
+      source: 'api_key',
+    };
+    attachTenantContext(req, context);
+    return context;
+  }
+
+  const actorUserId = req.mcpUser?.id ?? req.session?.userId;
+  const context = await resolveTenantContextForUser(actorUserId, {
+    ...options,
+    requestedTenantId: options.requestedTenantId ?? requestedTenantFromRequest(req, options),
+    platformWideRequested: platformWideRequested(req, options),
+  });
+  attachTenantContext(req, context);
+  return context;
+}
+
+export function sendTenantResolutionError(res: Response, error: unknown): void {
+  if (error instanceof TenantResolutionError) {
+    res.status(error.status).json({
+      error: error.code,
+      message: error.message,
+    });
+    return;
+  }
+
+  const message = error instanceof Error ? error.message : 'Tenant resolution failed';
+  res.status(500).json({
+    error: 'tenant_resolution_failed',
+    message,
+  });
+}

--- a/joyus-ai-mcp-server/src/tenancy/resolver.ts
+++ b/joyus-ai-mcp-server/src/tenancy/resolver.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { Request, Response } from 'express';
 
 import { tenantMemberships, type TenantMembership, type TenantRole } from '../db/schema.js';
@@ -96,6 +96,16 @@ export function canAccessTenantFromEnvironment(userId: string, tenantId: string)
   return Boolean(allowedTenants && allowedTenants.has(tenantId));
 }
 
+/**
+ * Synchronous tenant self/allowlist access check shared by callers that cannot
+ * perform a membership DB lookup (e.g. the exports service). A user may always
+ * access their own tenant; otherwise the environment allowlist applies.
+ */
+export function canAccessTenant(userId: string, tenantId: string): boolean {
+  if (tenantId === userId) return true;
+  return canAccessTenantFromEnvironment(userId, tenantId);
+}
+
 function asMembershipDb(db: unknown): TenantMembershipLookupDb | null {
   if (!db || typeof db !== 'object' || !('select' in db)) return null;
   return db as TenantMembershipLookupDb;
@@ -113,7 +123,7 @@ async function findDefaultMembership(
   return membership ?? null;
 }
 
-async function findMembershipOrOperator(
+async function findDirectMembership(
   db: TenantMembershipLookupDb,
   userId: string,
   requestedTenantId: string,
@@ -121,15 +131,7 @@ async function findMembershipOrOperator(
   const [membership] = await db
     .select()
     .from(tenantMemberships)
-    .where(
-      and(
-        eq(tenantMemberships.userId, userId),
-        or(
-          eq(tenantMemberships.tenantId, requestedTenantId),
-          eq(tenantMemberships.role, 'operator'),
-        ),
-      ),
-    )
+    .where(and(eq(tenantMemberships.userId, userId), eq(tenantMemberships.tenantId, requestedTenantId)))
     .limit(1);
   return membership ?? null;
 }
@@ -196,7 +198,10 @@ export async function resolveTenantContextForUser(
           };
         }
       } catch {
-        return { actorUserId, tenantId: actorUserId, source: 'self' };
+        // Fail closed: a default-membership lookup error must not silently
+        // downgrade the actor to self-scope (which could be the wrong tenant).
+        // Mirror the explicit-tenant path and surface a 503.
+        throw new TenantResolutionError(503, 'tenant_lookup_unavailable', 'Tenant authorization lookup failed');
       }
     }
 
@@ -213,16 +218,31 @@ export async function resolveTenantContextForUser(
 
   if (membershipDb) {
     try {
-      const membership = await findMembershipOrOperator(membershipDb, actorUserId, requestedTenantId);
+      // Operator superpower is an explicit, named branch: an operator (any
+      // tenant) may resolve any requested tenant. Checked first so the
+      // authorization widening can never be silently dropped by a future edit.
+      const operatorMembership = await findOperatorMembership(membershipDb, actorUserId);
+      if (operatorMembership) {
+        return {
+          actorUserId,
+          tenantId: requestedTenantId,
+          role: operatorMembership.role,
+          source: 'operator',
+        };
+      }
+
+      // Otherwise the actor must hold a direct membership in the requested tenant.
+      const membership = await findDirectMembership(membershipDb, actorUserId, requestedTenantId);
       if (membership) {
         return {
           actorUserId,
           tenantId: requestedTenantId,
           role: membership.role,
-          source: membership.role === 'operator' ? 'operator' : 'membership',
+          source: 'membership',
         };
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof TenantResolutionError) throw error;
       throw new TenantResolutionError(503, 'tenant_lookup_unavailable', 'Tenant authorization lookup failed');
     }
   }
@@ -268,7 +288,27 @@ export async function resolveTenantContext(
   req: Request,
   options: ResolveTenantRequestOptions = {},
 ): Promise<TenantContext> {
+  // Supported actor sources: Layer-2 MCP user auth (req.mcpUser) takes
+  // precedence; otherwise the Layer-1 API-key fast-path applies. Every caller
+  // populates req.mcpUser before reaching the resolver, so there is no
+  // session-only path here.
   if (!req.mcpUser?.id && req.apiKeyRecord && req.tenantId) {
+    const requestedTenantId =
+      normalizeTenantId(options.requestedTenantId) ?? requestedTenantFromRequest(req, options);
+    // Fail closed on a conflicting explicit tenant request: the API key is
+    // bound to a single tenant, so an explicit request for a different tenant
+    // must be rejected rather than silently ignored.
+    if (requestedTenantId && requestedTenantId !== req.tenantId) {
+      throw new TenantResolutionError(
+        403,
+        'tenant_forbidden',
+        `API key is scoped to tenant ${req.tenantId}; requested tenant ${requestedTenantId} is not permitted`,
+      );
+    }
+    // actorUserId is intentionally optional here: an API-key-only context
+    // (Layer-1 auth without a validated user JWT) has no end-user actor, so
+    // req.userId may be undefined. TenantContext.actorUserId is typed optional
+    // and audit writers tolerate a missing actor for these contexts.
     const context: TenantContext = {
       actorUserId: req.userId,
       tenantId: req.tenantId,
@@ -278,7 +318,7 @@ export async function resolveTenantContext(
     return context;
   }
 
-  const actorUserId = req.mcpUser?.id ?? req.session?.userId;
+  const actorUserId = req.mcpUser?.id;
   const context = await resolveTenantContextForUser(actorUserId, {
     ...options,
     requestedTenantId: options.requestedTenantId ?? requestedTenantFromRequest(req, options),

--- a/joyus-ai-mcp-server/src/tools/executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executor.ts
@@ -8,6 +8,7 @@ import { eq, and } from 'drizzle-orm';
 import type { SearchService } from '../content/search/index.js';
 import { db, connections, type Service } from '../db/client.js';
 import { decryptToken, encryptToken } from '../db/encryption.js';
+import { resolveTenantContextForUser } from '../tenancy/resolver.js';
 
 import { executeContentTool } from './executors/content-executor.js';
 import { executeGithubTool } from './executors/github-executor.js';
@@ -90,6 +91,26 @@ export function setContentContext(deps: ContentContextDeps): void {
   _contentContext = deps;
 }
 
+function requestedTenantIdFromInput(input: Record<string, unknown>): string | null {
+  const raw = input.tenant_id ?? input.tenantId;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function resolveToolTenantId(userId: string, input: Record<string, unknown>): Promise<string> {
+  const requestedTenantId = requestedTenantIdFromInput(input);
+  const tenantContext = await resolveTenantContextForUser(userId, {
+    requestedTenantId,
+    db: requestedTenantId ? db : undefined,
+  });
+
+  if (!tenantContext.tenantId) {
+    throw new Error('Tenant-scoped tool execution requires a tenant');
+  }
+  return tenantContext.tenantId;
+}
+
 /**
  * Execute a tool by name with the given input
  */
@@ -97,11 +118,19 @@ export async function executeTool(userId: string, toolName: string, input: Recor
   // --- Direct executors (no OAuth required) ---
 
   if (toolName.startsWith('ops_')) {
+    const requestedTenantId = requestedTenantIdFromInput(input);
+    if (requestedTenantId) {
+      await resolveTenantContextForUser(userId, {
+        requestedTenantId,
+        db,
+      });
+      return executeOpsTool(toolName, input, { userId, tenantAccessPreResolved: true });
+    }
     return executeOpsTool(toolName, input, { userId });
   }
 
   if (toolName.startsWith('content_')) {
-    const tenantId = userId; // tenant resolution deferred to WP12; use userId as tenantId for now
+    const tenantId = await resolveToolTenantId(userId, input);
     return executeContentTool(toolName, input, {
       userId,
       tenantId,
@@ -111,12 +140,12 @@ export async function executeTool(userId: string, toolName: string, input: Recor
   }
 
   if (toolName.startsWith('profile_')) {
-    const tenantId = userId; // tenant resolution deferred; use userId as tenantId for now
+    const tenantId = await resolveToolTenantId(userId, input);
     return executeProfileTool(toolName, input, { userId, tenantId, db });
   }
 
   if (toolName.startsWith('pipeline_')) {
-    const tenantId = userId; // tenant resolution deferred to WP12; use userId as tenantId for now
+    const tenantId = await resolveToolTenantId(userId, input);
     // Pipeline executor context requires additional deps — these are injected via setPipelineContext()
     if (!_pipelineContext) {
       throw new Error('Pipeline module not initialized');

--- a/joyus-ai-mcp-server/src/tools/executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executor.ts
@@ -123,15 +123,14 @@ export async function executeTool(userId: string, toolName: string, input: Recor
   // --- Direct executors (no OAuth required) ---
 
   if (toolName.startsWith('ops_')) {
-    const requestedTenantId = requestedTenantIdFromInput(input);
-    if (requestedTenantId) {
-      await resolveTenantContextForUser(userId, {
-        requestedTenantId,
-        db,
-      });
-      return executeOpsTool(toolName, input, { userId, tenantAccessPreResolved: true });
-    }
-    return executeOpsTool(toolName, input, { userId });
+    // Resolve tenant through the same shared path as the other tool families.
+    // resolveToolTenantId performs the authoritative, membership-aware
+    // authorization (including default-membership lookup), so the exports
+    // service can safely skip its narrower self/allowlist check
+    // (tenantAccessPreResolved) — that check would otherwise reject a
+    // legitimately membership-authorized cross-tenant export.
+    const tenantId = await resolveToolTenantId(userId, input);
+    return executeOpsTool(toolName, input, { userId, tenantId, tenantAccessPreResolved: true });
   }
 
   if (toolName.startsWith('content_')) {

--- a/joyus-ai-mcp-server/src/tools/executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executor.ts
@@ -100,9 +100,14 @@ function requestedTenantIdFromInput(input: Record<string, unknown>): string | nu
 
 async function resolveToolTenantId(userId: string, input: Record<string, unknown>): Promise<string> {
   const requestedTenantId = requestedTenantIdFromInput(input);
+  // Pass db + lookupDefaultTenant unconditionally so a caller with a default
+  // membership but no explicit tenant_id resolves to that membership — matching
+  // the HTTP middleware path (orchestrator/middleware/tenant.ts). Callers with
+  // no membership still fall back to self-scope inside the resolver.
   const tenantContext = await resolveTenantContextForUser(userId, {
     requestedTenantId,
-    db: requestedTenantId ? db : undefined,
+    db,
+    lookupDefaultTenant: true,
   });
 
   if (!tenantContext.tenantId) {

--- a/joyus-ai-mcp-server/src/tools/executors/ops-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/ops-executor.ts
@@ -2,6 +2,7 @@ import { createExcelExportJob } from '../../exports/service.js';
 
 interface OpsExecutorContext {
   userId: string;
+  tenantAccessPreResolved?: boolean;
 }
 
 function requireString(input: Record<string, unknown>, key: string): string {
@@ -38,6 +39,7 @@ export async function executeOpsTool(
     userId: context.userId,
     tenantId,
     baseUrl,
+    tenantAccessPreResolved: context.tenantAccessPreResolved,
     request: {
       scope,
       locations,
@@ -60,4 +62,3 @@ export async function executeOpsTool(
     download_url: downloadUrl,
   };
 }
-

--- a/joyus-ai-mcp-server/src/tools/executors/ops-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/ops-executor.ts
@@ -2,13 +2,9 @@ import { createExcelExportJob } from '../../exports/service.js';
 
 interface OpsExecutorContext {
   userId: string;
+  /** Tenant already resolved and authorized by the caller (executor.ts). */
+  tenantId: string;
   tenantAccessPreResolved?: boolean;
-}
-
-function requireString(input: Record<string, unknown>, key: string): string {
-  const value = input[key];
-  if (typeof value === 'string' && value.trim()) return value.trim();
-  throw new Error(`Missing required parameter: ${key}`);
 }
 
 function optionalString(input: Record<string, unknown>, key: string): string | undefined {
@@ -26,7 +22,10 @@ export async function executeOpsTool(
     throw new Error(`Unsupported ops tool: ${toolName}`);
   }
 
-  const tenantId = requireString(input, 'tenant_id');
+  const tenantId = context.tenantId;
+  if (!tenantId) {
+    throw new Error('Missing required tenant context');
+  }
   const scope = optionalString(input, 'scope');
   const locations = optionalString(input, 'locations');
   const dateStart = optionalString(input, 'date_start');

--- a/joyus-ai-mcp-server/tests/event-adapter/integration/admin.test.ts
+++ b/joyus-ai-mcp-server/tests/event-adapter/integration/admin.test.ts
@@ -4,7 +4,7 @@
  * Verifies:
  * - Each admin page route returns 200 with text/html content-type
  * - HTML contains expected nav links
- * - Tenant scoping: x-tenant-id header is passed through to DB queries
+ * - Tenant scoping: authenticated tenant context is passed through to DB queries
  * - XSS prevention: user-supplied data is escaped
  *
  * Uses Node's built-in http.request via a helper — no external HTTP client dep.
@@ -113,6 +113,31 @@ function makeAppAndServer(deps: AdminRouterDeps): {
   const app = express();
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());
+  app.use('/event-adapter/admin', (req, _res, next) => {
+    const header = req.headers['x-tenant-id'];
+    const tenantId = Array.isArray(header) ? header[0] : header;
+    if (tenantId) {
+      req.tenantId = tenantId;
+      req.tenantContext = {
+        actorUserId: 'test-user',
+        tenantId,
+        source: 'membership',
+      };
+    }
+    next();
+  }, createAdminRouter(deps));
+
+  const server = http.createServer(app);
+  return { app, server };
+}
+
+function makeUnscopedAppAndServer(deps: AdminRouterDeps): {
+  app: Application;
+  server: http.Server;
+} {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
   app.use('/event-adapter/admin', createAdminRouter(deps));
 
   const server = http.createServer(app);
@@ -173,16 +198,16 @@ describe('Admin Panel — smoke tests', () => {
     expect(res.body).toMatch(/class="[^"]*active[^"]*"[^>]*>Sources/);
   });
 
-  it('GET /sources shows platform admin banner when no x-tenant-id', async () => {
+  it('GET /sources shows platform operator banner when no tenant context is set', async () => {
     const res = await httpGet(server, '/event-adapter/admin/sources');
-    expect(res.body).toContain('Platform admin view');
+    expect(res.body).toContain('Platform operator view');
   });
 
   it('GET /sources does NOT show platform banner when x-tenant-id is set', async () => {
     const res = await httpGet(server, '/event-adapter/admin/sources', {
       'x-tenant-id': 'tenant-123',
     });
-    expect(res.body).not.toContain('Platform admin view');
+    expect(res.body).not.toContain('Platform operator view');
   });
 
   it('GET /sources shows empty state when no sources', async () => {
@@ -253,10 +278,10 @@ describe('Admin Panel — smoke tests', () => {
     expect(res.body).toMatch(/class="[^"]*active[^"]*"[^>]*>Automation/);
   });
 
-  it('GET /automation shows tenant prompt when no x-tenant-id', async () => {
+  it('GET /automation shows tenant prompt when no tenant context is set', async () => {
     const res = await httpGet(server, '/event-adapter/admin/automation');
-    expect(res.body).toContain('Platform admin view');
-    expect(res.body).toContain('x-tenant-id');
+    expect(res.body).toContain('Platform operator view');
+    expect(res.body).toContain('authenticated tenant context');
   });
 
   it('GET /automation shows register form when tenant set and no destination', async () => {
@@ -301,5 +326,22 @@ describe('Admin Panel — smoke tests', () => {
       'x-tenant-id': 'tenant-xyz',
     });
     expect(res.status).toBe(200);
+  });
+
+  it('does not trust x-tenant-id when no tenant context middleware is mounted', async () => {
+    const built = makeUnscopedAppAndServer(deps);
+    const unscopedServer = built.server;
+    await new Promise<void>((resolve) => unscopedServer.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const res = await httpGet(unscopedServer, '/event-adapter/admin/sources', {
+        'x-tenant-id': 'tenant-xyz',
+      });
+      expect(res.body).toContain('Platform operator view');
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        unscopedServer.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
   });
 });

--- a/joyus-ai-mcp-server/tests/exports.test.ts
+++ b/joyus-ai-mcp-server/tests/exports.test.ts
@@ -28,6 +28,7 @@ vi.mock('../src/exports/excel-builder.js', () => ({
 
 vi.mock('../src/db/client.js', () => ({
   db: {
+    select: vi.fn(),
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockResolvedValue(undefined),
     }),
@@ -59,7 +60,7 @@ import {
 } from '../src/exports/service.js';
 
 
-import { getUserFromToken } from '../src/auth/verify.js';
+import { db } from '../src/db/client.js';
 import { buildWorkbookFile } from '../src/exports/excel-builder.js';
 import { exportRouter } from '../src/exports/router.js';
 
@@ -112,6 +113,16 @@ function makeRes(): Response & {
   });
 
   return res;
+}
+
+function chainableSelect(resolveValue: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(resolveValue),
+      }),
+    }),
+  };
 }
 
 /** Build a minimal CreateExportJobParams. */
@@ -379,11 +390,15 @@ type RouterLayer = {
   };
 };
 
-function findDownloadHandler(router: import('express').Router) {
+function findRouteHandler(router: import('express').Router, path: string, handlerIndex = 0) {
   const layers = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = layers.find((l) => l.route?.path === '/exports/download/:token');
-  if (!layer?.route) throw new Error('Download route not found on exportRouter');
-  return layer.route.stack[0].handle;
+  const layer = layers.find((l) => l.route?.path === path);
+  if (!layer?.route) throw new Error(`Route not found on exportRouter: ${path}`);
+  return layer.route.stack[handlerIndex].handle;
+}
+
+function findDownloadHandler(router: import('express').Router) {
+  return findRouteHandler(router, '/exports/download/:token');
 }
 
 describe('Router: GET /exports/download/:token', () => {
@@ -431,5 +446,47 @@ describe('Router: GET /exports/download/:token', () => {
       'Content-Type',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     );
+  });
+});
+
+describe('Router: POST /tenants/:tenantId/exports/excel', () => {
+  beforeEach(() => {
+    vi.stubEnv('EXPORT_ALLOW_ANY_TENANT', 'false');
+    vi.stubEnv('EXPORT_TENANT_ALLOWLIST', '');
+    vi.mocked(buildWorkbookFile).mockResolvedValue(undefined);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('allows a distinct requested tenant when membership resolution succeeds', async () => {
+    vi.mocked(db.select).mockReturnValue(chainableSelect([
+      {
+        id: 'membership-1',
+        userId: 'user-member',
+        tenantId: 'tenant-member',
+        role: 'member',
+        isDefault: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]) as never);
+
+    const handler = findRouteHandler(exportRouter, '/tenants/:tenantId/exports/excel', 1);
+    const req = makeReq({
+      params: { tenantId: 'tenant-member' },
+      body: { scope: 'current_view', locations: 'current' },
+      mcpUser: { id: 'user-member' },
+    });
+    const res = makeRes();
+
+    await handler(req, res, vi.fn());
+
+    expect(res._status).toBe(201);
+    expect((res._body as { tenant_id: string }).tenant_id).toBe('tenant-member');
   });
 });

--- a/joyus-ai-mcp-server/tests/orchestrator/agent-loop.service.test.ts
+++ b/joyus-ai-mcp-server/tests/orchestrator/agent-loop.service.test.ts
@@ -359,7 +359,7 @@ describe('AgentLoopService.processMessage — tool use loop', () => {
     expect(result.responseText).toBe('The weather is sunny.');
     expect(result.toolIterations).toBe(1);
     expect(generateFn).toHaveBeenCalledTimes(2);
-    expect(toolRouter.executeToolCall).toHaveBeenCalledWith('search', { q: 'weather' }, TENANT_ID);
+    expect(toolRouter.executeToolCall).toHaveBeenCalledWith('search', { q: 'weather' }, TENANT_ID, 'user-1');
   });
 
   it('emits tool_call and tool_result events on the stream', async () => {

--- a/joyus-ai-mcp-server/tests/orchestrator/tool-router.service.test.ts
+++ b/joyus-ai-mcp-server/tests/orchestrator/tool-router.service.test.ts
@@ -163,7 +163,20 @@ describe('ToolRouterService.executeToolCall — T035', () => {
 
     expect(result.isError).toBe(false);
     expect(result.result).toBe('source list: []');
-    expect(mockExecuteTool).toHaveBeenCalledWith(TENANT_ID, 'content_list_sources', {});
+    expect(mockExecuteTool).toHaveBeenCalledWith(TENANT_ID, 'content_list_sources', { tenant_id: TENANT_ID });
+  });
+
+  it('dispatches with actor user id while preserving resolved tenant scope', async () => {
+    mockExecuteTool.mockResolvedValue('source list: []');
+    const router = new ToolRouterService();
+
+    await router.executeToolCall('content_list_sources', { filter: 'active' }, TENANT_ID, 'user-abc');
+
+    expect(mockExecuteTool).toHaveBeenCalledWith(
+      'user-abc',
+      'content_list_sources',
+      { filter: 'active', tenant_id: TENANT_ID },
+    );
   });
 
   it('JSON-stringifies non-string tool results', async () => {

--- a/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
+++ b/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
@@ -5,6 +5,7 @@ import type { TenantMembership } from '../../src/db/schema.js';
 import {
   resolveTenantContext,
   resolveTenantContextForUser,
+  tenantIdFromRequest,
   TenantResolutionError,
 } from '../../src/tenancy/resolver.js';
 
@@ -82,17 +83,35 @@ describe('tenant resolver', () => {
     });
   });
 
-  it('allows an explicitly requested tenant from the existing environment allowlist', async () => {
+  it('allows an explicitly requested tenant from the environment allowlist only when opted in', async () => {
     vi.stubEnv('EXPORT_ALLOW_ANY_TENANT', 'false');
     vi.stubEnv('EXPORT_TENANT_ALLOWLIST', 'user-1:tenant-allowed');
 
     const context = await resolveTenantContextForUser('user-1', {
       requestedTenantId: 'tenant-allowed',
+      allowEnvironmentAllowlist: true,
     });
 
     expect(context).toMatchObject({
       tenantId: 'tenant-allowed',
       source: 'env_allowlist',
+    });
+  });
+
+  it('ignores the environment allowlist when a caller does not opt in', async () => {
+    // The EXPORT_* allowlist is scoped to the exports feature: a non-exports
+    // caller (orchestrator / admin / tools) must not gain cross-tenant access
+    // from it, so without allowEnvironmentAllowlist the request fails closed.
+    vi.stubEnv('EXPORT_ALLOW_ANY_TENANT', 'false');
+    vi.stubEnv('EXPORT_TENANT_ALLOWLIST', 'user-1:tenant-allowed');
+
+    await expect(
+      resolveTenantContextForUser('user-1', {
+        requestedTenantId: 'tenant-allowed',
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: 'tenant_forbidden',
     });
   });
 
@@ -261,5 +280,32 @@ describe('tenant resolver', () => {
 
   it('rejects missing authenticated user context', async () => {
     await expect(resolveTenantContextForUser(null)).rejects.toBeInstanceOf(TenantResolutionError);
+  });
+});
+
+describe('tenantIdFromRequest', () => {
+  it('preserves an operator platform-wide null instead of collapsing to the user id', () => {
+    // The whole point of the fix: an authorized all-tenants context (tenantId
+    // null) must NOT be coerced back to the actor's user id by a `??` chain.
+    const req = {
+      mcpUser: { id: 'operator-1' },
+      tenantContext: { actorUserId: 'operator-1', tenantId: null, source: 'operator' as const },
+    } as unknown as Request;
+
+    expect(tenantIdFromRequest(req)).toBeNull();
+  });
+
+  it('returns the resolved tenant id when the context carries one', () => {
+    const req = {
+      mcpUser: { id: 'user-1' },
+      tenantContext: { actorUserId: 'user-1', tenantId: 'tenant-7', source: 'membership' as const },
+    } as unknown as Request;
+
+    expect(tenantIdFromRequest(req)).toBe('tenant-7');
+  });
+
+  it('falls back to the authenticated user id only when no context is attached', () => {
+    const req = { mcpUser: { id: 'user-1' } } as unknown as Request;
+    expect(tenantIdFromRequest(req)).toBe('user-1');
   });
 });

--- a/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
+++ b/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Request } from 'express';
+
+import type { TenantMembership } from '../../src/db/schema.js';
+import {
+  resolveTenantContext,
+  resolveTenantContextForUser,
+  TenantResolutionError,
+} from '../../src/tenancy/resolver.js';
+
+function membership(overrides: Partial<TenantMembership> = {}): TenantMembership {
+  return {
+    id: 'membership-1',
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    role: 'member',
+    isDefault: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeDb(resultSets: TenantMembership[][]) {
+  let callIndex = 0;
+  const db = {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => ({
+          limit: vi.fn().mockImplementation(async () => resultSets[callIndex++] ?? []),
+        })),
+      })),
+    })),
+  };
+  return db;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('tenant resolver', () => {
+  it('defaults to the authenticated user id when no membership is available', async () => {
+    const context = await resolveTenantContextForUser('user-1');
+    expect(context).toMatchObject({
+      actorUserId: 'user-1',
+      tenantId: 'user-1',
+      source: 'self',
+    });
+  });
+
+  it('uses the default membership when membership lookup is enabled', async () => {
+    const db = makeDb([
+      [membership({ tenantId: 'tenant-primary', isDefault: true, role: 'admin' })],
+    ]);
+
+    const context = await resolveTenantContextForUser('user-1', {
+      db,
+      lookupDefaultTenant: true,
+    });
+
+    expect(context).toMatchObject({
+      tenantId: 'tenant-primary',
+      role: 'admin',
+      source: 'membership',
+    });
+  });
+
+  it('allows an explicitly requested tenant from the existing environment allowlist', async () => {
+    vi.stubEnv('EXPORT_ALLOW_ANY_TENANT', 'false');
+    vi.stubEnv('EXPORT_TENANT_ALLOWLIST', 'user-1:tenant-allowed');
+
+    const context = await resolveTenantContextForUser('user-1', {
+      requestedTenantId: 'tenant-allowed',
+    });
+
+    expect(context).toMatchObject({
+      tenantId: 'tenant-allowed',
+      source: 'env_allowlist',
+    });
+  });
+
+  it('allows an explicitly requested tenant when a membership exists', async () => {
+    const db = makeDb([
+      [membership({ tenantId: 'tenant-member', role: 'member' })],
+    ]);
+
+    const context = await resolveTenantContextForUser('user-1', {
+      db,
+      requestedTenantId: 'tenant-member',
+    });
+
+    expect(context).toMatchObject({
+      tenantId: 'tenant-member',
+      role: 'member',
+      source: 'membership',
+    });
+  });
+
+  it('allows operators to resolve any explicitly requested tenant', async () => {
+    const db = makeDb([
+      [membership({ tenantId: 'operator-home', role: 'operator' })],
+    ]);
+
+    const context = await resolveTenantContextForUser('user-1', {
+      db,
+      requestedTenantId: 'tenant-any',
+    });
+
+    expect(context).toMatchObject({
+      tenantId: 'tenant-any',
+      role: 'operator',
+      source: 'operator',
+    });
+  });
+
+  it('allows operators to request platform-wide context only where enabled', async () => {
+    const db = makeDb([
+      [membership({ tenantId: 'operator-home', role: 'operator' })],
+    ]);
+
+    const context = await resolveTenantContextForUser('user-1', {
+      db,
+      allowPlatformWide: true,
+      platformWideRequested: true,
+    });
+
+    expect(context).toMatchObject({
+      tenantId: null,
+      role: 'operator',
+      source: 'operator',
+    });
+  });
+
+  it('denies an explicitly requested tenant without membership or allowlist access', async () => {
+    await expect(
+      resolveTenantContextForUser('user-1', {
+        requestedTenantId: 'tenant-denied',
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: 'tenant_forbidden',
+    });
+  });
+
+  it('preserves API-key tenant context for content mediation requests', async () => {
+    const req = {
+      apiKeyRecord: { id: 'key-1' },
+      tenantId: 'tenant-from-api-key',
+      userId: 'external-user-1',
+    } as unknown as Request;
+
+    const context = await resolveTenantContext(req);
+
+    expect(context).toMatchObject({
+      actorUserId: 'external-user-1',
+      tenantId: 'tenant-from-api-key',
+      source: 'api_key',
+    });
+    expect(req.tenantContext?.tenantId).toBe('tenant-from-api-key');
+  });
+
+  it('rejects missing authenticated user context', async () => {
+    await expect(resolveTenantContextForUser(null)).rejects.toBeInstanceOf(TenantResolutionError);
+  });
+});

--- a/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
+++ b/joyus-ai-mcp-server/tests/tenancy/resolver.test.ts
@@ -35,6 +35,22 @@ function makeDb(resultSets: TenantMembership[][]) {
   return db;
 }
 
+// A membership DB whose lookups always reject — used to assert fail-closed
+// behavior (503) on transient DB outages.
+function makeFailingDb() {
+  return {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => ({
+          limit: vi.fn().mockImplementation(async () => {
+            throw new Error('connection refused');
+          }),
+        })),
+      })),
+    })),
+  };
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -81,7 +97,10 @@ describe('tenant resolver', () => {
   });
 
   it('allows an explicitly requested tenant when a membership exists', async () => {
+    // Operator lookup runs first (no operator row), then the direct-membership
+    // lookup for the requested tenant succeeds.
     const db = makeDb([
+      [],
       [membership({ tenantId: 'tenant-member', role: 'member' })],
     ]);
 
@@ -98,6 +117,7 @@ describe('tenant resolver', () => {
   });
 
   it('allows operators to resolve any explicitly requested tenant', async () => {
+    // Operator lookup runs first and short-circuits the direct-membership check.
     const db = makeDb([
       [membership({ tenantId: 'operator-home', role: 'operator' })],
     ]);
@@ -111,6 +131,55 @@ describe('tenant resolver', () => {
       tenantId: 'tenant-any',
       role: 'operator',
       source: 'operator',
+    });
+  });
+
+  it('denies a member requesting a tenant they do not belong to even when operator rows exist for other users', async () => {
+    // The actor has no operator membership of their own and no direct
+    // membership in the requested tenant. Operator rows belonging to OTHER
+    // users must never widen this actor's access — the per-user operator
+    // lookup returns empty, and the direct-membership lookup returns empty.
+    const db = makeDb([
+      [], // findOperatorMembership(actor) → no operator membership for this user
+      [], // findDirectMembership(actor, requested) → not a member of this tenant
+    ]);
+
+    await expect(
+      resolveTenantContextForUser('member-user', {
+        db,
+        requestedTenantId: 'tenant-not-mine',
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: 'tenant_forbidden',
+    });
+  });
+
+  it('fails closed with 503 when the default-membership lookup errors', async () => {
+    const db = makeFailingDb();
+
+    await expect(
+      resolveTenantContextForUser('user-1', {
+        db,
+        lookupDefaultTenant: true,
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: 'tenant_lookup_unavailable',
+    });
+  });
+
+  it('fails closed with 503 when an explicit-tenant lookup errors', async () => {
+    const db = makeFailingDb();
+
+    await expect(
+      resolveTenantContextForUser('user-1', {
+        db,
+        requestedTenantId: 'tenant-x',
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: 'tenant_lookup_unavailable',
     });
   });
 
@@ -158,6 +227,36 @@ describe('tenant resolver', () => {
       source: 'api_key',
     });
     expect(req.tenantContext?.tenantId).toBe('tenant-from-api-key');
+  });
+
+  it('rejects an API-key request that explicitly asks for a different tenant', async () => {
+    const req = {
+      apiKeyRecord: { id: 'key-1' },
+      tenantId: 'tenant-from-api-key',
+      userId: 'external-user-1',
+    } as unknown as Request;
+
+    await expect(
+      resolveTenantContext(req, { requestedTenantId: 'tenant-other' }),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: 'tenant_forbidden',
+    });
+  });
+
+  it('keeps the API-key fast-path when the explicit request matches the key tenant', async () => {
+    const req = {
+      apiKeyRecord: { id: 'key-1' },
+      tenantId: 'tenant-from-api-key',
+      userId: 'external-user-1',
+    } as unknown as Request;
+
+    const context = await resolveTenantContext(req, { requestedTenantId: 'tenant-from-api-key' });
+
+    expect(context).toMatchObject({
+      tenantId: 'tenant-from-api-key',
+      source: 'api_key',
+    });
   });
 
   it('rejects missing authenticated user context', async () => {

--- a/joyus-ai-mcp-server/tests/tools/executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/executor.test.ts
@@ -116,7 +116,11 @@ beforeEach(() => {
 describe('executeTool — ops_ prefix', () => {
   it('routes ops_* tools directly to executeOpsTool', async () => {
     const result = await executeTool('user-1', 'ops_export_excel', { tenant_id: 'user-1' });
-    expect(vi.mocked(executeOpsTool)).toHaveBeenCalledWith('ops_export_excel', { tenant_id: 'user-1' }, { userId: 'user-1', tenantAccessPreResolved: true });
+    expect(vi.mocked(executeOpsTool)).toHaveBeenCalledWith(
+      'ops_export_excel',
+      { tenant_id: 'user-1' },
+      { userId: 'user-1', tenantId: 'user-1', tenantAccessPreResolved: true },
+    );
     expect(result).toEqual({ ops: 'result' });
   });
 });
@@ -136,8 +140,28 @@ describe('executeTool — content_ prefix', () => {
     expect(result).toEqual({ content: 'result' });
   });
 
-  it('uses the shared resolver for explicitly requested tenants', async () => {
-    vi.stubEnv('EXPORT_TENANT_ALLOWLIST', 'user-1:tenant-allowed');
+  it('uses the shared resolver for explicitly requested tenants the actor is a member of', async () => {
+    // First lookup (operator) returns none; second lookup (direct membership)
+    // authorizes the requested tenant. The EXPORT_* env allowlist is no longer
+    // a cross-tenant path for tools, so access must come from membership.
+    let call = 0;
+    vi.mocked(db.select).mockImplementation(() =>
+      chainable(
+        call++ === 0
+          ? []
+          : [
+              {
+                id: 'membership-1',
+                userId: 'user-1',
+                tenantId: 'tenant-allowed',
+                role: 'member',
+                isDefault: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ],
+      ),
+    );
 
     await executeTool('user-1', 'content_list_sources', {
       tenant_id: 'tenant-allowed',

--- a/joyus-ai-mcp-server/tests/tools/executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/executor.test.ts
@@ -104,6 +104,9 @@ const validConnection = {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
+  // Default membership lookups resolve to "no membership" so tenant resolution
+  // falls back to self-scope unless a test overrides db.select.
+  vi.mocked(db.select).mockReturnValue(chainable([]));
 });
 
 // ============================================================
@@ -144,6 +147,33 @@ describe('executeTool — content_ prefix', () => {
       'content_list_sources',
       { tenant_id: 'tenant-allowed' },
       expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-allowed' }),
+    );
+  });
+
+  it('honors the default membership when no tenant_id is supplied', async () => {
+    // A direct tool call with no explicit tenant_id should resolve to the
+    // caller's default membership (consistent with the HTTP middleware path),
+    // not silently self-scope.
+    vi.mocked(db.select).mockReturnValue(
+      chainable([
+        {
+          id: 'membership-1',
+          userId: 'user-1',
+          tenantId: 'tenant-default',
+          role: 'member',
+          isDefault: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]),
+    );
+
+    await executeTool('user-1', 'content_create', { title: 'Test' });
+
+    expect(vi.mocked(executeContentTool)).toHaveBeenCalledWith(
+      'content_create',
+      { title: 'Test' },
+      expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-default' }),
     );
   });
 

--- a/joyus-ai-mcp-server/tests/tools/executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/executor.test.ts
@@ -103,6 +103,7 @@ const validConnection = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
 });
 
 // ============================================================
@@ -111,8 +112,8 @@ beforeEach(() => {
 
 describe('executeTool — ops_ prefix', () => {
   it('routes ops_* tools directly to executeOpsTool', async () => {
-    const result = await executeTool('user-1', 'ops_export_excel', { tenant_id: 't1' });
-    expect(vi.mocked(executeOpsTool)).toHaveBeenCalledWith('ops_export_excel', { tenant_id: 't1' }, { userId: 'user-1' });
+    const result = await executeTool('user-1', 'ops_export_excel', { tenant_id: 'user-1' });
+    expect(vi.mocked(executeOpsTool)).toHaveBeenCalledWith('ops_export_excel', { tenant_id: 'user-1' }, { userId: 'user-1', tenantAccessPreResolved: true });
     expect(result).toEqual({ ops: 'result' });
   });
 });
@@ -130,6 +131,32 @@ describe('executeTool — content_ prefix', () => {
       expect.objectContaining({ userId: 'user-1', tenantId: 'user-1' }),
     );
     expect(result).toEqual({ content: 'result' });
+  });
+
+  it('uses the shared resolver for explicitly requested tenants', async () => {
+    vi.stubEnv('EXPORT_TENANT_ALLOWLIST', 'user-1:tenant-allowed');
+
+    await executeTool('user-1', 'content_list_sources', {
+      tenant_id: 'tenant-allowed',
+    });
+
+    expect(vi.mocked(executeContentTool)).toHaveBeenCalledWith(
+      'content_list_sources',
+      { tenant_id: 'tenant-allowed' },
+      expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-allowed' }),
+    );
+  });
+
+  it('rejects explicitly requested tenants without membership or allowlist access', async () => {
+    vi.mocked(db.select).mockReturnValue(chainable([]));
+
+    await expect(
+      executeTool('user-1', 'content_list_sources', {
+        tenant_id: 'tenant-denied',
+      }),
+    ).rejects.toThrow('not authorized for tenant tenant-denied');
+
+    expect(vi.mocked(executeContentTool)).not.toHaveBeenCalled();
   });
 });
 

--- a/joyus-ai-mcp-server/tests/tools/ops-executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/ops-executor.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../src/exports/service.js', () => ({
   }),
 }));
 
+import { createExcelExportJob } from '../../src/exports/service.js';
 import { executeOpsTool } from '../../src/tools/executors/ops-executor.js';
 
 beforeEach(() => {
@@ -20,23 +21,33 @@ beforeEach(() => {
 describe('executeOpsTool', () => {
   it('throws on unsupported tool name', async () => {
     await expect(
-      executeOpsTool('ops_unknown', {}, { userId: 'user-1' }),
+      executeOpsTool('ops_unknown', {}, { userId: 'user-1', tenantId: 'tenant-1' }),
     ).rejects.toThrow('Unsupported ops tool');
   });
 
-  it('throws when required tenant_id is missing', async () => {
+  it('throws when the resolved tenant context is missing', async () => {
+    // The caller (executor.ts) resolves and authorizes the tenant; a missing
+    // context.tenantId indicates a wiring bug and must fail closed.
     await expect(
-      executeOpsTool('ops_export_excel', {}, { userId: 'user-1' }),
-    ).rejects.toThrow('Missing required parameter: tenant_id');
+      executeOpsTool('ops_export_excel', {}, { userId: 'user-1' } as never),
+    ).rejects.toThrow('Missing required tenant context');
   });
 
-  it('ops_export_excel — creates export job', async () => {
-    const result = await executeOpsTool(
+  it('ops_export_excel — uses the resolved tenant from context, not raw input', async () => {
+    await executeOpsTool(
       'ops_export_excel',
-      { tenant_id: 'tenant-1' },
-      { userId: 'user-1' },
-    ) as any;
+      // A divergent tenant_id in raw input must be ignored in favor of the
+      // resolved-and-authorized context.tenantId.
+      { tenant_id: 'tenant-from-input' },
+      { userId: 'user-1', tenantId: 'tenant-resolved', tenantAccessPreResolved: true },
+    );
 
-    expect(result).toBeDefined();
+    expect(vi.mocked(createExcelExportJob)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        tenantId: 'tenant-resolved',
+        tenantAccessPreResolved: true,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add a tenant_memberships table and shared tenant resolver for self, membership, environment allowlist, API-key, and operator contexts.
- Wire pipeline routes, exports, event adapter management/admin routes, orchestrator tenant middleware, and direct tool execution through the shared resolver.
- Preserve existing content API-key tenant resolution and export allowlist compatibility while allowing distinct tenant records through membership checks.

Closes #37

## Merge-order dependency
Depends on #75 (migration 0008) merging first; rebase on main before merge so the journal is contiguous (0007→0008→0009). The migration here is intentionally numbered `0009` — renumbering to `0008` would collide with #75.

## Validation
- npm run build
- npm run lint
- npm run db:check
- npx vitest run tests/tenancy/resolver.test.ts tests/tools/executor.test.ts tests/exports.test.ts tests/pipelines/routes.test.ts tests/event-adapter/integration/admin.test.ts tests/orchestrator/tool-router.service.test.ts
- npx vitest run tests/tenancy/resolver.test.ts tests/event-adapter/integration/admin.test.ts tests/tools/executor.test.ts tests/exports.test.ts tests/orchestrator/agent-loop.service.test.ts tests/orchestrator/tool-router.service.test.ts
- npm test (108 files passed, 7 skipped; 1492 tests passed, 50 skipped)
