### PR TITLE
[codex] Add mediation API key provisioning commands

### DIFF
--- a/joyus-ai-mcp-server/docs/manual-testing/content-mediation-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/content-mediation-manual-test.md
@@ -1,13 +1,13 @@
 # Content Mediation Manual Test
 
-| Field | Value |
-| --- | --- |
-| Feature area | Content mediation |
-| Related PR/issues | Not specified |
-| Environment | Local Docker Compose |
-| Required services | PostgreSQL, MCP server, local JWT/JWKS helper |
-| Required credentials | Mediation API key and user JWT |
-| Last verified | Not yet verified |
+| Field                | Value                                         |
+| -------------------- | --------------------------------------------- |
+| Feature area         | Content mediation                             |
+| Related PR/issues    | Not specified                                 |
+| Environment          | Local Docker Compose                          |
+| Required services    | PostgreSQL, MCP server, local JWT/JWKS helper |
+| Required credentials | Mediation API key and user JWT                |
+| Last verified        | Not yet verified                              |
 
 ## Purpose
 
@@ -24,20 +24,14 @@ count increments, idle-gap tracking, and cache-miss logging.
   - `Authorization: Bearer <JWT>`: identifies the end user inside that integration.
 
 The mediation API key is not recoverable from the database. Only its SHA-256
-hash is stored. If you do not already have the raw key, create a local test key
-and insert its hash.
+hash is stored. The operator command prints the raw key once at creation time.
+If you lose it, revoke that key and create a new one.
 
-## Do I Need To Run Postgres Commands?
+## Do I Need To Write SQL?
 
-For the current code, yes, unless a valid mediation API key and matching JWT
-already exist.
-
-There is an `ApiKeyService` in code, but there is no admin HTTP endpoint or CLI
-wrapper for creating mediation API keys. Manual DB setup is the current shortest
-path for a local smoke test.
-
-The database commands below only create/update local test data. They are not
-needed in production if the integration key has already been provisioned.
+No. Use the `mediation-api-keys` operator command to create, list, and revoke
+mediation API keys. The command wraps `ApiKeyService`, stores only the hashed
+key, and prints the raw key only in the `create` response.
 
 ## Overview
 
@@ -87,7 +81,7 @@ curl -sS "http://localhost:3000/api/mediation/health"
 Expected:
 
 ```json
-{"status":"ok"}
+{ "status": "ok" }
 ```
 
 ## Terminal 2: Start Local JWT/JWKS Helper
@@ -127,7 +121,7 @@ Set the database URL if needed:
 export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/joyus_ai_mcp"
 ```
 
-Verify Postgres is reachable:
+Verify Postgres is reachable if this is a fresh local environment:
 
 ```bash
 psql "$DATABASE_URL" -c "select 1;"
@@ -135,66 +129,36 @@ psql "$DATABASE_URL" -c "select 1;"
 
 Copy the `JWKS_URI` and `USER_JWT` exports from Terminal 2 into this terminal.
 
-## Create A Local Mediation API Key Row
+## Create A Local Mediation API Key
 
-Choose a raw key:
+Create a key for the local test tenant:
 
 ```bash
-export MEDIATION_API_KEY="jyk_local_manual_test_key_001"
+npm run mediation-api-keys -- create \
+  --tenant-id tenant-1 \
+  --integration-name local-manual-test \
+  --jwks-uri "$JWKS_URI"
 ```
 
