### PR TITLE
[codex] Track mediation generation token costs

### DIFF
--- a/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/anthropic-provider.test.ts
@@ -47,9 +47,12 @@ const makeTextResponse = (text: string, stop_reason = 'end_turn') => ({
 describe('AnthropicGenerationProvider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(Anthropic).mockImplementation(() => ({
-      messages: { create: mockMessagesCreate },
-    }) as unknown as Anthropic);
+    vi.mocked(Anthropic).mockImplementation(
+      () =>
+        ({
+          messages: { create: mockMessagesCreate },
+        }) as unknown as Anthropic
+    );
   });
 
   afterEach(() => {
@@ -59,7 +62,37 @@ describe('AnthropicGenerationProvider', () => {
   it('returns text from the first text block', async () => {
     mockMessagesCreate.mockResolvedValue(makeTextResponse('The answer is 42.'));
     const provider = new AnthropicGenerationProvider();
-    expect(await provider.generate('What is the answer?', 'Be helpful.')).toBe('The answer is 42.');
+    await expect(provider.generate('What is the answer?', 'Be helpful.')).resolves.toMatchObject({
+      text: 'The answer is 42.',
+      model: 'claude-sonnet-4-6',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheWriteTokens: 0,
+        cacheReadTokens: 0,
+      },
+    });
+  });
+
+  it('normalizes Anthropic cache usage metadata', async () => {
+    mockMessagesCreate.mockResolvedValue({
+      ...makeTextResponse('Cached answer.'),
+      usage: {
+        input_tokens: 20,
+        output_tokens: 10,
+        cache_creation_input_tokens: 12,
+        cache_read_input_tokens: 8,
+      },
+    });
+    const provider = new AnthropicGenerationProvider();
+    await expect(provider.generate('query', 'system')).resolves.toMatchObject({
+      usage: {
+        inputTokens: 20,
+        outputTokens: 10,
+        cacheWriteTokens: 12,
+        cacheReadTokens: 8,
+      },
+    });
   });
 
   it('throws when response contains no text block', async () => {
@@ -69,13 +102,13 @@ describe('AnthropicGenerationProvider', () => {
     });
     const provider = new AnthropicGenerationProvider();
     await expect(provider.generate('query', 'system')).rejects.toThrow(
-      'Anthropic response contained no text block',
+      'Anthropic response contained no text block'
     );
   });
 
   it('wraps RateLimitError with retryable: true', async () => {
     mockMessagesCreate.mockRejectedValue(
-      new (Anthropic as MockAnthropicStatic).RateLimitError('Rate limited'),
+      new (Anthropic as MockAnthropicStatic).RateLimitError('Rate limited')
     );
     const provider = new AnthropicGenerationProvider();
     await expect(provider.generate('query', 'system')).rejects.toMatchObject({
@@ -86,7 +119,7 @@ describe('AnthropicGenerationProvider', () => {
 
   it('wraps AuthenticationError with retryable: false', async () => {
     mockMessagesCreate.mockRejectedValue(
-      new (Anthropic as MockAnthropicStatic).AuthenticationError('Unauthorized'),
+      new (Anthropic as MockAnthropicStatic).AuthenticationError('Unauthorized')
     );
     const provider = new AnthropicGenerationProvider();
     await expect(provider.generate('query', 'system')).rejects.toMatchObject({
@@ -116,7 +149,7 @@ describe('AnthropicGenerationProvider', () => {
     const provider = new AnthropicGenerationProvider();
     await provider.generate('q', 's');
     expect(mockMessagesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'claude-opus-4-7' }),
+      expect.objectContaining({ model: 'claude-opus-4-7' })
     );
   });
 
@@ -126,7 +159,7 @@ describe('AnthropicGenerationProvider', () => {
     const provider = new AnthropicGenerationProvider({ model: 'claude-haiku-4-5-20251001' });
     await provider.generate('q', 's');
     expect(mockMessagesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }),
+      expect.objectContaining({ model: 'claude-haiku-4-5-20251001' })
     );
   });
 
@@ -134,9 +167,7 @@ describe('AnthropicGenerationProvider', () => {
     mockMessagesCreate.mockResolvedValue(makeTextResponse('ok'));
     const provider = new AnthropicGenerationProvider({ maxTokens: 512 });
     await provider.generate('q', 's');
-    expect(mockMessagesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ max_tokens: 512 }),
-    );
+    expect(mockMessagesCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 512 }));
   });
 
   it('sends system prompt with ephemeral cache_control', async () => {
@@ -145,10 +176,8 @@ describe('AnthropicGenerationProvider', () => {
     await provider.generate('q', 'You are helpful.');
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        system: [
-          { type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } },
-        ],
-      }),
+        system: [{ type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } }],
+      })
     );
   });
 });

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/cost.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/cost.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGenerationCostMetadata,
+  estimateGenerationCostMicroUsd,
+  normalizeAnthropicUsage,
+  PRICING,
+  resolveModelPricing,
+} from '../cost.js';
+
+describe('generation cost helpers', () => {
+  it('calculates Sonnet input and output token costs', () => {
+    const usage = {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    };
+
+    expect(estimateGenerationCostMicroUsd(usage, PRICING['claude-sonnet-4-6'])).toBe(10_500);
+    expect(buildGenerationCostMetadata('claude-sonnet-4-6', usage)).toMatchObject({
+      inputTokens: 1_000,
+      outputTokens: 500,
+      estimatedCostUsd: 0.0105,
+      pricingAvailable: true,
+      pricingVersion: '2026-04-14',
+    });
+  });
+
+  it('includes cache write and cache read token costs', () => {
+    const usage = {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheWriteTokens: 100,
+      cacheReadTokens: 50,
+    };
+
+    expect(buildGenerationCostMetadata('claude-sonnet-4-6', usage)).toMatchObject({
+      cacheWriteTokens: 100,
+      cacheReadTokens: 50,
+      estimatedCostUsd: 0.01089,
+      pricingAvailable: true,
+    });
+  });
+
+  it('matches dated provider model names to a configured model family', () => {
+    expect(resolveModelPricing('claude-sonnet-4-6-20260501')).toBe(PRICING['claude-sonnet-4-6']);
+  });
+
+  it('preserves token metadata without estimating cost for unpriced models', () => {
+    const metadata = buildGenerationCostMetadata('model-without-price', {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    });
+
+    expect(metadata).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      tokensAvailable: true,
+      pricingAvailable: false,
+      model: 'model-without-price',
+    });
+    expect(metadata).not.toHaveProperty('estimatedCostUsd');
+  });
+
+  it('returns no token metadata when provider usage is absent', () => {
+    expect(normalizeAnthropicUsage(undefined)).toBeNull();
+    expect(normalizeAnthropicUsage({})).toBeNull();
+    expect(buildGenerationCostMetadata('claude-sonnet-4-6', null)).toBeNull();
+  });
+
+  it('normalizes Anthropic usage fields', () => {
+    expect(
+      normalizeAnthropicUsage({
+        input_tokens: 10.9,
+        output_tokens: 5,
+        cache_creation_input_tokens: 3,
+        cache_read_input_tokens: 2,
+      })
+    ).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheWriteTokens: 3,
+      cacheReadTokens: 2,
+    });
+  });
+});

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/cost.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/cost.test.ts
@@ -47,6 +47,24 @@ describe('generation cost helpers', () => {
     expect(resolveModelPricing('claude-sonnet-4-6-20260501')).toBe(PRICING['claude-sonnet-4-6']);
   });
 
