### PR TITLE
[codex] Clean up legacy Spec Governance findings

### DIFF
--- a/.github/workflows/spec-governance.yml
+++ b/.github/workflows/spec-governance.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Run governance checks (P0 merge gate)
+      - name: Run governance checks (P0 merge gate with accepted legacy baseline)
         run: |
           python scripts/spec-governance-check.py

--- a/governance/spec-governance-baseline.json
+++ b/governance/spec-governance-baseline.json
@@ -1,0 +1,104 @@
+{
+  "description": "Accepted legacy Spec Governance findings. These entries document known pre-vNext debt so new findings remain visible while the P0 merge gate stays honest.",
+  "created_at": "2026-05-25",
+  "findings": [
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/002-session-context-management/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: aws, docker, mcp server",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/003-platform-architecture-overview/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: aws, docker, mcp server",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/004-workflow-enforcement/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: aws, mcp server",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/005-content-intelligence/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: aws, jwt, python, spacy",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/006-content-infrastructure/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: mysql, postgresql",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/009-automated-pipelines-framework/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: express",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/010-inngest-evaluation/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: express, mcp server, redis, typescript",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/011-inngest-migration/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: docker, redis, typescript",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "CHK-001",
+      "severity": "P1",
+      "target": "kitty-specs/platform-core-orchestrator-01KREQVK/spec.md",
+      "message": "Checklist claims no implementation details, but spec contains technical terms: express, jwt, mcp server, python, typescript",
+      "reason": "Legacy checklist/spec wording predates current checklist consistency policy."
+    },
+    {
+      "check_id": "PLAT-002",
+      "severity": "P2",
+      "target": "kitty-specs/002-session-context-management/spec.md",
+      "message": "Legacy platform feature missing vNext sections: adoption plan, roi metrics, security + mcp governance",
+      "reason": "Legacy platform spec predates the vNext platform-section contract."
+    },
+    {
+      "check_id": "PLAT-002",
+      "severity": "P2",
+      "target": "kitty-specs/003-platform-architecture-overview/spec.md",
+      "message": "Legacy platform feature missing vNext sections: adoption plan, roi metrics, security + mcp governance",
+      "reason": "Legacy platform spec predates the vNext platform-section contract."
+    },
+    {
+      "check_id": "PLAT-002",
+      "severity": "P2",
+      "target": "kitty-specs/004-workflow-enforcement/spec.md",
+      "message": "Legacy platform feature missing vNext sections: adoption plan, roi metrics, security + mcp governance",
+      "reason": "Legacy platform spec predates the vNext platform-section contract."
+    },
+    {
+      "check_id": "PLAT-002",
+      "severity": "P2",
+      "target": "kitty-specs/005-content-intelligence/spec.md",
+      "message": "Legacy platform feature missing vNext sections: adoption plan, roi metrics, security + mcp governance",
+      "reason": "Legacy platform spec predates the vNext platform-section contract."
+    },
+    {
+      "check_id": "PLAT-002",
+      "severity": "P2",
+      "target": "kitty-specs/006-content-infrastructure/spec.md",
+      "message": "Legacy platform feature missing vNext sections: adoption plan, roi metrics, security + mcp governance",
+      "reason": "Legacy platform spec predates the vNext platform-section contract."
+    }
+  ]
+}