-Hash it:
+The command prints:
+
+- key ID
+- key prefix
+- tenant and integration metadata
+- raw API key, shown once
+
+Copy the raw key into an environment variable:
 
 ```bash
-export MEDIATION_API_KEY_HASH="$(
-  node -e "console.log(require('crypto').createHash('sha256').update(process.env.MEDIATION_API_KEY).digest('hex'))"
-)"
-```
-
-Insert or update the test key:
-
-```bash
-psql "$DATABASE_URL" -c "
-insert into content.api_keys (
-  id,
-  tenant_id,
-  key_hash,
-  key_prefix,
-  integration_name,
-  jwks_uri,
-  issuer,
-  audience,
-  is_active
-)
-values (
-  'manual-api-key-1',
-  'tenant-1',
-  '$MEDIATION_API_KEY_HASH',
-  'jyk_loca',
-  'manual-local-test',
-  '$JWKS_URI',
-  null,
-  null,
-  true
-)
-on conflict (id) do update set
-  key_hash = excluded.key_hash,
-  key_prefix = excluded.key_prefix,
-  jwks_uri = excluded.jwks_uri,
-  is_active = true;
-"
+export MEDIATION_API_KEY="<raw-key-printed-by-create>"
 ```
 
 The local helper's JWT `sub` claim becomes the mediation user ID.
 
-Check that the API key row exists:
+List safe key metadata without exposing raw keys or hashes:
 
 ```bash
-psql "$DATABASE_URL" -c "
-select id, tenant_id, key_prefix, integration_name, jwks_uri, is_active
-from content.api_keys
-where id = 'manual-api-key-1';
-"
+npm run mediation-api-keys -- list --tenant-id tenant-1
 ```
 
 ## Create A Session
@@ -305,9 +269,14 @@ limit 5;
 Expected: one row with `operation = 'cache_miss'` and metadata containing
 `idleGapSeconds` and `cacheTtlSeconds`.
 
-## Cleaner Future Improvement
+## Revoke The Local Key
 
-Issue #60 tracks adding a local/operator provisioning command that wraps
-`ApiKeyService.createKey`. That would remove the need to hand-write SQL for
-local manual testing. The `dev:mediation-auth` helper only handles the JWKS/JWT
-side of local auth.
+After testing, revoke the key by ID:
+
+```bash
+npm run mediation-api-keys -- revoke --key-id <key-id-printed-by-create>
+```
+
+The `dev:mediation-auth` helper only handles the JWKS/JWT side of local auth.
+The `mediation-api-keys` command manages the integration API key used in the
+`X-API-Key` header.

--- a/joyus-ai-mcp-server/package.json
+++ b/joyus-ai-mcp-server/package.json
@@ -10,6 +10,7 @@
     "prepare": "../scripts/install-git-hooks.sh",
     "dev": "tsx watch src/index.ts",
     "dev:mediation-auth": "node scripts/mediation-dev-auth.mjs",