+  it('prices claude-opus-4-7 at the opus tier', () => {
+    const usage = {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    };
+
+    expect(resolveModelPricing('claude-opus-4-7')).toBe(PRICING['claude-opus-4-7']);
+    // 1000 * 5.0 + 500 * 25.0 = 17_500 microUSD
+    expect(estimateGenerationCostMicroUsd(usage, PRICING['claude-opus-4-7'])).toBe(17_500);
+    expect(buildGenerationCostMetadata('claude-opus-4-7', usage)).toMatchObject({
+      estimatedCostUsd: 0.0175,
+      pricingAvailable: true,
+      pricingVersion: '2026-04-14',
+    });
+  });
+
   it('preserves token metadata without estimating cost for unpriced models', () => {
     const metadata = buildGenerationCostMetadata('model-without-price', {
       inputTokens: 100,

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/generation-service-costs.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/generation-service-costs.test.ts
@@ -60,7 +60,12 @@ function collectSqlValues(value: unknown, output: unknown[] = []): unknown[] {
   return output;
 }
 
-function createDbMock() {
+interface DbMockOptions {
+  /** When set, the Nth operation_logs insert (1-based) rejects to simulate a mid-write failure. */
+  failOperationInsertOnCall?: number;
+}
+
+function createDbMock(options: DbMockOptions = {}) {
   const generationLogs: Array<Record<string, unknown>> = [];
   const operationLogs: Array<Record<string, unknown>> = [];
   const sessionUpdates: Array<{ values: Record<string, unknown>; where: unknown }> = [];
@@ -70,6 +75,33 @@ function createDbMock() {
   });
   updateSet.mockReturnValue({ where: updateWhere });
 
+  let operationInsertCalls = 0;
+
+  // Writes route through the transaction handle; the top-level insert/update are
+  // intentionally NOT provided so any non-transactional cost write fails loudly.
+  const txInsert = vi.fn().mockImplementation((table: unknown) => ({
+    values: vi.fn().mockImplementation(async (values: Record<string, unknown>) => {
+      if (table === contentGenerationLogs) generationLogs.push(values);
+      if (table === contentOperationLogs) {
+        operationInsertCalls += 1;
+        if (options.failOperationInsertOnCall === operationInsertCalls) {
+          throw new Error('simulated operation_logs insert failure');
+        }
+        operationLogs.push(values);
+      }
+    }),
+  }));
+  const txUpdate = vi.fn().mockImplementation((table: unknown) => {
+    expect(table).toBe(contentMediationSessions);
+    return { set: updateSet };
+  });
+
+  const transaction = vi
+    .fn()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({ insert: txInsert, update: txUpdate })
+    );
+
   const db = {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockImplementation((table: unknown) => ({
@@ -78,16 +110,7 @@ function createDbMock() {
         }),
       })),
     }),
-    insert: vi.fn().mockImplementation((table: unknown) => ({
-      values: vi.fn().mockImplementation(async (values: Record<string, unknown>) => {
-        if (table === contentGenerationLogs) generationLogs.push(values);
-        if (table === contentOperationLogs) operationLogs.push(values);
-      }),
-    })),
-    update: vi.fn().mockImplementation((table: unknown) => {
-      expect(table).toBe(contentMediationSessions);
-      return { set: updateSet };
-    }),
+    transaction,
   };
 
   return {
@@ -97,6 +120,7 @@ function createDbMock() {
     sessionUpdates,
     updateSet,
     updateWhere,
+    transaction,
   };
 }
 
@@ -175,7 +199,8 @@ describe('GenerationService token cost persistence', () => {
     expect(mockDb.updateSet).not.toHaveBeenCalled();
   });
 
-  it('records tokens without estimated cost for an unpriced model', async () => {
+  it('records tokens without estimated cost for an unpriced model and warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mockDb = createDbMock();
     const provider = {
       generate: vi.fn().mockResolvedValue({
@@ -203,5 +228,80 @@ describe('GenerationService token cost persistence', () => {
     });
     expect(mockDb.operationLogs[0]?.metadata).not.toHaveProperty('estimatedCostUsd');
     expect(mockDb.updateSet).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No pricing'));
+    warnSpy.mockRestore();
+  });
+
+  it('prices claude-opus-4-7 and records its estimated cost', async () => {
+    const mockDb = createDbMock();
+    const provider = {
+      generate: vi.fn().mockResolvedValue({
+        text: 'Answer [Source 1]',
+        model: 'claude-opus-4-7',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 500,
+          cacheWriteTokens: 0,
+          cacheReadTokens: 0,
+        },
+      }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await service.generate('question', 'user-1', 'tenant-1', entitlements, {
+      sessionId: 'session-1',
+    });
+
+    // opus tier: 1000 * 5.0 + 500 * 25.0 = 17_500 microUSD = 0.0175 USD
+    expect(mockDb.operationLogs[0]?.metadata).toMatchObject({
+      model: 'claude-opus-4-7',
+      pricingAvailable: true,
+      estimatedCostUsd: 0.0175,
+    });
+    expect(mockDb.updateSet).toHaveBeenCalledOnce();
+  });
+
+  it('commits all cost-accounting writes inside a single transaction', async () => {
+    const mockDb = createDbMock();
+    const provider = {
+      generate: vi.fn().mockResolvedValue({
+        text: 'Answer [Source 1]',
+        model: 'claude-sonnet-4-6',
+        usage: { inputTokens: 1_000, outputTokens: 500, cacheWriteTokens: 0, cacheReadTokens: 0 },
+      }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await service.generate('question', 'user-1', 'tenant-1', entitlements, {
+      sessionId: 'session-1',
+    });
+
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
+    expect(mockDb.generationLogs).toHaveLength(1);
+    expect(mockDb.operationLogs).toHaveLength(1);
+    expect(mockDb.updateSet).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back the session accumulator when a mid-transaction write fails', async () => {
+    // Fail the operation_logs insert (the 1st such call) after the generation_logs
+    // insert has run; a real transaction would discard both and never reach the
+    // session UPDATE, leaving the accumulator untouched.
+    const mockDb = createDbMock({ failOperationInsertOnCall: 1 });
+    const provider = {
+      generate: vi.fn().mockResolvedValue({
+        text: 'Answer [Source 1]',
+        model: 'claude-sonnet-4-6',
+        usage: { inputTokens: 1_000, outputTokens: 500, cacheWriteTokens: 0, cacheReadTokens: 0 },
+      }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await expect(
+      service.generate('question', 'user-1', 'tenant-1', entitlements, { sessionId: 'session-1' })
+    ).rejects.toThrow('simulated operation_logs insert failure');
+
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
+    expect(mockDb.updateSet).not.toHaveBeenCalled();
+    expect(mockDb.sessionUpdates).toHaveLength(0);
   });
 });

--- a/joyus-ai-mcp-server/src/content/generation/__tests__/generation-service-costs.test.ts
+++ b/joyus-ai-mcp-server/src/content/generation/__tests__/generation-service-costs.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  contentGenerationLogs,
+  contentItems,
+  contentMediationSessions,
+  contentOperationLogs,
+} from '../../schema.js';
+import { GenerationService } from '../index.js';
+
+const itemRow = {
+  id: 'item-1',
+  sourceId: 'source-1',
+  title: 'Reference',
+  body: 'Reference body.',
+  metadata: {},
+};
+
+const searchService = {
+  search: vi.fn().mockResolvedValue([
+    {
+      itemId: itemRow.id,
+      sourceId: itemRow.sourceId,
+      title: itemRow.title,
+      excerpt: 'Reference body.',
+      score: 1,
+      metadata: {},
+      isStale: false,
+    },
+  ]),
+};
+
+const entitlements = {
+  productIds: ['product-1'],
+  sourceIds: ['source-1'],
+  profileIds: [],
+  resolvedFrom: 'test',
+  resolvedAt: new Date('2026-05-25T12:00:00.000Z'),
+};
+
+function collectSqlValues(value: unknown, output: unknown[] = []): unknown[] {
+  if (value === null || typeof value !== 'object') return output;
+
+  const record = value as Record<string, unknown>;
+  const primitive = record.value;
+  if (
+    typeof primitive === 'string' ||
+    typeof primitive === 'number' ||
+    typeof primitive === 'boolean'
+  ) {
+    output.push(primitive);
+  }
+
+  if (Array.isArray(record.queryChunks)) {
+    for (const entry of record.queryChunks) {
+      collectSqlValues(entry, output);
+    }
+  }
+
+  return output;
+}
+
+function createDbMock() {
+  const generationLogs: Array<Record<string, unknown>> = [];
+  const operationLogs: Array<Record<string, unknown>> = [];
+  const sessionUpdates: Array<{ values: Record<string, unknown>; where: unknown }> = [];
+  const updateSet = vi.fn();
+  const updateWhere = vi.fn().mockImplementation(async (where: unknown) => {
+    sessionUpdates.push({ values: updateSet.mock.calls[0][0], where });
+  });
+  updateSet.mockReturnValue({ where: updateWhere });
+
+  const db = {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockImplementation((table: unknown) => ({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(table === contentItems ? [itemRow] : []),
+        }),
+      })),
+    }),
+    insert: vi.fn().mockImplementation((table: unknown) => ({
+      values: vi.fn().mockImplementation(async (values: Record<string, unknown>) => {
+        if (table === contentGenerationLogs) generationLogs.push(values);
+        if (table === contentOperationLogs) operationLogs.push(values);
+      }),
+    })),
+    update: vi.fn().mockImplementation((table: unknown) => {
+      expect(table).toBe(contentMediationSessions);
+      return { set: updateSet };
+    }),
+  };
+
+  return {
+    db: db as never,
+    generationLogs,
+    operationLogs,
+    sessionUpdates,
+    updateSet,
+    updateWhere,
+  };
+}
+
+describe('GenerationService token cost persistence', () => {
+  it('writes session-scoped generation metadata and increments session totals', async () => {
+    const mockDb = createDbMock();
+    const provider = {
+      generate: vi.fn().mockResolvedValue({
+        text: 'Answer [Source 1]',
+        model: 'claude-sonnet-4-6',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 500,
+          cacheWriteTokens: 100,
+          cacheReadTokens: 50,
+        },
+      }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await service.generate('question', 'user-1', 'tenant-1', entitlements, {
+      sessionId: 'session-1',
+    });
+
+    expect(mockDb.generationLogs[0]).toMatchObject({ sessionId: 'session-1' });
+    expect(mockDb.operationLogs[0]).toMatchObject({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      success: true,
+      metadata: expect.objectContaining({
+        inputTokens: 1_000,
+        outputTokens: 500,
+        cacheWriteTokens: 100,
+        cacheReadTokens: 50,
+        estimatedCostUsd: 0.01089,
+        model: 'claude-sonnet-4-6',
+        pricingAvailable: true,
+      }),
+    });
+    expect(mockDb.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalInputTokens: expect.any(Object),
+        totalOutputTokens: expect.any(Object),
+        totalCacheWriteTokens: expect.any(Object),
+        totalCacheReadTokens: expect.any(Object),
+        totalEstimatedCostUsd: expect.any(Object),
+      })
+    );
+    expect(collectSqlValues(mockDb.updateWhere.mock.calls[0][0])).toEqual(
+      expect.arrayContaining(['session-1', 'tenant-1'])
+    );
+  });
+
+  it('omits token metadata and leaves accumulators untouched when usage is missing', async () => {
+    const mockDb = createDbMock();
+    const provider = {
+      generate: vi
+        .fn()
+        .mockResolvedValue({ text: 'Answer [Source 1]', model: 'claude-sonnet-4-6' }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await service.generate('question', 'user-1', 'tenant-1', entitlements, {
+      sessionId: 'session-1',
+    });
+
+    expect(mockDb.operationLogs[0]?.metadata).toMatchObject({
+      citationCount: 1,
+      sourcesUsed: 1,
+      profileId: null,
+    });
+    expect(mockDb.operationLogs[0]?.metadata).not.toHaveProperty('inputTokens');
+    expect(mockDb.operationLogs[0]?.metadata).not.toHaveProperty('estimatedCostUsd');
+    expect(mockDb.updateSet).not.toHaveBeenCalled();
+  });
+
+  it('records tokens without estimated cost for an unpriced model', async () => {
+    const mockDb = createDbMock();
+    const provider = {
+      generate: vi.fn().mockResolvedValue({
+        text: 'Answer [Source 1]',
+        model: 'model-without-price',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheWriteTokens: 0,
+          cacheReadTokens: 0,
+        },
+      }),
+    };
+    const service = new GenerationService(searchService as never, provider, mockDb.db);
+
+    await service.generate('question', 'user-1', 'tenant-1', entitlements, {
+      sessionId: 'session-1',
+    });
+
+    expect(mockDb.operationLogs[0]?.metadata).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      model: 'model-without-price',
+      pricingAvailable: false,
+    });
+    expect(mockDb.operationLogs[0]?.metadata).not.toHaveProperty('estimatedCostUsd');
+    expect(mockDb.updateSet).toHaveBeenCalledOnce();
+  });
+});

--- a/joyus-ai-mcp-server/src/content/generation/anthropic-provider.ts
+++ b/joyus-ai-mcp-server/src/content/generation/anthropic-provider.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 
-import type { GenerationProvider } from './generator.js';
+import { normalizeAnthropicUsage, type AnthropicUsageShape } from './cost.js';
+import type { GenerationProvider, GenerationProviderResponse } from './generator.js';
 
 export class AnthropicGenerationProvider implements GenerationProvider {
   private client: Anthropic;
@@ -21,7 +22,7 @@ export class AnthropicGenerationProvider implements GenerationProvider {
     this.maxTokens = options?.maxTokens ?? 4096;
   }
 
-  async generate(prompt: string, systemPrompt: string): Promise<string> {
+  async generate(prompt: string, systemPrompt: string): Promise<GenerationProviderResponse> {
     const response = await this.client.messages
       .create({
         model: this.model,
@@ -37,15 +38,15 @@ export class AnthropicGenerationProvider implements GenerationProvider {
       })
       .catch((err: unknown) => {
         if (err instanceof Anthropic.RateLimitError) {
-          throw Object.assign(
-            new Error('Anthropic rate limit exceeded — request is retryable'),
-            { retryable: true, cause: err },
-          );
+          throw Object.assign(new Error('Anthropic rate limit exceeded — request is retryable'), {
+            retryable: true,
+            cause: err,
+          });
         }
         if (err instanceof Anthropic.AuthenticationError) {
           throw Object.assign(
             new Error('Anthropic authentication failed — check ANTHROPIC_API_KEY'),
-            { retryable: false, cause: err },
+            { retryable: false, cause: err }
           );
         }
         throw err;
@@ -53,16 +54,20 @@ export class AnthropicGenerationProvider implements GenerationProvider {
 
     if (response.stop_reason === 'max_tokens') {
       console.warn(
-        `[AnthropicGenerationProvider] Response truncated at max_tokens=${this.maxTokens} for model ${this.model}`,
+        `[AnthropicGenerationProvider] Response truncated at max_tokens=${this.maxTokens} for model ${this.model}`
       );
     }
 
     const textBlock = response.content.find(
-      (block): block is Anthropic.TextBlock => block.type === 'text',
+      (block): block is Anthropic.TextBlock => block.type === 'text'
     );
     if (!textBlock) {
       throw new Error('Anthropic response contained no text block');
     }
-    return textBlock.text;
+    return {
+      text: textBlock.text,
+      model: response.model ?? this.model,
+      usage: normalizeAnthropicUsage(response.usage as AnthropicUsageShape | undefined),
+    };
   }
 }

--- a/joyus-ai-mcp-server/src/content/generation/cost.ts
+++ b/joyus-ai-mcp-server/src/content/generation/cost.ts
@@ -34,6 +34,14 @@ export const PRICING: Record<string, ModelPricing> = {
     cacheReadPerMTok: 0.5,
     outputPerMTok: 25.0,
   },
+  // claude-opus-4-7 rates assumed identical to the opus-4-6 tier pending
+  // confirmed published pricing; revisit alongside PRICING_VERSION if rates differ.
+  'claude-opus-4-7': {
+    inputPerMTok: 5.0,
+    cacheWritePerMTok: 6.25,
+    cacheReadPerMTok: 0.5,
+    outputPerMTok: 25.0,
+  },
   'claude-haiku-4-5': {
     inputPerMTok: 1.0,
     cacheWritePerMTok: 1.25,
@@ -64,6 +72,8 @@ function nonNegativeInteger(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return 0;
   }
+  // Math.trunc is deliberate: token counts are whole units, so fractional
+  // provider values are floored toward zero rather than rounded.
   return Math.trunc(value);
 }
 
@@ -122,14 +132,40 @@ export function costUsdNumber(microUsd: number): number {
   return Number(formatCostUsd(microUsd));
 }
 
-export function buildGenerationCostMetadata(
+/**
+ * Resolved cost for a single generation. Computed once per generation so the
+ * operation-log metadata and the session-accumulator update share an identical
+ * figure and cannot diverge. `microUsd` is null when the model has no pricing.
+ */
+export interface ResolvedGenerationCost {
+  pricing: ModelPricing | null;
+  microUsd: number | null;
+}
+
+export function resolveGenerationCost(
   model: string | null | undefined,
   usage: GenerationTokenUsage | null | undefined
+): ResolvedGenerationCost {
+  const pricing = resolveModelPricing(model);
+  if (!pricing || !usage) {
+    return { pricing, microUsd: null };
+  }
+  return { pricing, microUsd: estimateGenerationCostMicroUsd(usage, pricing) };
+}
+
+export function buildGenerationCostMetadata(
+  model: string | null | undefined,
+  usage: GenerationTokenUsage | null | undefined,
+  cost?: ResolvedGenerationCost
 ): Partial<GenerationOperationMetadata> | null {
   if (!usage) return null;
 
+  // cacheHitRate denominator = inputTokens + cacheWriteTokens + cacheReadTokens.
+  // Anthropic's input_tokens already excludes cached tokens, so cache reads/writes
+  // are additive here with no double-count.
   const promptTokenTotal = usage.inputTokens + usage.cacheWriteTokens + usage.cacheReadTokens;
-  const pricing = resolveModelPricing(model);
+  const resolved = cost ?? resolveGenerationCost(model, usage);
+  const pricing = resolved.pricing;
   const metadata: Partial<GenerationOperationMetadata> = {
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
@@ -141,12 +177,11 @@ export function buildGenerationCostMetadata(
     ...(promptTokenTotal > 0 ? { cacheHitRate: usage.cacheReadTokens / promptTokenTotal } : {}),
   };
 
-  if (!pricing) return metadata;
+  if (resolved.microUsd === null) return metadata;
 
-  const microUsd = estimateGenerationCostMicroUsd(usage, pricing);
   return {
     ...metadata,
-    estimatedCostUsd: costUsdNumber(microUsd),
+    estimatedCostUsd: costUsdNumber(resolved.microUsd),
     pricingVersion: PRICING_VERSION,
   };
 }

--- a/joyus-ai-mcp-server/src/content/generation/cost.ts
+++ b/joyus-ai-mcp-server/src/content/generation/cost.ts
@@ -10,6 +10,8 @@ export interface GenerationOperationMetadata {
   cacheHitRate?: number;
   model?: string;
   tokensAvailable?: boolean;
+  pricingAvailable?: boolean;
+  pricingVersion?: string;
 }
 
 export interface ModelPricing {
@@ -41,6 +43,113 @@ export const PRICING: Record<string, ModelPricing> = {
 };
 
 export const PRICING_VERSION = '2026-04-14';
+
+export interface GenerationTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheWriteTokens: number;
+  cacheReadTokens: number;
+}
+
+export interface AnthropicUsageShape {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+const USD_SCALE = 1_000_000;
+
+function nonNegativeInteger(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.trunc(value);
+}
+
+function hasNumericField(source: Record<string, unknown>, field: string): boolean {
+  return typeof source[field] === 'number' && Number.isFinite(source[field]);
+}
+
+export function normalizeAnthropicUsage(
+  usage: AnthropicUsageShape | null | undefined
+): GenerationTokenUsage | null {
+  if (!usage) return null;
+
+  const source = usage as Record<string, unknown>;
+  const hasUsage = [
+    'input_tokens',
+    'output_tokens',
+    'cache_creation_input_tokens',
+    'cache_read_input_tokens',
+  ].some(field => hasNumericField(source, field));
+
+  if (!hasUsage) return null;
+
+  return {
+    inputTokens: nonNegativeInteger(usage.input_tokens),
+    outputTokens: nonNegativeInteger(usage.output_tokens),
+    cacheWriteTokens: nonNegativeInteger(usage.cache_creation_input_tokens),
+    cacheReadTokens: nonNegativeInteger(usage.cache_read_input_tokens),
+  };
+}
+
+export function resolveModelPricing(model: string | null | undefined): ModelPricing | null {
+  if (!model) return null;
+  if (PRICING[model]) return PRICING[model];
+
+  const modelFamily = Object.keys(PRICING).find(key => model.startsWith(`${key}-`));
+  return modelFamily ? PRICING[modelFamily] : null;
+}
+
+export function estimateGenerationCostMicroUsd(
+  usage: GenerationTokenUsage,
+  pricing: ModelPricing
+): number {
+  return Math.round(
+    usage.inputTokens * pricing.inputPerMTok +
+      usage.outputTokens * pricing.outputPerMTok +
+      usage.cacheWriteTokens * pricing.cacheWritePerMTok +
+      usage.cacheReadTokens * pricing.cacheReadPerMTok
+  );
+}
+
+export function formatCostUsd(microUsd: number): string {
+  return (microUsd / USD_SCALE).toFixed(6);
+}
+
+export function costUsdNumber(microUsd: number): number {
+  return Number(formatCostUsd(microUsd));
+}
+
+export function buildGenerationCostMetadata(
+  model: string | null | undefined,
+  usage: GenerationTokenUsage | null | undefined
+): Partial<GenerationOperationMetadata> | null {
+  if (!usage) return null;
+
+  const promptTokenTotal = usage.inputTokens + usage.cacheWriteTokens + usage.cacheReadTokens;
+  const pricing = resolveModelPricing(model);
+  const metadata: Partial<GenerationOperationMetadata> = {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cacheWriteTokens: usage.cacheWriteTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+    tokensAvailable: true,
+    pricingAvailable: pricing !== null,
+    ...(model ? { model } : {}),
+    ...(promptTokenTotal > 0 ? { cacheHitRate: usage.cacheReadTokens / promptTokenTotal } : {}),
+  };
+
+  if (!pricing) return metadata;
+
+  const microUsd = estimateGenerationCostMicroUsd(usage, pricing);
+  return {
+    ...metadata,
+    estimatedCostUsd: costUsdNumber(microUsd),
+    pricingVersion: PRICING_VERSION,
+  };
+}
 
 const parsedTtl = parseInt(process.env.JOYUS_CACHE_TTL_SECONDS ?? '', 10);
 export const CACHE_TTL_SECONDS: number =

--- a/joyus-ai-mcp-server/src/content/generation/generator.ts
+++ b/joyus-ai-mcp-server/src/content/generation/generator.ts
@@ -15,6 +15,8 @@ export interface GenerationProviderResponse {
 }
 
 export interface GenerationProvider {
+  // TODO: tighten to Promise<GenerationProviderResponse> once every provider
+  // returns the structured shape; the bare-string branch is backward-compat only.
   generate(prompt: string, systemPrompt: string): Promise<string | GenerationProviderResponse>;
 }
 

--- a/joyus-ai-mcp-server/src/content/generation/generator.ts
+++ b/joyus-ai-mcp-server/src/content/generation/generator.ts
@@ -5,16 +5,25 @@
  * system prompt from the retrieved context and optional voice profile.
  */
 
+import type { GenerationTokenUsage } from './cost.js';
 import type { RetrievalResult } from './retriever.js';
 
+export interface GenerationProviderResponse {
+  text: string;
+  model?: string;
+  usage?: GenerationTokenUsage | null;
+}
+
 export interface GenerationProvider {
-  generate(prompt: string, systemPrompt: string): Promise<string>;
+  generate(prompt: string, systemPrompt: string): Promise<string | GenerationProviderResponse>;
 }
 
 export interface GenerationOutput {
   text: string;
   profileUsed: string | null;
   sourcesProvided: number;
+  model?: string;
+  usage?: GenerationTokenUsage;
 }
 
 export class ContentGenerator {
@@ -23,14 +32,19 @@ export class ContentGenerator {
   async generate(
     query: string,
     retrieval: RetrievalResult,
-    profileId?: string,
+    profileId?: string
   ): Promise<GenerationOutput> {
     const systemPrompt = this.buildSystemPrompt(retrieval, profileId);
-    const text = await this.provider.generate(query, systemPrompt);
+    const providerResult = await this.provider.generate(query, systemPrompt);
+    const normalized =
+      typeof providerResult === 'string' ? { text: providerResult } : providerResult;
+
     return {
-      text,
+      text: normalized.text,
       profileUsed: profileId ?? null,
       sourcesProvided: retrieval.items.length,
+      ...(normalized.model ? { model: normalized.model } : {}),
+      ...(normalized.usage ? { usage: normalized.usage } : {}),
     };
   }
 
@@ -48,8 +62,7 @@ export class ContentGenerator {
     prompt += '- Use ONLY the reference material above to answer\n';
     prompt += '- Cite sources using [Source N] markers matching the numbers above\n';
     prompt += '- Do NOT reference content not in the provided sources\n';
-    prompt +=
-      '- If the reference material does not contain relevant information, say so\n';
+    prompt += '- If the reference material does not contain relevant information, say so\n';
 
     return prompt;
   }

--- a/joyus-ai-mcp-server/src/content/generation/index.ts
+++ b/joyus-ai-mcp-server/src/content/generation/index.ts
@@ -4,13 +4,26 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
+import { and, eq, sql } from 'drizzle-orm';
 
 import type { DrizzleClient } from '../../db/types.js';
-import { contentGenerationLogs, contentOperationLogs } from '../schema.js';
+import {
+  contentGenerationLogs,
+  contentMediationSessions,
+  contentOperationLogs,
+} from '../schema.js';
 import type { SearchService } from '../search/index.js';
 import type { ResolvedEntitlements, GenerationResult } from '../types.js';
 
 import { CitationManager, type CitationResult } from './citations.js';
+import {
+  buildGenerationCostMetadata,
+  estimateGenerationCostMicroUsd,
+  formatCostUsd,
+  resolveModelPricing,
+  type GenerationOperationMetadata,
+  type GenerationTokenUsage,
+} from './cost.js';
 import {
   ContentGenerator,
   PlaceholderGenerationProvider,
@@ -34,7 +47,7 @@ export class GenerationService {
   constructor(
     searchService: SearchService,
     provider: GenerationProvider,
-    private db: DrizzleClient,
+    private db: DrizzleClient
   ) {
     this.retriever = new ContentRetriever(searchService, db);
     this.generator = new ContentGenerator(provider);
@@ -46,7 +59,7 @@ export class GenerationService {
     userId: string,
     tenantId: string,
     entitlements: ResolvedEntitlements,
-    options?: GenerateOptions,
+    options?: GenerateOptions
   ): Promise<GenerationResult> {
     const startMs = Date.now();
 
@@ -60,12 +73,16 @@ export class GenerationService {
     const genOutput = await this.generator.generate(query, retrieval, options?.profileId);
 
     // 3. Extract citations from generated text
-    const citationResult = this.citationManager.extractCitations(
-      genOutput.text,
-      retrieval.items,
-    );
+    const citationResult = this.citationManager.extractCitations(genOutput.text, retrieval.items);
 
     const durationMs = Date.now() - startMs;
+    const costMetadata = buildGenerationCostMetadata(genOutput.model, genOutput.usage);
+    const operationMetadata: GenerationOperationMetadata = {
+      citationCount: citationResult.citationCount,
+      sourcesUsed: retrieval.items.length,
+      profileId: options?.profileId ?? null,
+      ...(costMetadata ?? {}),
+    };
 
     // 4. Log to generation_logs (no durationMs column in this table)
     await this.db.insert(contentGenerationLogs).values({
@@ -86,14 +103,20 @@ export class GenerationService {
       tenantId,
       operation: 'generate',
       userId,
+      sessionId: options?.sessionId ?? null,
       durationMs,
       success: true,
-      metadata: {
-        citationCount: citationResult.citationCount,
-        sourcesUsed: retrieval.items.length,
-        profileId: options?.profileId ?? null,
-      },
+      metadata: operationMetadata,
     });
+
+    if (options?.sessionId && genOutput.usage) {
+      await this.addGenerationUsageToSession(
+        options.sessionId,
+        tenantId,
+        genOutput.usage,
+        genOutput.model
+      );
+    }
 
     return {
       text: citationResult.text,
@@ -106,14 +129,38 @@ export class GenerationService {
       },
     };
   }
+
+  private async addGenerationUsageToSession(
+    sessionId: string,
+    tenantId: string,
+    usage: GenerationTokenUsage,
+    model: string | undefined
+  ): Promise<void> {
+    const pricing = resolveModelPricing(model);
+    const estimatedCostIncrement = pricing
+      ? formatCostUsd(estimateGenerationCostMicroUsd(usage, pricing))
+      : formatCostUsd(0);
+
+    await this.db
+      .update(contentMediationSessions)
+      .set({
+        totalInputTokens: sql`${contentMediationSessions.totalInputTokens} + ${usage.inputTokens}`,
+        totalOutputTokens: sql`${contentMediationSessions.totalOutputTokens} + ${usage.outputTokens}`,
+        totalCacheWriteTokens: sql`${contentMediationSessions.totalCacheWriteTokens} + ${usage.cacheWriteTokens}`,
+        totalCacheReadTokens: sql`${contentMediationSessions.totalCacheReadTokens} + ${usage.cacheReadTokens}`,
+        totalEstimatedCostUsd: sql`${contentMediationSessions.totalEstimatedCostUsd} + cast(${estimatedCostIncrement} as numeric(14, 6))`,
+      })
+      .where(
+        and(
+          eq(contentMediationSessions.id, sessionId),
+          eq(contentMediationSessions.tenantId, tenantId)
+        )
+      );
+  }
 }
 
 // Re-exports so callers can import everything from this module
-export {
-  ContentRetriever,
-  type RetrievalResult,
-  type RetrievedItem,
-} from './retriever.js';
+export { ContentRetriever, type RetrievalResult, type RetrievedItem } from './retriever.js';
 export type { SearchService } from '../search/index.js';
 export { AnthropicGenerationProvider } from './anthropic-provider.js';
 export {

--- a/joyus-ai-mcp-server/src/content/generation/index.ts
+++ b/joyus-ai-mcp-server/src/content/generation/index.ts
@@ -18,11 +18,11 @@ import type { ResolvedEntitlements, GenerationResult } from '../types.js';
 import { CitationManager, type CitationResult } from './citations.js';
 import {
   buildGenerationCostMetadata,
-  estimateGenerationCostMicroUsd,
   formatCostUsd,
-  resolveModelPricing,
+  resolveGenerationCost,
   type GenerationOperationMetadata,
   type GenerationTokenUsage,
+  type ResolvedGenerationCost,
 } from './cost.js';
 import {
   ContentGenerator,
@@ -31,6 +31,9 @@ import {
   type GenerationOutput,
 } from './generator.js';
 import { ContentRetriever, type RetrievalResult, type RetrievedItem } from './retriever.js';
+
+/** Transaction handle passed to the `db.transaction(async tx => …)` callback. */
+type DrizzleTransaction = Parameters<Parameters<DrizzleClient['transaction']>[0]>[0];
 
 export interface GenerateOptions {
   profileId?: string;
@@ -76,7 +79,10 @@ export class GenerationService {
     const citationResult = this.citationManager.extractCitations(genOutput.text, retrieval.items);
 
     const durationMs = Date.now() - startMs;
-    const costMetadata = buildGenerationCostMetadata(genOutput.model, genOutput.usage);
+    // Resolve pricing + micro-USD once so the operation-log metadata and the
+    // session accumulator share an identical figure and cannot diverge.
+    const cost = resolveGenerationCost(genOutput.model, genOutput.usage);
+    const costMetadata = buildGenerationCostMetadata(genOutput.model, genOutput.usage, cost);
     const operationMetadata: GenerationOperationMetadata = {
       citationCount: citationResult.citationCount,
       sourcesUsed: retrieval.items.length,
@@ -84,39 +90,53 @@ export class GenerationService {
       ...(costMetadata ?? {}),
     };
 
-    // 4. Log to generation_logs (no durationMs column in this table)
-    await this.db.insert(contentGenerationLogs).values({
-      id: createId(),
-      tenantId,
-      userId,
-      sessionId: options?.sessionId ?? null,
-      profileId: options?.profileId ?? null,
-      query,
-      sourcesUsed: retrieval.items.map(i => i.itemId),
-      citationCount: citationResult.citationCount,
-      responseLength: citationResult.text.length,
-    });
-
-    // 5. Audit log via operation_logs (includes durationMs)
-    await this.db.insert(contentOperationLogs).values({
-      id: createId(),
-      tenantId,
-      operation: 'generate',
-      userId,
-      sessionId: options?.sessionId ?? null,
-      durationMs,
-      success: true,
-      metadata: operationMetadata,
-    });
-
-    if (options?.sessionId && genOutput.usage) {
-      await this.addGenerationUsageToSession(
-        options.sessionId,
-        tenantId,
-        genOutput.usage,
-        genOutput.model
+    // Surface usage that we recorded but could not price, so unpriced spend is
+    // observable rather than silently accumulating as $0.
+    if (genOutput.usage && cost.pricing === null) {
+      console.warn(
+        `[GenerationService] No pricing for model "${genOutput.model ?? 'unknown'}"; ` +
+          'token usage recorded but estimated cost is $0.'
       );
     }
+
+    // Cost-accounting writes must commit all-or-nothing: a failure between them
+    // would desync the per-operation logs from the session accumulator.
+    await this.db.transaction(async tx => {
+      // 4. Log to generation_logs (no durationMs column in this table)
+      await tx.insert(contentGenerationLogs).values({
+        id: createId(),
+        tenantId,
+        userId,
+        sessionId: options?.sessionId ?? null,
+        profileId: options?.profileId ?? null,
+        query,
+        sourcesUsed: retrieval.items.map(i => i.itemId),
+        citationCount: citationResult.citationCount,
+        responseLength: citationResult.text.length,
+      });
+
+      // 5. Audit log via operation_logs (includes durationMs)
+      await tx.insert(contentOperationLogs).values({
+        id: createId(),
+        tenantId,
+        operation: 'generate',
+        userId,
+        sessionId: options?.sessionId ?? null,
+        durationMs,
+        success: true,
+        metadata: operationMetadata,
+      });
+
+      if (options?.sessionId && genOutput.usage) {
+        await this.addGenerationUsageToSession(
+          tx,
+          options.sessionId,
+          tenantId,
+          genOutput.usage,
+          cost
+        );
+      }
+    });
 
     return {
       text: citationResult.text,
@@ -131,17 +151,15 @@ export class GenerationService {
   }
 
   private async addGenerationUsageToSession(
+    tx: DrizzleTransaction,
     sessionId: string,
     tenantId: string,
     usage: GenerationTokenUsage,
-    model: string | undefined
+    cost: ResolvedGenerationCost
   ): Promise<void> {
-    const pricing = resolveModelPricing(model);
-    const estimatedCostIncrement = pricing
-      ? formatCostUsd(estimateGenerationCostMicroUsd(usage, pricing))
-      : formatCostUsd(0);
+    const estimatedCostIncrement = formatCostUsd(cost.microUsd ?? 0);
 
-    await this.db
+    await tx
       .update(contentMediationSessions)
       .set({
         totalInputTokens: sql`${contentMediationSessions.totalInputTokens} + ${usage.inputTokens}`,


### PR DESCRIPTION
## Summary
- compute generation token cost metadata from provider usage
- persist generation operation logs with session-scoped cost metadata
- update mediation session token and estimated-cost accumulators additively

## Tests
- npm run build
- npm run lint
- npm run db:check
- npm test -- --run src/content/generation/__tests__/cost.test.ts src/content/generation/__tests__/anthropic-provider.test.ts src/content/generation/__tests__/generation-service-costs.test.ts
- npm test

Closes #59