### PR TITLE
[codex] Evaluate AGUI for mediation approvals

### DIFF
--- a/joyus-ai-mcp-server/docs/AGUI_MEDIATION_APPROVALS.md
+++ b/joyus-ai-mcp-server/docs/AGUI_MEDIATION_APPROVALS.md
@@ -1,0 +1,121 @@
+# AG-UI Mediation Approval Design
+
+Status: issue #72 evaluation and proof of concept
+Last refreshed: 2026-05-25
+
+## Source Refresh
+
+The current AG-UI docs describe AG-UI as a lightweight, event-based protocol between user-facing applications and agent backends. The architecture remains transport-flexible: an endpoint can accept `RunAgentInput` and stream `BaseEvent` objects over HTTP SSE, binary HTTP, WebSockets, or another adapter. The event set includes lifecycle, step, message, tool, state, raw, and custom events. `STATE_DELTA` uses JSON Patch operations, and `CUSTOM` carries application-specific event names and values.
+
+Sources checked:
+
+- [AG-UI overview](https://docs.ag-ui.com/introduction)
+- [AG-UI core architecture](https://docs.ag-ui.com/concepts/architecture)
+- [AG-UI JavaScript event model](https://docs.ag-ui.com/sdk/js/core/events)
+- [CopilotKit AG-UI docs](https://docs.copilotkit.ai/langgraph-python/ag-ui)
+- [Mastra and CopilotKit AG-UI starter note](https://mastra.ai/blog/copilotkitmastra)
+- [LangGraph interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts)
+
+## Recommendation
+
+Use a thin local AG-UI-compatible adapter for the first approval slice.
+
+This keeps the first implementation aligned with the existing TypeScript MCP server, Inngest-backed orchestration, and the judge layer from issue #71. It avoids adopting a larger frontend or graph runtime before the product has a stable review UI surface. CopilotKit remains the strongest candidate once a React approval UI exists. Mastra should be revisited only as part of the broader orchestrator runtime decision. LangGraph is useful prior art for interrupt semantics, but it is a heavier runtime fit here.
+
+## Protocol Mapping
+
+| Judge outcome     | Platform state                                  | AG-UI event mapping                                                                                    | User decision needed       |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `allow`           | `completed`                                     | No approval event. Normal mediation response proceeds.                                                 | No                         |
+| `block`           | `blocked`                                       | Terminal response with judge summary. Future clients may render a non-actionable `CUSTOM` event.       | No                         |
+| `revise`          | `awaiting_revision`                             | `RUN_STARTED`, `STATE_DELTA /mediationApproval`, `CUSTOM mediation.approval.requested`, `RUN_FINISHED` | Yes, editable              |
+| `escalate`        | `awaiting_approval`                             | `RUN_STARTED`, `STATE_DELTA /mediationApproval`, `CUSTOM mediation.approval.requested`, `RUN_FINISHED` | Yes, approve/reject/revise |
+| approval response | `approved`, `rejected`, or `revision_submitted` | `CUSTOM mediation.approval.decided`                                                                    | No, resumes server flow    |
+
+The custom request event value is `MediationApprovalRequest`. It includes:
+
+- `approvalRequestId`
+- `actionProposalId`
+- `judgmentId`
+- `judgeOutcome`
+- `actionType`
+- `actionTarget`
+- `payloadSummary`
+- `payloadRef`
+- `judgment.reasonCode`, `judgment.summary`, `judgment.policyVersion`, `judgment.judgedAt`
+- optional `requiredRevision`
+- optional `escalation`
+- deterministic `expiresAt`
+- `responseContract`
+- `resume.requestId`, `resume.sessionId`, `resume.actionProposalId`, `resume.judgmentId`
+
+The event intentionally excludes raw authorization context, raw evidence, judge criteria, API keys, tenant IDs, user IDs, profile authorization lists, source authorization lists, and generated response text.
+
+## Response Contract
+
+Clients submit one of three decisions:
+
+| Decision            | Required fields                                                 | Server next action |
+| ------------------- | --------------------------------------------------------------- | ------------------ |
+| `approve`           | `approvalRequestId`, `actionProposalId`                         | `execute`          |
+| `reject`            | `approvalRequestId`, `actionProposalId`                         | `cancel`           |
+| `revise_with_edits` | `approvalRequestId`, `actionProposalId`, `editedPayloadSummary` | `rerun_judge`      |
+
+The current proof of concept is type-level and serialization-level. A follow-on route should persist the request, validate the authenticated requester, and only then execute, cancel, or re-run the judge.
+
+## Integration Design
+
+Current mediation flow:
+
+1. The mediation router validates integration and user auth.
+2. `GenerationService` produces a response proposal.
+3. `createMediationResponseProposal()` converts the generated response into an `ActionProposal`.
+4. `MediationJudgeService` returns `allow`, `block`, `revise`, or `escalate`.
+5. `allow` proceeds to response delivery.
+6. `block`, `revise`, and `escalate` halt delivery.
+
+The adapter added for issue #72 fits between steps 4 and 6:
+
+```ts
+const judgment = await judgeService.judge(proposal);
+const events = createMediationApprovalAguiEvents(proposal, judgment, {
+  approvalRequestId,
+  now,
+});
+```
+
+Initial event transport can be either:
+
+- response-embedded event objects for a narrow mediation API prototype, or
+- an SSE stream mounted beside the existing session/event routes.
+
+The second path is the recommended production direction. It lets authenticated clients subscribe once, render judge pauses in real time, and send a separate decision command.
+
+## Library Comparison
+
+| Option                   | Fit         | Strength                                                                                         | Risk                                                                                            | Recommendation                     |
+| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Thin local AG-UI adapter | High        | Minimal dependency change, matches existing TypeScript services, works with current judge output | More UI glue later                                                                              | Use now                            |
+| CopilotKit               | Medium-high | AG-UI-native React hooks, subscriptions, and frontend state                                      | Introduces frontend framework assumptions before review UI is settled                           | Revisit for UI implementation      |
+| Mastra                   | Medium      | TypeScript-native agent/workflow runtime with visible AG-UI path                                 | Larger runtime adoption decision and overlap with existing orchestration                        | Defer to orchestrator runtime work |
+| LangGraph                | Medium-low  | Mature interrupt/resume and checkpoint model                                                     | Runtime mismatch and heavier graph semantics; side effects before interrupts must be idempotent | Use as semantic reference only     |
+
+## Proof of Concept
+
+Implemented in `src/content/mediation/agui.ts`:
+
+- creates deterministic approval requests for `revise` and `escalate`
+- emits AG-UI-compatible `RUN_STARTED`, `STATE_DELTA`, `CUSTOM`, and `RUN_FINISHED` events
+- models approval responses as `approve`, `reject`, and `revise_with_edits`
+- maps responses to `execute`, `cancel`, and `rerun_judge`
+- keeps event payloads minimized for public-safe client rendering
+
+Test coverage in `tests/content/mediation/agui.test.ts` asserts event stability, expiry behavior, response validation, resume/audit IDs, and payload minimization.
+
+## Follow-on Work
+
+- Persist approval requests so decisions can be validated against server state.
+- Add an authenticated decision endpoint.
+- Stream approval events via SSE rather than returning static arrays.
+- Wire the approved path to execute the original action only after the persisted decision matches the proposal and judgment.
+- Add a review UI after the event contract stabilizes.

--- a/joyus-ai-mcp-server/src/content/mediation/agui.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/agui.ts
@@ -1,0 +1,292 @@
+import { createId } from '@paralleldrive/cuid2';
+
+import type {
+  ActionProposal,
+  ActionProposalType,
+  ActionProposalTargetEntityType,
+  JudgeResult,
+} from '../types.js';
+
+export const MEDIATION_APPROVAL_AGUI_VERSION = 'mediation-approval-agui-v1';
+export const DEFAULT_MEDIATION_APPROVAL_TTL_MS = 48 * 60 * 60 * 1000;
+
+export const MEDIATION_APPROVAL_AGUI_EVENT_NAMES = {
+  requested: 'mediation.approval.requested',
+  decided: 'mediation.approval.decided',
+} as const;
+
+export const MEDIATION_APPROVAL_DECISIONS = ['approve', 'reject', 'revise_with_edits'] as const;
+
+export type MediationApprovalDecision = (typeof MEDIATION_APPROVAL_DECISIONS)[number];
+export type MediationApprovalKind = 'approval_request' | 'revision_request';
+export type MediationApprovalNextAction = 'execute' | 'cancel' | 'rerun_judge';
+
+export interface AguiBaseEvent {
+  type: string;
+  timestamp?: number;
+  rawEvent?: unknown;
+}
+
+export interface AguiRunStartedEvent extends AguiBaseEvent {
+  type: 'RUN_STARTED';
+  threadId: string;
+  runId: string;
+  parentRunId?: string;
+}
+
+export interface AguiRunFinishedEvent extends AguiBaseEvent {
+  type: 'RUN_FINISHED';
+  threadId: string;
+  runId: string;
+  result?: unknown;
+}
+
+export interface AguiStateDeltaEvent extends AguiBaseEvent {
+  type: 'STATE_DELTA';
+  delta: Array<{
+    op: 'add' | 'replace' | 'remove';
+    path: string;
+    value?: unknown;
+  }>;
+}
+
+export interface AguiCustomEvent extends AguiBaseEvent {
+  type: 'CUSTOM';
+  name: string;
+  value: unknown;
+}
+
+export type MediationApprovalAguiEvent =
+  | AguiRunStartedEvent
+  | AguiStateDeltaEvent
+  | AguiCustomEvent
+  | AguiRunFinishedEvent;
+
+export interface MediationApprovalRequest {
+  version: typeof MEDIATION_APPROVAL_AGUI_VERSION;
+  approvalRequestId: string;
+  kind: MediationApprovalKind;
+  status: 'awaiting_user_decision';
+  actionProposalId: string;
+  judgmentId: string;
+  judgeOutcome: 'revise' | 'escalate';
+  actionType: ActionProposalType;
+  actionTarget: {
+    entityType: ActionProposalTargetEntityType;
+    entityId: string;
+  };
+  payloadSummary: string;
+  payloadRef?: {
+    type: string;
+    id: string;
+  };
+  judgment: {
+    reasonCode: string;
+    summary: string;
+    policyVersion: string;
+    judgedAt: string;
+  };
+  requiredRevision?: JudgeResult['requiredRevision'];
+  escalation?: JudgeResult['escalation'];
+  expiresAt: string;
+  responseContract: {
+    decisions: readonly MediationApprovalDecision[];
+    reviseWithEditsRequires: readonly ['editedPayloadSummary'];
+  };
+  resume: {
+    requestId: string | null;
+    sessionId: string | null;
+    actionProposalId: string;
+    judgmentId: string;
+  };
+}
+
+export interface CreateMediationApprovalRequestOptions {
+  approvalRequestId?: string;
+  now?: Date;
+  ttlMs?: number;
+}
+
+export interface CreateMediationApprovalEventsOptions extends CreateMediationApprovalRequestOptions {
+  threadId?: string;
+  runId?: string;
+  parentRunId?: string;
+}
+
+export interface CreateMediationApprovalResponseInput {
+  approvalRequestId: string;
+  actionProposalId: string;
+  decision: MediationApprovalDecision;
+  decidedAt?: Date;
+  reviewerNote?: string;
+  editedPayloadSummary?: string;
+  editedPayloadRef?: {
+    type: string;
+    id: string;
+  };
+}
+
+export interface MediationApprovalResponse {
+  version: typeof MEDIATION_APPROVAL_AGUI_VERSION;
+  approvalRequestId: string;
+  actionProposalId: string;
+  decision: MediationApprovalDecision;
+  nextAction: MediationApprovalNextAction;
+  decidedAt: string;
+  reviewerNote?: string;
+  editedPayloadSummary?: string;
+  editedPayloadRef?: {
+    type: string;
+    id: string;
+  };
+}
+
+function isApprovalDecision(value: string): value is MediationApprovalDecision {
+  return MEDIATION_APPROVAL_DECISIONS.includes(value as MediationApprovalDecision);
+}
+
+function expiresAt(now: Date, ttlMs: number): string {
+  return new Date(now.getTime() + ttlMs).toISOString();
+}
+
+function approvalKindFor(judgment: JudgeResult): MediationApprovalKind {
+  return judgment.outcome === 'revise' ? 'revision_request' : 'approval_request';
+}
+
+function nextActionFor(decision: MediationApprovalDecision): MediationApprovalNextAction {
+  if (decision === 'approve') return 'execute';
+  if (decision === 'reject') return 'cancel';
+  return 'rerun_judge';
+}
+
+export function createMediationApprovalRequest(
+  proposal: ActionProposal,
+  judgment: JudgeResult,
+  options: CreateMediationApprovalRequestOptions = {}
+): MediationApprovalRequest {
+  if (judgment.outcome !== 'revise' && judgment.outcome !== 'escalate') {
+    throw new Error(`Cannot create approval request for ${judgment.outcome} judgment`);
+  }
+
+  const now = options.now ?? new Date();
+  const ttlMs = options.ttlMs ?? DEFAULT_MEDIATION_APPROVAL_TTL_MS;
+
+  return {
+    version: MEDIATION_APPROVAL_AGUI_VERSION,
+    approvalRequestId: options.approvalRequestId ?? createId(),
+    kind: approvalKindFor(judgment),
+    status: 'awaiting_user_decision',
+    actionProposalId: proposal.id,
+    judgmentId: judgment.id,
+    judgeOutcome: judgment.outcome,
+    actionType: proposal.action.type,
+    actionTarget: {
+      entityType: proposal.action.target.entityType,
+      entityId: proposal.action.target.entityId,
+    },
+    payloadSummary: proposal.action.payloadSummary,
+    payloadRef: proposal.action.payloadRef,
+    judgment: {
+      reasonCode: judgment.reasonCode,
+      summary: judgment.summary,
+      policyVersion: judgment.policyVersion,
+      judgedAt: judgment.judgedAt,
+    },
+    requiredRevision: judgment.requiredRevision,
+    escalation: judgment.escalation,
+    expiresAt: expiresAt(now, ttlMs),
+    responseContract: {
+      decisions: MEDIATION_APPROVAL_DECISIONS,
+      reviseWithEditsRequires: ['editedPayloadSummary'],
+    },
+    resume: {
+      requestId: proposal.context.requestId ?? null,
+      sessionId: proposal.context.sessionId ?? null,
+      actionProposalId: proposal.id,
+      judgmentId: judgment.id,
+    },
+  };
+}
+
+export function createMediationApprovalAguiEvents(
+  proposal: ActionProposal,
+  judgment: JudgeResult,
+  options: CreateMediationApprovalEventsOptions = {}
+): MediationApprovalAguiEvent[] {
+  const request = createMediationApprovalRequest(proposal, judgment, options);
+  const timestamp = (options.now ?? new Date()).getTime();
+  const threadId = options.threadId ?? proposal.context.sessionId ?? request.approvalRequestId;
+  const runId = options.runId ?? request.approvalRequestId;
+
+  return [
+    {
+      type: 'RUN_STARTED',
+      threadId,
+      runId,
+      parentRunId: options.parentRunId,
+      timestamp,
+    },
+    {
+      type: 'STATE_DELTA',
+      timestamp,
+      delta: [
+        {
+          op: 'add',
+          path: '/mediationApproval',
+          value: request,
+        },
+      ],
+    },
+    {
+      type: 'CUSTOM',
+      name: MEDIATION_APPROVAL_AGUI_EVENT_NAMES.requested,
+      value: request,
+      timestamp,
+    },
+    {
+      type: 'RUN_FINISHED',
+      threadId,
+      runId,
+      timestamp,
+      result: {
+        status: request.status,
+        approvalRequestId: request.approvalRequestId,
+      },
+    },
+  ];
+}
+
+export function createMediationApprovalResponse(
+  input: CreateMediationApprovalResponseInput
+): MediationApprovalResponse {
+  if (!isApprovalDecision(input.decision)) {
+    throw new Error(`Unsupported approval decision: ${input.decision}`);
+  }
+  if (input.decision === 'revise_with_edits' && !input.editedPayloadSummary) {
+    throw new Error('revise_with_edits requires editedPayloadSummary');
+  }
+
+  return {
+    version: MEDIATION_APPROVAL_AGUI_VERSION,
+    approvalRequestId: input.approvalRequestId,
+    actionProposalId: input.actionProposalId,
+    decision: input.decision,
+    nextAction: nextActionFor(input.decision),
+    decidedAt: (input.decidedAt ?? new Date()).toISOString(),
+    reviewerNote: input.reviewerNote,
+    editedPayloadSummary: input.editedPayloadSummary,
+    editedPayloadRef: input.editedPayloadRef,
+  };
+}
+
+export function createMediationApprovalDecisionEvent(
+  response: MediationApprovalResponse,
+  now = new Date()
+): AguiCustomEvent {
+  return {
+    type: 'CUSTOM',
+    name: MEDIATION_APPROVAL_AGUI_EVENT_NAMES.decided,
+    value: response,
+    timestamp: now.getTime(),
+  };
+}

--- a/joyus-ai-mcp-server/src/content/mediation/index.ts
+++ b/joyus-ai-mcp-server/src/content/mediation/index.ts
@@ -6,6 +6,31 @@ export { hashApiKey, createAuthMiddleware } from './auth.js';
 export { ApiKeyService } from './keys.js';
 export type { CreateKeyInput } from './keys.js';
 export {
+  DEFAULT_MEDIATION_APPROVAL_TTL_MS,
+  MEDIATION_APPROVAL_AGUI_EVENT_NAMES,
+  MEDIATION_APPROVAL_AGUI_VERSION,
+  MEDIATION_APPROVAL_DECISIONS,
+  createMediationApprovalAguiEvents,
+  createMediationApprovalDecisionEvent,
+  createMediationApprovalRequest,
+  createMediationApprovalResponse,
+} from './agui.js';
+export type {
+  AguiCustomEvent,
+  AguiRunFinishedEvent,
+  AguiRunStartedEvent,
+  AguiStateDeltaEvent,
+  CreateMediationApprovalEventsOptions,
+  CreateMediationApprovalRequestOptions,
+  CreateMediationApprovalResponseInput,
+  MediationApprovalAguiEvent,
+  MediationApprovalDecision,
+  MediationApprovalKind,
+  MediationApprovalNextAction,
+  MediationApprovalRequest,
+  MediationApprovalResponse,
+} from './agui.js';
+export {
   DeterministicMediationJudgeService,
   MEDIATION_RESPONSE_JUDGE_POLICY_VERSION,
   createMediationResponseProposal,

--- a/joyus-ai-mcp-server/tests/content/mediation/agui.test.ts
+++ b/joyus-ai-mcp-server/tests/content/mediation/agui.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MEDIATION_APPROVAL_AGUI_EVENT_NAMES,
+  createMediationApprovalAguiEvents,
+  createMediationApprovalDecisionEvent,
+  createMediationApprovalRequest,
+  createMediationApprovalResponse,
+} from '../../../src/content/mediation/agui.js';
+import {
+  createMediationResponseProposal,
+  evaluateMediationActionProposal,
+} from '../../../src/content/mediation/judge.js';
+import type {
+  ActionProposal,
+  ActionRiskFlag,
+  Citation,
+  GenerationResult,
+  ResolvedEntitlements,
+} from '../../../src/content/types.js';
+
+const NOW = new Date('2026-05-25T12:00:00.000Z');
+
+function makeCitation(id: string): Citation {
+  return {
+    sourceId: `source-${id}`,
+    itemId: `item-${id}`,
+    title: `Reference ${id}`,
+    excerpt: `Excerpt ${id}`,
+    sourceType: 'article',
+  };
+}
+
+function makeGenerationResult(overrides: Partial<GenerationResult> = {}): GenerationResult {
+  const citations = overrides.citations ?? [makeCitation('a')];
+  return {
+    text: 'Use the cited reference to answer the requester.',
+    citations,
+    profileUsed: 'profile-a',
+    metadata: {
+      generationLogId: 'generation-log-a',
+      totalSearchResults: citations.length,
+      sourcesUsed: citations.length,
+      durationMs: 35,
+      ...overrides.metadata,
+    },
+    ...overrides,
+  };
+}
+
+function makeEntitlements(overrides: Partial<ResolvedEntitlements> = {}): ResolvedEntitlements {
+  return {
+    productIds: ['product-a'],
+    sourceIds: ['source-a', 'source-b'],
+    profileIds: ['profile-a'],
+    resolvedFrom: 'resolver-a',
+    resolvedAt: NOW,
+    ...overrides,
+  };
+}
+
+function baseProposal(overrides: { generationResult?: GenerationResult } = {}): ActionProposal {
+  return createMediationResponseProposal({
+    requestId: 'request-a',
+    tenantId: 'tenant-a',
+    userId: 'user-a',
+    apiKeyId: 'api-key-a',
+    sessionId: 'session-a',
+    profileId: 'profile-a',
+    entitlements: makeEntitlements(),
+    generationResult: overrides.generationResult ?? makeGenerationResult(),
+    proposedAt: NOW,
+  });
+}
+
+function withRiskFlags(proposal: ActionProposal, riskFlags: ActionRiskFlag[]): ActionProposal {
+  return { ...proposal, riskFlags };
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe('mediation AG-UI approval adapter', () => {
+  it('maps escalate judgments to an approval request stream', () => {
+    const proposal = withRiskFlags(baseProposal(), ['policy_conflict']);
+    const judgment = evaluateMediationActionProposal(proposal);
+
+    const events = createMediationApprovalAguiEvents(proposal, judgment, {
+      approvalRequestId: 'approval-a',
+      now: NOW,
+      ttlMs: 60_000,
+    });
+    const customEvent = events.find(event => event.type === 'CUSTOM');
+
+    expect(judgment.outcome).toBe('escalate');
+    expect(events.map(event => event.type)).toEqual([
+      'RUN_STARTED',
+      'STATE_DELTA',
+      'CUSTOM',
+      'RUN_FINISHED',
+    ]);
+    expect(customEvent).toEqual(
+      expect.objectContaining({
+        name: MEDIATION_APPROVAL_AGUI_EVENT_NAMES.requested,
+        value: expect.objectContaining({
+          approvalRequestId: 'approval-a',
+          kind: 'approval_request',
+          status: 'awaiting_user_decision',
+          actionProposalId: proposal.id,
+          judgmentId: judgment.id,
+          judgeOutcome: 'escalate',
+          actionType: 'deliver_mediation_response',
+          expiresAt: '2026-05-25T12:01:00.000Z',
+          responseContract: expect.objectContaining({
+            decisions: ['approve', 'reject', 'revise_with_edits'],
+          }),
+          resume: expect.objectContaining({
+            requestId: 'request-a',
+            sessionId: 'session-a',
+            actionProposalId: proposal.id,
+            judgmentId: judgment.id,
+          }),
+        }),
+      })
+    );
+  });
+
+  it('maps revise judgments to an editable revision request', () => {
+    const proposal = baseProposal({
+      generationResult: makeGenerationResult({
+        citations: [],
+        metadata: {
+          generationLogId: 'generation-log-empty',
+          totalSearchResults: 0,
+          sourcesUsed: 0,
+          durationMs: 10,
+        },
+      }),
+    });
+    const judgment = evaluateMediationActionProposal(proposal);
+
+    const request = createMediationApprovalRequest(proposal, judgment, {
+      approvalRequestId: 'approval-revise',
+      now: NOW,
+    });
+
+    expect(judgment.outcome).toBe('revise');
+    expect(request.kind).toBe('revision_request');
+    expect(request.requiredRevision).toEqual(
+      expect.objectContaining({
+        instruction: 'Revise the response proposal before delivery.',
+        mustChange: expect.arrayContaining([
+          'Attach authoritative cited content evidence or change the response to state that no supported answer is available.',
+        ]),
+      })
+    );
+  });
+
+  it('accepts approval, rejection, and revise-with-edits responses with deterministic next actions', () => {
+    expect(
+      createMediationApprovalResponse({
+        approvalRequestId: 'approval-a',
+        actionProposalId: 'proposal-a',
+        decision: 'approve',
+        decidedAt: NOW,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        decision: 'approve',
+        nextAction: 'execute',
+        decidedAt: NOW.toISOString(),
+      })
+    );
+
+    expect(
+      createMediationApprovalResponse({
+        approvalRequestId: 'approval-a',
+        actionProposalId: 'proposal-a',
+        decision: 'reject',
+        decidedAt: NOW,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        decision: 'reject',
+        nextAction: 'cancel',
+      })
+    );
+
+    const revised = createMediationApprovalResponse({
+      approvalRequestId: 'approval-a',
+      actionProposalId: 'proposal-a',
+      decision: 'revise_with_edits',
+      editedPayloadSummary: 'Use a narrower supported answer.',
+      decidedAt: NOW,
+    });
+    expect(revised).toEqual(
+      expect.objectContaining({
+        decision: 'revise_with_edits',
+        nextAction: 'rerun_judge',
+        editedPayloadSummary: 'Use a narrower supported answer.',
+      })
+    );
+    expect(createMediationApprovalDecisionEvent(revised, NOW)).toEqual(
+      expect.objectContaining({
+        type: 'CUSTOM',
+        name: MEDIATION_APPROVAL_AGUI_EVENT_NAMES.decided,
+        timestamp: NOW.getTime(),
+        value: revised,
+      })
+    );
+  });
+
+  it('rejects unsupported or incomplete approval responses', () => {
+    expect(() =>
+      createMediationApprovalResponse({
+        approvalRequestId: 'approval-a',
+        actionProposalId: 'proposal-a',
+        decision: 'revise_with_edits',
+      })
+    ).toThrow('revise_with_edits requires editedPayloadSummary');
+
+    expect(() =>
+      createMediationApprovalResponse({
+        approvalRequestId: 'approval-a',
+        actionProposalId: 'proposal-a',
+        decision: 'defer' as never,
+      })
+    ).toThrow('Unsupported approval decision');
+  });
+
+  it('does not expose raw authorization, tenant, user, or API-key data', () => {
+    const proposal = withRiskFlags(baseProposal(), ['policy_conflict']);
+    const judgment = evaluateMediationActionProposal(proposal);
+    const request = createMediationApprovalRequest(proposal, judgment, {
+      approvalRequestId: 'approval-a',
+      now: NOW,
+    });
+    const serialized = json(request);
+
+    expect(serialized).not.toContain('tenant-a');
+    expect(serialized).not.toContain('user-a');
+    expect(serialized).not.toContain('api-key-a');
+    expect(serialized).not.toContain('authorizedSourceIds');
+    expect(serialized).not.toContain('authorizedProfileIds');
+    expect(serialized).not.toContain('"criteria"');
+    expect(serialized).not.toContain('"authorization"');
+    expect(serialized).not.toContain('"evidence"');
+  });
+
+  it('requires a revise or escalate judgment', () => {
+    const proposal = baseProposal();
+    const judgment = evaluateMediationActionProposal(proposal);
+
+    expect(judgment.outcome).toBe('allow');
+    expect(() =>
+      createMediationApprovalRequest(proposal, judgment, {
+        now: NOW,
+      })
+    ).toThrow('Cannot create approval request for allow judgment');
+  });
+});

--- a/kitty-specs/006-content-infrastructure/agui-mediation-approval-decision.md
+++ b/kitty-specs/006-content-infrastructure/agui-mediation-approval-decision.md
@@ -1,0 +1,119 @@
+# AG-UI Mediation Approval Decision
+
+**Feature**: `006-content-infrastructure`
+**Issue**: `#72`
+**Status**: Accepted for first proof-of-concept slice
+**Scope**: Public platform architecture for human approval of mediated actions
+
+## Spec Kitty Routing
+
+This work is a post-completion extension to `006-content-infrastructure`, not a
+new standalone platform feature.
+
+The approval surface belongs to the mediation gateway because it decides what
+happens when a generated, citation-bearing response is paused by the judge layer
+before delivery. The existing mission already owns the mediation API, session
+handling, entitlement filtering, content-aware generation, and response delivery
+contracts. This addendum records the new human-review event surface without
+reopening every legacy work package in the completed mission.
+
+## Dependency
+
+The approval adapter depends on the judge-layer contract from issue `#71`.
+Without that contract, there is no structured `revise` or `escalate` outcome to
+surface to a reviewer. Without this adapter, those outcomes have no standard
+client-facing approval event shape.
+
+## Requirement Trace
+
+| Requirement | Relationship |
+|---|---|
+| `FR-020` Mediation API | Approval events extend the mediation API behavior for paused actions. |
+| `FR-021` Two-layer auth | Approval payloads must not expose raw API-key, tenant, or user auth context. |
+| `FR-022` Entitlement enforcement | Approval payloads carry summaries and durable refs, not unauthorized source lists or raw evidence. |
+| `FR-023` Mediated response delivery | `approve`, `reject`, and `revise_with_edits` determine whether delivery executes, cancels, or reruns the judge. |
+| `SC-006` 100 concurrent sessions | The first slice is a typed adapter; streaming and persistence follow after this contract stabilizes. |
+
+## Decision
+
+Use a thin local AG-UI-compatible adapter for the first approval slice.
+
+This keeps the proof of concept aligned with the current TypeScript mediation
+module and the judge-layer contract. It also avoids adopting a larger frontend
+or graph runtime before the platform has a stable review UI and persistence
+model.
+
+Library positioning:
+
+| Option | Decision | Rationale |
+|---|---|---|
+| Thin local adapter | Use now | Minimal dependency change, exact fit for current judge output, easy to test. |
+| CopilotKit | Revisit for UI | Strong AG-UI-native React surface once the review UI exists. |
+| Mastra | Defer | Runtime adoption overlaps with broader orchestrator decisions. |
+| LangGraph | Reference only | Useful interrupt semantics, but a heavier runtime mismatch for this slice. |
+
+## Acceptance Criteria
+
+1. `revise` and `escalate` judge outcomes produce an AG-UI-compatible event
+   stream containing `RUN_STARTED`, `STATE_DELTA`, `CUSTOM`, and `RUN_FINISHED`.
+2. Approval requests include stable resume identifiers for the proposal,
+   judgment, request, and session when available.
+3. Approval responses support exactly `approve`, `reject`, and
+   `revise_with_edits`, mapping to `execute`, `cancel`, and `rerun_judge`.
+4. Client-facing payloads exclude raw authorization context, raw evidence, judge
+   criteria, API keys, tenant IDs, user IDs, entitlement lists, and generated
+   response text.
+5. Tests cover event stability, expiry behavior, response validation, resume
+   identifiers, and payload minimization.
+
+## Implementation Surface
+
+| Surface | Purpose |
+|---|---|
+| `joyus-ai-mcp-server/src/content/mediation/agui.ts` | Typed approval request, event, and response adapter. |
+| `joyus-ai-mcp-server/src/content/mediation/index.ts` | Public mediation barrel exports. |
+| `joyus-ai-mcp-server/tests/content/mediation/agui.test.ts` | Focused adapter coverage. |
+| `joyus-ai-mcp-server/docs/AGUI_MEDIATION_APPROVALS.md` | Detailed protocol mapping and library comparison. |
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| Section 2.1 Multi-Tenant from Day One | PASS | Tenant/user context remains server-side and is not emitted in approval payloads. |
+| Section 2.3 Sandbox by Default | PASS | Only judge-paused actions produce approval requests; allowed actions proceed without extra exposure. |
+| Section 2.4 Monitor Everything | PASS | Resume identifiers preserve the audit chain between proposal, judgment, and decision. |
+| Section 2.6 Mediated AI Access | PASS | The adapter is model-agnostic and tied to mediation actions, not a specific provider. |
+| Section 2.10 Client-Informed, Platform-Generic | PASS | Artifact names and examples are generic platform concepts. |
+| Section 3.3 Non-Negotiables | PASS | The design preserves human authority before paused actions execute. |
+
+## Out Of Scope
+
+- Persisting approval requests and decisions.
+- Authenticated decision endpoints.
+- Server-sent event streaming.
+- Review UI implementation.
+- Broad adoption of a new agent or graph runtime.
+- Client-specific policy, corpus, or reviewer examples.
+
+## Validation
+
+Result on 2026-05-25: targeted adapter, judge, and router-judge tests passed;
+full `npm test` passed with 1491 tests passed and 50 skipped; `build`, `lint`,
+and `db:check` passed. Staged client-abstraction and diff checks passed before
+commit.
+
+Run from `joyus-ai-mcp-server/`:
+
+```bash
+npm test -- --run tests/content/mediation/agui.test.ts tests/content/mediation/judge.test.ts tests/content/mediation/router-judge.test.ts
+npm run build
+npm run lint
+npm run db:check
+```
+
+Run from the repository root:
+
+```bash
+./scripts/check-client-abstraction.sh --staged
+git diff --cached --check
+```


### PR DESCRIPTION
## Summary
- map mediation judge revise/escalate outcomes to an AG-UI-compatible approval event model
- compare CopilotKit, LangGraph, Mastra, and a thin local adapter for the current TypeScript architecture
- add a typed approval event/response proof of concept with privacy-focused payload tests

## Stack
- Stacked on #82 because #72 consumes the judge-layer contracts from issue #71
- Base should be updated to main after #82 merges

## Tests
- npm run build
- npm run lint
- npm run db:check
- npm test -- --run tests/content/mediation/agui.test.ts tests/content/mediation/judge.test.ts tests/content/mediation/router-judge.test.ts
- npm test
- ./scripts/check-client-abstraction.sh --staged
- git diff --cached --check

Closes #72