+    "mediation-api-keys": "tsx src/content/mediation/api-key-cli.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/joyus-ai-mcp-server/src/content/mediation/api-key-cli.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/api-key-cli.ts
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import 'dotenv/config';
+
+import type { ContentApiKey } from '../schema.js';
+
+import { ApiKeyService, type CreateKeyInput, type RevokeKeyResult } from './keys.js';
+
+export interface ApiKeyCommandService {
+  createKey(
+    tenantId: string,
+    input: CreateKeyInput
+  ): Promise<{ key: string; id: string; keyPrefix?: string }>;
+  listKeys(tenantId: string): Promise<ContentApiKey[]>;
+  revokeKey(keyId: string): Promise<RevokeKeyResult>;
+}
+
+export interface CommandIo {
+  stdout(message: string): void;
+  stderr(message: string): void;
+}
+
+export interface CommandServiceHandle {
+  service: ApiKeyCommandService;
+  close?: () => Promise<void>;
+}
+
+export interface CommandRuntime {
+  io?: CommandIo;
+  service?: ApiKeyCommandService;
+  createService?: () => Promise<CommandServiceHandle>;
+}
+
+type ParsedCommand =
+  | {
+      command: 'create';
+      tenantId: string;
+      integrationName: string;
+      jwksUri: string;
+      issuer?: string;
+      audience?: string;
+    }
+  | { command: 'list'; tenantId: string }
+  | { command: 'revoke'; keyId: string };
+
+type ParseResult =
+  | { ok: true; value: ParsedCommand }
+  | { ok: false; message: string; exitCode: number };
+
+const usage = `Usage:
+  npm run mediation-api-keys -- create --tenant-id <tenant> --integration-name <name> --jwks-uri <uri> [--issuer <iss>] [--audience <aud>]
+  npm run mediation-api-keys -- list --tenant-id <tenant>
+  npm run mediation-api-keys -- revoke --key-id <key>
+
+Commands:
+  create   Create a mediation API key and print the raw key once.
+  list     List safe mediation API key metadata for a tenant.
+  revoke   Revoke a mediation API key by key ID.
+
+Environment:
+  DATABASE_URL must point to the Joyus MCP database for create/list/revoke.`;
+
+const defaultIo: CommandIo = {
+  stdout: message => console.log(message),
+  stderr: message => console.error(message),
+};
+
+function parseOptions(tokens: string[]): { options: Map<string, string>; error?: string } {
+  const options = new Map<string, string>();
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (!token.startsWith('--')) {
+      return { options, error: `Unexpected positional argument: ${token}` };
+    }
+
+    const optionText = token.slice(2);
+    const separatorIndex = optionText.indexOf('=');
+    let name = optionText;
+    let value: string | undefined;
+
+    if (separatorIndex >= 0) {
+      name = optionText.slice(0, separatorIndex);
+      value = optionText.slice(separatorIndex + 1);
+    } else {
+      value = tokens[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        return { options, error: `Missing value for --${name}` };
+      }
+      index += 1;
+    }
+
+    if (!name) {
+      return { options, error: 'Empty option name' };
+    }
+
+    if (options.has(name)) {
+      return { options, error: `Duplicate option: --${name}` };
+    }
+
+    options.set(name, value);
+  }
+
+  return { options };
+}
+
+function optionValue(options: Map<string, string>, name: string): string | undefined {
+  const value = options.get(name)?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function validateAllowedOptions(
+  options: Map<string, string>,
+  allowedOptions: readonly string[]
+): string | undefined {
+  for (const name of options.keys()) {
+    if (!allowedOptions.includes(name)) {
+      return `Unknown option for command: --${name}`;
+    }
+  }
+  return undefined;
+}
+
+function requireOption(options: Map<string, string>, name: string): string | ParseResult {
+  const value = optionValue(options, name);
+  if (!value) {
+    return {
+      ok: false,
+      message: `Missing required option: --${name}`,
+      exitCode: 1,
+    };
+  }
+  return value;
+}
+
+function requireUrl(value: string, optionName: string): ParseResult | undefined {
+  try {
+    new URL(value);
+    return undefined;
+  } catch {
+    return {
+      ok: false,
+      message: `Invalid URL for --${optionName}: ${value}`,
+      exitCode: 1,
+    };
+  }
+}
+
+export function parseMediationApiKeyCommand(args: string[]): ParseResult {
+  const [command, ...optionTokens] = args;
+
+  if (!command) {
+    return { ok: false, message: usage, exitCode: 1 };
+  }
+
+  if (command === '--help' || command === '-h' || command === 'help') {
+    return { ok: false, message: usage, exitCode: 0 };
+  }
+
+  if (optionTokens.includes('--help') || optionTokens.includes('-h')) {
+    return { ok: false, message: usage, exitCode: 0 };
+  }
+
+  const { options, error } = parseOptions(optionTokens);
+  if (error) {
+    return { ok: false, message: error, exitCode: 1 };
+  }
+
+  if (command === 'create') {
+    const allowedError = validateAllowedOptions(options, [
+      'tenant-id',
+      'integration-name',
+      'jwks-uri',
+      'issuer',
+      'audience',
+    ]);
+    if (allowedError) {
+      return { ok: false, message: allowedError, exitCode: 1 };
+    }
+
+    const tenantId = requireOption(options, 'tenant-id');
+    if (typeof tenantId !== 'string') return tenantId;
+
+    const integrationName = requireOption(options, 'integration-name');
+    if (typeof integrationName !== 'string') return integrationName;
+
+    const jwksUri = requireOption(options, 'jwks-uri');
+    if (typeof jwksUri !== 'string') return jwksUri;
+
+    const urlError = requireUrl(jwksUri, 'jwks-uri');
+    if (urlError) return urlError;
+
+    return {
+      ok: true,
+      value: {
+        command,
+        tenantId,
+        integrationName,
+        jwksUri,
+        issuer: optionValue(options, 'issuer'),
+        audience: optionValue(options, 'audience'),
+      },
+    };
+  }
+
+  if (command === 'list') {
+    const allowedError = validateAllowedOptions(options, ['tenant-id']);
+    if (allowedError) {
+      return { ok: false, message: allowedError, exitCode: 1 };
+    }
+
+    const tenantId = requireOption(options, 'tenant-id');
+    if (typeof tenantId !== 'string') return tenantId;
+
+    return { ok: true, value: { command, tenantId } };
+  }
+
+  if (command === 'revoke') {
+    const allowedError = validateAllowedOptions(options, ['key-id']);
+    if (allowedError) {
+      return { ok: false, message: allowedError, exitCode: 1 };
+    }
+
+    const keyId = requireOption(options, 'key-id');
+    if (typeof keyId !== 'string') return keyId;
+
+    return { ok: true, value: { command, keyId } };
+  }
+
+  return { ok: false, message: `Unknown command: ${command}\n\n${usage}`, exitCode: 1 };
+}
+
+function optionalValue(value: string | null | undefined): string {
+  return value && value.length > 0 ? value : '(not set)';
+}
+
+function formatDate(value: Date | string | null | undefined): string {
+  if (!value) return '(never)';
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function renderKeyMetadata(key: ContentApiKey): string[] {
+  return [
+    `Key ID: ${key.id}`,
+    `Key prefix: ${key.keyPrefix}`,
+    `Integration: ${key.integrationName}`,
+    `JWKS URI: ${optionalValue(key.jwksUri)}`,
+    `Issuer: ${optionalValue(key.issuer)}`,
+    `Audience: ${optionalValue(key.audience)}`,
+    `Active: ${key.isActive ? 'yes' : 'no'}`,
+    `Created: ${formatDate(key.createdAt)}`,
+    `Last used: ${formatDate(key.lastUsedAt)}`,
+  ];
+}
+
+async function createKey(
+  command: Extract<ParsedCommand, { command: 'create' }>,
+  service: ApiKeyCommandService,
+  io: CommandIo
+): Promise<number> {
+  const result = await service.createKey(command.tenantId, {
+    integrationName: command.integrationName,
+    jwksUri: command.jwksUri,
+    issuer: command.issuer,
+    audience: command.audience,
+  });
+  const keyPrefix = result.keyPrefix ?? result.key.substring(0, 8);
+
+  io.stdout(
+    [
+      'Mediation API key created.',
+      `Key ID: ${result.id}`,
+      `Key prefix: ${keyPrefix}`,
+      `Tenant ID: ${command.tenantId}`,
+      `Integration: ${command.integrationName}`,
+      `JWKS URI: ${command.jwksUri}`,
+      `Issuer: ${optionalValue(command.issuer)}`,
+      `Audience: ${optionalValue(command.audience)}`,
+      '',
+      'Raw API key (shown once):',
+      result.key,
+      '',
+      'Store this value now. It cannot be recovered from the database.',
+    ].join('\n')
+  );
+
+  return 0;
+}
+
+async function listKeys(
+  command: Extract<ParsedCommand, { command: 'list' }>,
+  service: ApiKeyCommandService,
+  io: CommandIo
+): Promise<number> {
+  const keys = await service.listKeys(command.tenantId);
+
+  if (keys.length === 0) {
+    io.stdout(`No mediation API keys found for tenant ${command.tenantId}.`);
+    return 0;
+  }
+
+  io.stdout(
+    [
+      `Mediation API keys for tenant ${command.tenantId}:`,
+      '',
+      ...keys.flatMap((key, index) => [
+        `${index + 1}.`,
+        ...renderKeyMetadata(key).map(line => `   ${line}`),
+        '',
+      ]),
+    ]
+      .join('\n')
+      .trimEnd()
+  );
+
+  return 0;
+}
+
+async function revokeKey(
+  command: Extract<ParsedCommand, { command: 'revoke' }>,
+  service: ApiKeyCommandService,
+  io: CommandIo
+): Promise<number> {
+  const result = await service.revokeKey(command.keyId);
+
+  if (result.status === 'not_found') {
+    io.stderr(`No mediation API key found for key ID ${command.keyId}.`);
+    return 1;
+  }
+
+  if (result.status === 'already_revoked') {
+    io.stdout(
+      ['Mediation API key is already revoked.', ...renderKeyMetadata(result.key)].join('\n')
+    );
+    return 0;
+  }
+
+  io.stdout(['Mediation API key revoked.', ...renderKeyMetadata(result.key)].join('\n'));
+  return 0;
+}
+
+async function createDefaultService(): Promise<CommandServiceHandle> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required to manage mediation API keys.');
+  }
+
+  const { db, closeDb } = await import('../../db/client.js');
+  return { service: new ApiKeyService(db), close: closeDb };
+}
+
+export async function runMediationApiKeyCommand(
+  args: string[],
+  runtime: CommandRuntime = {}
+): Promise<number> {
+  const io = runtime.io ?? defaultIo;
+  const parsed = parseMediationApiKeyCommand(args);
+
+  if (!parsed.ok) {
+    const writer = parsed.exitCode === 0 ? io.stdout : io.stderr;
+    writer(parsed.message);
+    return parsed.exitCode;
+  }
+
+  let handle: CommandServiceHandle | undefined;
+
+  try {
+    handle = runtime.service
+      ? { service: runtime.service }
+      : await (runtime.createService ?? createDefaultService)();
+
+    if (parsed.value.command === 'create') {
+      return await createKey(parsed.value, handle.service, io);
+    }
+
+    if (parsed.value.command === 'list') {
+      return await listKeys(parsed.value, handle.service, io);
+    }
+
+    return await revokeKey(parsed.value, handle.service, io);
+  } catch (error) {
+    io.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  } finally {
+    await handle?.close?.();
+  }
+}
+
+function isEntrypoint(): boolean {
+  return Boolean(process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href);
+}
+
+if (isEntrypoint()) {
+  runMediationApiKeyCommand(process.argv.slice(2)).then(exitCode => {
+    process.exitCode = exitCode;
+  });
+}