--- a/scripts/spec-governance-check.py
+++ b/scripts/spec-governance-check.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+DEFAULT_BASELINE_PATH = "governance/spec-governance-baseline.json"
+
 REQUIRED_META_KEYS = [
     "feature_number",
     "slug",
@@ -107,9 +109,143 @@ SCOPE_MARKDOWN_FILES = [
 class Finding:
     check_id: str
     severity: str  # P0/P1/P2
-    status: str  # fail/warn
+    status: str  # fail/warn/accepted
     target: str
     message: str
+
+
+def _finding_key(finding: Finding) -> tuple[str, str, str, str]:
+    return (
+        finding.check_id,
+        finding.severity,
+        finding.target,
+        finding.message,
+    )
+
+
+def _normalize_status(finding: Finding) -> Finding:
+    if finding.status == "fail" and finding.severity != "P0":
+        return Finding(
+            finding.check_id,
+            finding.severity,
+            "warn",
+            finding.target,
+            finding.message,
+        )
+    return finding
+
+
+def _baseline_path(root: Path, baseline_arg: str, no_baseline: bool) -> Path | None:
+    if no_baseline:
+        return None
+    baseline_path = Path(baseline_arg)
+    if not baseline_path.is_absolute():
+        baseline_path = root / baseline_path
+    return baseline_path
+
+
+def _load_baseline(root: Path, baseline_path: Path | None) -> tuple[set[tuple[str, str, str, str]], list[Finding]]:
+    if baseline_path is None or not baseline_path.exists():
+        return set(), []
+
+    target = str(baseline_path.relative_to(root)) if baseline_path.is_relative_to(root) else str(baseline_path)
+
+    try:
+        data = json.loads(baseline_path.read_text())
+    except Exception as exc:
+        return set(), [
+            Finding(
+                "BASE-001",
+                "P0",
+                "fail",
+                target,
+                f"Baseline file is invalid JSON: {exc}",
+            )
+        ]
+
+    entries = data.get("findings") if isinstance(data, dict) else data
+    if not isinstance(entries, list):
+        return set(), [
+            Finding(
+                "BASE-001",
+                "P0",
+                "fail",
+                target,
+                "Baseline file must contain a findings list",
+            )
+        ]
+
+    baseline_keys: set[tuple[str, str, str, str]] = set()
+    errors: list[Finding] = []
+    required = ["check_id", "severity", "target", "message"]
+
+    for index, entry in enumerate(entries):
+        entry_target = f"{target}#{index + 1}"
+        if not isinstance(entry, dict):
+            errors.append(
+                Finding("BASE-001", "P0", "fail", entry_target, "Baseline entry must be an object")
+            )
+            continue
+
+        missing = [key for key in required if not entry.get(key)]
+        if missing:
+            errors.append(
+                Finding(
+                    "BASE-001",
+                    "P0",
+                    "fail",
+                    entry_target,
+                    "Baseline entry missing required keys: " + ", ".join(missing),
+                )
+            )
+            continue
+
+        severity = str(entry["severity"])
+        if severity == "P0":
+            errors.append(
+                Finding(
+                    "BASE-002",
+                    "P0",
+                    "fail",
+                    entry_target,
+                    "Baseline entries cannot accept P0 findings",
+                )
+            )
+            continue
+
+        baseline_keys.add(
+            (
+                str(entry["check_id"]),
+                severity,
+                str(entry["target"]),
+                str(entry["message"]),
+            )
+        )
+
+    return baseline_keys, errors
+
+
+def _split_baselined_findings(
+    findings: list[Finding], baseline_keys: set[tuple[str, str, str, str]]
+) -> tuple[list[Finding], list[Finding]]:
+    active: list[Finding] = []
+    accepted: list[Finding] = []
+
+    for finding in findings:
+        if _finding_key(finding) in baseline_keys:
+            accepted.append(
+                Finding(
+                    finding.check_id,
+                    finding.severity,
+                    "accepted",
+                    finding.target,
+                    finding.message,
+                )
+            )
+        else:
+            active.append(finding)
+
+    return active, accepted
 
 
 def _iter_feature_dirs(root: Path) -> Iterable[Path]:
@@ -468,7 +604,7 @@ def check_platform_sections(root: Path) -> list[Finding]:
     return findings
 
 
-def _to_markdown_report(root: Path, findings: list[Finding]) -> str:
+def _to_markdown_report(root: Path, findings: list[Finding], accepted_baseline: list[Finding]) -> str:
     fails = [f for f in findings if f.status == "fail"]
     warns = [f for f in findings if f.status == "warn"]
     p0 = [f for f in findings if f.severity == "P0" and f.status == "fail"]
@@ -479,24 +615,37 @@ def _to_markdown_report(root: Path, findings: list[Finding]) -> str:
     lines.append(f"Generated from `{root}`")
     lines.append("")
     lines.append("## Summary")
-    lines.append(f"- Total findings: {len(findings)}")
-    lines.append(f"- Fails: {len(fails)}")
+    lines.append(f"- Active findings: {len(findings)}")
+    lines.append(f"- Blocking failures: {len(fails)}")
     lines.append(f"- Warnings: {len(warns)}")
-    lines.append(f"- P0 fails: {len(p0)}")
+    lines.append(f"- Accepted baseline findings: {len(accepted_baseline)}")
+    lines.append(f"- P0 blocking failures: {len(p0)}")
     lines.append("")
 
     if not findings:
-        lines.append("No findings. Governance checks passed.")
-        return "\n".join(lines)
+        lines.append("No active findings. Governance checks passed.")
+    else:
+        lines.append("## Active Findings")
+        lines.append("")
+        lines.append("| Check | Severity | Status | Target | Message |")
+        lines.append("|---|---|---|---|---|")
+        for f in findings:
+            lines.append(
+                f"| {f.check_id} | {f.severity} | {f.status} | `{f.target}` | {f.message.replace('|', '/')} |"
+            )
 
-    lines.append("## Findings")
-    lines.append("")
-    lines.append("| Check | Severity | Status | Target | Message |")
-    lines.append("|---|---|---|---|---|")
-    for f in findings:
-        lines.append(
-            f"| {f.check_id} | {f.severity} | {f.status} | `{f.target}` | {f.message.replace('|', '/')} |"
-        )
+    if accepted_baseline:
+        lines.append("")
+        lines.append("## Accepted Baseline Findings")
+        lines.append("")
+        lines.append("These findings are known legacy debt and do not block the P0 merge gate.")
+        lines.append("")
+        lines.append("| Check | Severity | Status | Target | Message |")
+        lines.append("|---|---|---|---|---|")
+        for f in accepted_baseline:
+            lines.append(
+                f"| {f.check_id} | {f.severity} | {f.status} | `{f.target}` | {f.message.replace('|', '/')} |"
+            )
 
     return "\n".join(lines)
 
@@ -507,36 +656,50 @@ def main() -> None:
     parser.add_argument("--strict", action="store_true", help="Fail on any fail/warn finding")
     parser.add_argument("--report", default="", help="Optional markdown report output path")
     parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    parser.add_argument(
+        "--baseline",
+        default=DEFAULT_BASELINE_PATH,
+        help=f"Accepted legacy finding baseline path (default: {DEFAULT_BASELINE_PATH})",
+    )
+    parser.add_argument("--no-baseline", action="store_true", help="Disable accepted legacy baseline")
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
 
-    findings: list[Finding] = []
-    findings.extend(check_artifacts_and_metadata(root))
-    findings.extend(check_markdown_links(root))
-    findings.extend(check_constitution_sync(root))
-    findings.extend(check_checklist_consistency(root))
-    findings.extend(check_platform_sections(root))
+    raw_findings: list[Finding] = []
+    raw_findings.extend(check_artifacts_and_metadata(root))
+    raw_findings.extend(check_markdown_links(root))
+    raw_findings.extend(check_constitution_sync(root))
+    raw_findings.extend(check_checklist_consistency(root))
+    raw_findings.extend(check_platform_sections(root))
+
+    normalized_findings = [_normalize_status(finding) for finding in raw_findings]
+    baseline_path = _baseline_path(root, args.baseline, args.no_baseline)
+    baseline_keys, baseline_errors = _load_baseline(root, baseline_path)
+    findings, accepted_baseline = _split_baselined_findings(normalized_findings, baseline_keys)
+    findings = baseline_errors + findings
 
     if args.report:
         report_path = Path(args.report)
         if not report_path.is_absolute():
             report_path = root / report_path
         report_path.parent.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(_to_markdown_report(root, findings))
+        report_path.write_text(_to_markdown_report(root, findings, accepted_baseline))
 
     if args.json:
         print(
             json.dumps(
                 {
                     "root": str(root),
+                    "baseline": str(baseline_path) if baseline_path else None,
                     "findings": [f.__dict__ for f in findings],
+                    "accepted_baseline": [f.__dict__ for f in accepted_baseline],
                 },
                 indent=2,
             )
         )
     else:
-        print(_to_markdown_report(root, findings))
+        print(_to_markdown_report(root, findings, accepted_baseline))
 
     p0_fails = [f for f in findings if f.status == "fail" and f.severity == "P0"]
     any_fails = [f for f in findings if f.status == "fail"]

--- a/scripts/test_spec_governance_check.py
+++ b/scripts/test_spec_governance_check.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Focused tests for scripts/spec-governance-check.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("spec-governance-check.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("spec_governance_check", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_module()
+
+
+class SpecGovernanceCheckTest(unittest.TestCase):
+    def _write_governance_skeleton(self, root: Path) -> None:
+        (root / "spec").mkdir(parents=True)
+        (root / "spec" / "constitution.md").write_text("# Constitution\n")
+
+        charter_dir = root / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text("# Charter\n")
+        (charter_dir / "governance.yaml").write_text("{}\n")
+        (charter_dir / "directives.yaml").write_text("{}\n")
+        (charter_dir / "metadata.yaml").write_text("{}\n")
+
+    def _write_low_risk_feature(self, root: Path) -> None:
+        feature_dir = root / "kitty-specs" / "001-example"
+        (feature_dir / "checklists").mkdir(parents=True)
+        (feature_dir / "meta.json").write_text(
+            json.dumps(
+                {
+                    "feature_number": "001",
+                    "slug": "example",
+                    "friendly_name": "Example Capability",
+                    "mission": "software-dev",
+                    "created_at": "2026-05-25",
+                    "measurement_owner": "Platform Owner",
+                    "review_cadence": "monthly",
+                    "risk_class": "low",
+                    "lifecycle_state": "spec-only",
+                }
+            )
+        )
+        (feature_dir / "spec.md").write_text("# Spec\nThis example mentions Python.\n")
+        (feature_dir / "checklists" / "requirements.md").write_text(
+            "- [x] No implementation details (languages, frameworks, APIs)\n"
+        )
+
+    def _run_checker(self, root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--root", str(root), "--json", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_non_p0_failures_are_reported_as_warnings(self) -> None:
+        finding = checker.Finding("CHK-001", "P1", "fail", "target.md", "message")
+        normalized = checker._normalize_status(finding)
+
+        self.assertEqual(normalized.status, "warn")
+
+    def test_p0_failures_remain_blocking_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_governance_skeleton(root)
+            (root / "kitty-specs" / "001-example").mkdir(parents=True)
+
+            result = self._run_checker(root)
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(payload["findings"][0]["check_id"], "ART-001")
+            self.assertEqual(payload["findings"][0]["severity"], "P0")
+            self.assertEqual(payload["findings"][0]["status"], "fail")
+
+    def test_new_unbaselined_p1_findings_remain_visible_and_strict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_governance_skeleton(root)
+            self._write_low_risk_feature(root)
+
+            result = self._run_checker(root)
+            payload = json.loads(result.stdout)
+            strict_result = self._run_checker(root, "--strict")
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(len(payload["findings"]), 1)
+            self.assertEqual(payload["findings"][0]["check_id"], "CHK-001")
+            self.assertEqual(payload["findings"][0]["severity"], "P1")
+            self.assertEqual(payload["findings"][0]["status"], "warn")
+            self.assertEqual(payload["accepted_baseline"], [])
+            self.assertEqual(strict_result.returncode, 1)
+
+    def test_accepted_legacy_findings_are_reported_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_governance_skeleton(root)
+            self._write_low_risk_feature(root)
+
+            baseline_dir = root / "governance"
+            baseline_dir.mkdir()
+            (baseline_dir / "spec-governance-baseline.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "check_id": "CHK-001",
+                                "severity": "P1",
+                                "target": "kitty-specs/001-example/spec.md",
+                                "message": "Checklist claims no implementation details, but spec contains technical terms: python",
+                            }
+                        ]
+                    }
+                )
+            )
+
+            result = self._run_checker(root, "--strict")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(payload["findings"], [])
+            self.assertEqual(len(payload["accepted_baseline"]), 1)
+            self.assertEqual(payload["accepted_baseline"][0]["status"], "accepted")
+
+    def test_baseline_cannot_accept_p0_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_governance_skeleton(root)
+
+            baseline_dir = root / "governance"
+            baseline_dir.mkdir()
+            (baseline_dir / "spec-governance-baseline.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "check_id": "ART-001",
+                                "severity": "P0",
+                                "target": "kitty-specs/001-example",
+                                "message": "Missing meta.json",
+                            }
+                        ]
+                    }
+                )
+            )
+
+            result = self._run_checker(root)
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(payload["findings"][0]["check_id"], "BASE-002")
+            self.assertEqual(payload["findings"][0]["status"], "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/spec-governance.md
+++ b/spec/spec-governance.md
@@ -152,6 +152,18 @@ Severity model:
 - P1: must-fix governance debt.
 - P2: improvement backlog.
 
+Status model:
+- `fail`: active P0 finding that blocks the default CI merge gate.
+- `warn`: active non-P0 finding that remains visible and must be triaged, but does not block the default P0 merge gate.
+- `accepted`: explicitly baselined legacy P1/P2 finding recorded in `governance/spec-governance-baseline.json`.
+
+Default CI policy:
+- The Spec Governance workflow runs `python scripts/spec-governance-check.py`.
+- Active P0 findings fail CI.
+- Active P1/P2 findings are reported as warnings and do not fail the default P0 merge gate.
+- Accepted baseline findings are reported separately as known legacy debt and do not fail CI.
+- `--strict` is available for local or future CI modes that should fail on any active fail/warn finding. Accepted baseline findings remain nonblocking in strict mode.
+
 ---
 
 ## 9. Source-of-Truth Freshness


### PR DESCRIPTION
## Summary
- baseline legacy nonblocking Spec Governance findings so default output has zero active findings
- clarify governance-check severity/status wording for P0 failures, nonblocking warnings, and accepted baseline entries
- document default CI behavior and add focused fixture coverage for baseline/status behavior

## Tests
- python3 scripts/spec-governance-check.py
- python3 scripts/spec-governance-check.py --strict
- python3 -m unittest scripts/test_spec_governance_check.py
- python3 -m py_compile scripts/spec-governance-check.py scripts/test_spec_governance_check.py
- git diff --check
- joyus-ai-mcp-server: npm run build
- joyus-ai-mcp-server: npm run lint
- joyus-ai-mcp-server: npm run db:check
- joyus-ai-mcp-server: npm test
- joyus-ai-state: npm run build
- joyus-ai-state: npm test

Closes #66