--- a/joyus-ai-mcp-server/src/content/mediation/keys.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/keys.ts
@@ -15,13 +15,17 @@ import { contentApiKeys } from '../schema.js';
 
 import { hashApiKey } from './auth.js';
 
-
 export interface CreateKeyInput {
   integrationName: string;
   jwksUri?: string;
   issuer?: string;
   audience?: string;
 }
+
+export type RevokeKeyResult =
+  | { status: 'not_found' }
+  | { status: 'already_revoked'; key: typeof contentApiKeys.$inferSelect }
+  | { status: 'revoked'; key: typeof contentApiKeys.$inferSelect };
 
 export class ApiKeyService {
   constructor(private db: DrizzleClient) {}
@@ -32,8 +36,8 @@ export class ApiKeyService {
    */
   async createKey(
     tenantId: string,
-    input: CreateKeyInput,
-  ): Promise<{ key: string; id: string }> {
+    input: CreateKeyInput
+  ): Promise<{ key: string; id: string; keyPrefix: string }> {
     const rawKey = 'jyk_' + crypto.randomBytes(16).toString('hex');
     const keyHash = hashApiKey(rawKey);
     const keyPrefix = rawKey.substring(0, 8);
@@ -51,26 +55,44 @@ export class ApiKeyService {
       isActive: true,
     });
 
-    return { key: rawKey, id };
+    return { key: rawKey, id, keyPrefix };
   }
 
   /**
    * Deactivate an API key. Does not delete — preserves audit history.
    */
-  async revokeKey(keyId: string): Promise<void> {
-    await this.db
+  async revokeKey(keyId: string): Promise<RevokeKeyResult> {
+    const existingRows = await this.db
+      .select()
+      .from(contentApiKeys)
+      .where(eq(contentApiKeys.id, keyId))
+      .limit(1);
+    const existing = existingRows[0];
+
+    if (!existing) {
+      return { status: 'not_found' };
+    }
+
+    if (!existing.isActive) {
+      return { status: 'already_revoked', key: existing };
+    }
+
+    const updatedRows = await this.db
       .update(contentApiKeys)
       .set({ isActive: false })
-      .where(eq(contentApiKeys.id, keyId));
+      .where(eq(contentApiKeys.id, keyId))
+      .returning();
+
+    return {
+      status: 'revoked',
+      key: updatedRows[0] ?? { ...existing, isActive: false },
+    };
   }
 
   /**
    * List all API keys for a tenant (active and inactive).
    */
   async listKeys(tenantId: string): Promise<Array<typeof contentApiKeys.$inferSelect>> {
-    return this.db
-      .select()
-      .from(contentApiKeys)
-      .where(eq(contentApiKeys.tenantId, tenantId));
+    return this.db.select().from(contentApiKeys).where(eq(contentApiKeys.tenantId, tenantId));
   }
 }

--- a/joyus-ai-mcp-server/tests/content/keys.test.ts
+++ b/joyus-ai-mcp-server/tests/content/keys.test.ts
@@ -6,21 +6,44 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { ApiKeyService } from '../../src/content/mediation/keys.js';
 
-function createMockDb() {
+function createSelectResult(rows: unknown[]) {
+  const query = Promise.resolve(rows) as Promise<unknown[]> & {
+    limit: ReturnType<typeof vi.fn>;
+  };
+  query.limit = vi.fn().mockResolvedValue(rows);
+  return query;
+}
+
+function createMockDb(selectRows: unknown[] = [], returningRows: unknown[] = []) {
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const updateReturning = vi.fn().mockResolvedValue(returningRows);
+  const updateWhere = vi.fn().mockReturnValue({
+    returning: updateReturning,
+  });
+  const updateSet = vi.fn().mockReturnValue({
+    where: updateWhere,
+  });
+  const selectWhere = vi.fn().mockReturnValue(createSelectResult(selectRows));
+
   return {
     insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined),
+      values: insertValues,
     }),
     update: vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
+      set: updateSet,
     }),
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([]),
+        where: selectWhere,
       }),
     }),
+    __mocks: {
+      insertValues,
+      updateReturning,
+      updateWhere,
+      updateSet,
+      selectWhere,
+    },
   } as any;
 }
 
@@ -41,7 +64,18 @@ describe('ApiKeyService', () => {
 
       expect(result.key).toMatch(/^jyk_[0-9a-f]{32}$/);
       expect(result.id).toBeDefined();
+      expect(result.keyPrefix).toBe(result.key.substring(0, 8));
       expect(db.insert).toHaveBeenCalledOnce();
+      expect(db.__mocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant-1',
+          keyHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          keyPrefix: result.keyPrefix,
+          integrationName: 'test-app',
+          isActive: true,
+        })
+      );
+      expect(db.__mocks.insertValues.mock.calls[0][0].keyHash).not.toBe(result.key);
     });
 
     it('passes optional JWKS/issuer/audience to insert', async () => {
@@ -53,13 +87,48 @@ describe('ApiKeyService', () => {
       });
 
       expect(db.insert).toHaveBeenCalledOnce();
+      expect(db.__mocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant-1',
+          integrationName: 'test-app',
+          jwksUri: 'https://example.com/.well-known/jwks.json',
+          issuer: 'https://example.com',
+          audience: 'api',
+          isActive: true,
+        })
+      );
     });
   });
 
   describe('revokeKey', () => {
-    it('sets isActive to false', async () => {
-      await service.revokeKey('key-1');
+    it('sets isActive to false for an active key', async () => {
+      const activeKey = { id: 'key-1', isActive: true };
+      db = createMockDb([activeKey], [{ id: 'key-1', isActive: false }]);
+      service = new ApiKeyService(db);
+
+      const result = await service.revokeKey('key-1');
+
+      expect(result.status).toBe('revoked');
       expect(db.update).toHaveBeenCalledOnce();
+      expect(db.__mocks.updateSet).toHaveBeenCalledWith({ isActive: false });
+    });
+
+    it('reports an already revoked key without updating it again', async () => {
+      const inactiveKey = { id: 'key-1', isActive: false };
+      db = createMockDb([inactiveKey]);
+      service = new ApiKeyService(db);
+
+      const result = await service.revokeKey('key-1');
+
+      expect(result.status).toBe('already_revoked');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('reports a missing key without updating anything', async () => {
+      const result = await service.revokeKey('missing-key');
+
+      expect(result.status).toBe('not_found');
+      expect(db.update).not.toHaveBeenCalled();
     });
   });
 

--- a/joyus-ai-mcp-server/tests/content/mediation-api-key-cli.test.ts
+++ b/joyus-ai-mcp-server/tests/content/mediation-api-key-cli.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ContentApiKey } from '../../src/content/schema.js';
+import {
+  type ApiKeyCommandService,
+  runMediationApiKeyCommand,
+} from '../../src/content/mediation/api-key-cli.js';
+
+function apiKeyRecord(overrides: Partial<ContentApiKey> = {}): ContentApiKey {
+  return {
+    id: 'key-1',
+    tenantId: 'tenant-1',
+    keyHash: 'stored-hash-that-must-not-print',
+    keyPrefix: 'jyk_list',
+    integrationName: 'Example Integration',
+    jwksUri: 'https://idp.example.com/.well-known/jwks.json',
+    issuer: null,
+    audience: null,
+    isActive: true,
+    lastUsedAt: null,
+    createdAt: new Date('2026-05-25T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createService(overrides: Partial<ApiKeyCommandService> = {}): ApiKeyCommandService {
+  return {
+    createKey: vi.fn().mockResolvedValue({
+      id: 'key-1',
+      key: 'jyk_raw_secret_1234567890',
+      keyPrefix: 'jyk_raw',
+    }),
+    listKeys: vi.fn().mockResolvedValue([]),
+    revokeKey: vi.fn().mockResolvedValue({
+      status: 'revoked',
+      key: apiKeyRecord({ isActive: false }),
+    }),
+    ...overrides,
+  };
+}
+
+async function runCommand(args: string[], service: ApiKeyCommandService) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const exitCode = await runMediationApiKeyCommand(args, {
+    service,
+    io: {
+      stdout: message => stdout.push(message),
+      stderr: message => stderr.push(message),
+    },
+  });
+
+  return {
+    exitCode,
+    stdout: stdout.join('\n'),
+    stderr: stderr.join('\n'),
+  };
+}
+
+describe('mediation API key CLI', () => {
+  it('creates a key, passes metadata to the service, and prints the raw key exactly once', async () => {
+    const service = createService();
+
+    const result = await runCommand(
+      [
+        'create',
+        '--tenant-id',
+        'tenant-1',
+        '--integration-name',
+        'Example Integration',
+        '--jwks-uri',
+        'https://idp.example.com/.well-known/jwks.json',
+        '--issuer',
+        'https://idp.example.com',
+        '--audience',
+        'api://mediation',
+      ],
+      service
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(service.createKey).toHaveBeenCalledWith('tenant-1', {
+      integrationName: 'Example Integration',
+      jwksUri: 'https://idp.example.com/.well-known/jwks.json',
+      issuer: 'https://idp.example.com',
+      audience: 'api://mediation',
+    });
+    expect(result.stdout.match(/jyk_raw_secret_1234567890/g)).toHaveLength(1);
+    expect(result.stdout).toContain('Key ID: key-1');
+    expect(result.stdout).toContain('Key prefix: jyk_raw');
+  });
+
+  it('lists only safe key metadata without raw keys or hashes', async () => {
+    const service = createService({
+      listKeys: vi.fn().mockResolvedValue([
+        apiKeyRecord({
+          keyHash: 'do-not-print-this-hash',
+          keyPrefix: 'jyk_safe',
+        }),
+      ]),
+    });
+
+    const result = await runCommand(['list', '--tenant-id', 'tenant-1'], service);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Key prefix: jyk_safe');
+    expect(result.stdout).toContain('Integration: Example Integration');
+    expect(result.stdout).not.toContain('do-not-print-this-hash');
+    expect(result.stdout).not.toContain('keyHash');
+  });
+
+  it('revokes a key and prints safe metadata', async () => {
+    const service = createService();
+
+    const result = await runCommand(['revoke', '--key-id', 'key-1'], service);
+
+    expect(result.exitCode).toBe(0);
+    expect(service.revokeKey).toHaveBeenCalledWith('key-1');
+    expect(result.stdout).toContain('Mediation API key revoked.');
+    expect(result.stdout).toContain('Active: no');
+    expect(result.stdout).not.toContain('stored-hash-that-must-not-print');
+  });
+
+  it('handles missing and already revoked keys predictably', async () => {
+    const missingService = createService({
+      revokeKey: vi.fn().mockResolvedValue({ status: 'not_found' }),
+    });
+    const missing = await runCommand(['revoke', '--key-id', 'missing-key'], missingService);
+
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain('No mediation API key found');
+
+    const alreadyRevokedService = createService({
+      revokeKey: vi.fn().mockResolvedValue({
+        status: 'already_revoked',
+        key: apiKeyRecord({ isActive: false }),
+      }),
+    });
+    const alreadyRevoked = await runCommand(['revoke', '--key-id', 'key-1'], alreadyRevokedService);
+
+    expect(alreadyRevoked.exitCode).toBe(0);
+    expect(alreadyRevoked.stdout).toContain('already revoked');
+  });
+
+  it('fails invalid create inputs before calling the service', async () => {
+    const service = createService();
+
+    const missingRequired = await runCommand(
+      ['create', '--tenant-id', 'tenant-1', '--integration-name', 'Example Integration'],
+      service
+    );
+
+    expect(missingRequired.exitCode).toBe(1);
+    expect(missingRequired.stderr).toContain('Missing required option: --jwks-uri');
+    expect(service.createKey).not.toHaveBeenCalled();
+
+    const invalidUrl = await runCommand(
+      [
+        'create',
+        '--tenant-id',
+        'tenant-1',
+        '--integration-name',
+        'Example Integration',
+        '--jwks-uri',
+        'not-a-url',
+      ],
+      service
+    );
+
+    expect(invalidUrl.exitCode).toBe(1);
+    expect(invalidUrl.stderr).toContain('Invalid URL for --jwks-uri');
+    expect(service.createKey).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add operator commands for creating, listing, and revoking mediation API keys
- preserve one-time raw key display while keeping stored values hashed
- document the local mediation API key testing workflow

## Tests
- npm run build
- npm run lint
- npm run db:check
- npm test -- tests/content/keys.test.ts tests/content/mediation-api-key-cli.test.ts
- npm run mediation-api-keys -- --help
- npm test

Closes #60