### PR TITLE
[codex] Wire profile engine contract

### DIFF
--- a/joyus-ai-mcp-server/docs/manual-testing/profile-isolation-manual-test.md
+++ b/joyus-ai-mcp-server/docs/manual-testing/profile-isolation-manual-test.md
@@ -69,13 +69,15 @@ docker compose up server
 
 ## 4. Profile Engine Boundary
 
-Feature 008 expects the private Spec 005 `joyus-profile-engine` companion runtime. That engine is not included in this public repository, and the server-to-engine contract is tracked separately in https://github.com/zivtech/joyus-ai/issues/67. If the private companion is available in the target environment, set `ENGINE_SCRIPT_PATH` to its Python entrypoint.
+Feature 008 expects a separately deployed profile engine runtime. That engine is not included in this public repository. The server-to-engine contract is documented in `../profile-engine-contract.md`. If an engine is available in the target environment, configure its CLI command:
 
 ```bash
-export ENGINE_SCRIPT_PATH="/absolute/path/to/joyus-profile-engine-entrypoint.py"
+export PROFILE_ENGINE_COMMAND="joyus-profile"
+export PROFILE_ENGINE_ARGS="generate"
+export PROFILE_ENGINE_HEALTH_ARGS="health-check"
 ```
 
-If the private companion engine is not available, leave `ENGINE_SCRIPT_PATH` unset and do not expect `profile_generate` to produce real profiles. The server should still boot, migrations should apply, and profile infrastructure should be testable. A `profile_generate` request should create a real generation run, mark it failed with a clear engine-not-configured error, and avoid creating fake profile rows.
+If the profile engine is not available, leave `PROFILE_ENGINE_COMMAND` unset and do not expect `profile_generate` to produce real profiles. The server should still boot, migrations should apply, and profile infrastructure should be testable. A `profile_generate` request should create a real generation run, mark it failed with a clear engine-not-configured error, and avoid creating fake profile rows.
 
 ## 5. Optional Profile Integration Test Run
 
@@ -124,7 +126,7 @@ profiles.operation_logs
 
 ### No-Engine Generation Check
 
-If `ENGINE_SCRIPT_PATH` is unset, call `profile_generate` for a known tenant and corpus snapshot.
+If `PROFILE_ENGINE_COMMAND` is unset, call `profile_generate` for a known tenant and corpus snapshot.
 
 Step by step:
 

--- a/joyus-ai-mcp-server/docs/profile-engine-contract.md
+++ b/joyus-ai-mcp-server/docs/profile-engine-contract.md
@@ -1,0 +1,88 @@
+# Profile Engine Contract
+
+`profile_generate` integrates with a separately deployed profile engine through
+a CLI subprocess contract. The public platform owns tenant scoping, corpus
+snapshot selection, generation run state, and profile storage. The engine only
+receives a temporary directory containing the selected snapshot's extracted
+text plus the requested author identifier.
+
+## Configuration
+
+Set these environment variables when an engine is available:
+
+```bash
+export PROFILE_ENGINE_COMMAND="joyus-profile"
+export PROFILE_ENGINE_ARGS="generate"
+export PROFILE_ENGINE_HEALTH_ARGS="health-check"
+```
+
+Leave `PROFILE_ENGINE_COMMAND` unset when no engine is available. In that state,
+`profile_generate` creates a generation run, marks it failed with a clear
+not-configured error, and does not create profile rows.
+
+## Generate Invocation
+
+The bridge invokes:
+
+```text
+<PROFILE_ENGINE_COMMAND> <PROFILE_ENGINE_ARGS> \
+  --corpus-path <tenant-scoped-snapshot-directory> \
+  --author-id <author-id> \
+  --output-format json \
+  [--engine-version <version>]
+```
+
+The corpus path is a temporary directory materialized by this server from the
+selected corpus snapshot. It is not a tenant ID, snapshot ID, database key, or
+deployment-specific path.
+
+## Generate Response
+
+The engine must write one JSON object to stdout:
+
+```json
+{
+  "authorId": "author-001",
+  "stylometricFeatures": {
+    "sentence_length_stats.mean": 18.4
+  },
+  "markers": [
+    {
+      "signal": "high",
+      "text": "structured claims",
+      "weight": 0.8,
+      "frequency": 0.2,
+      "domain": "general"
+    }
+  ],
+  "fidelityScore": 0.91,
+  "engineVersion": "0.1.0"
+}
+```
+
+Contract rules:
+
+- `authorId` is required and must match the requested author.
+- `stylometricFeatures` is a string-keyed object whose values are numbers.
+- `markers` is an array. Marker object fields may evolve, but the array shape is stable.
+- `fidelityScore` is required and may be `null` when the engine cannot score yet.
+- `engineVersion` is a required string identifying the engine contract/model version.
+- `durationMs` is owned by the TypeScript bridge and must not be required from the engine.
+
+## Health Check
+
+The bridge invokes:
+
+```text
+<PROFILE_ENGINE_COMMAND> <PROFILE_ENGINE_HEALTH_ARGS>
+```
+
+Exit code `0` means healthy. Non-zero exits, timeouts, or missing configuration
+mean unhealthy.
+
+## Failure Semantics
+
+For validation failures, the engine should exit non-zero and write a concise
+machine-readable error to stderr. The public platform stores a failed generation
+run and avoids exposing tenant IDs, snapshot IDs, filesystem paths, or raw corpus
+content in user-facing tool responses.

--- a/joyus-ai-mcp-server/src/profiles/generation/corpus-snapshot.ts
+++ b/joyus-ai-mcp-server/src/profiles/generation/corpus-snapshot.ts
@@ -7,6 +7,9 @@
  */
 
 import { createHash } from 'crypto';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { createId } from '@paralleldrive/cuid2';
 import { eq, desc } from 'drizzle-orm';
@@ -32,6 +35,23 @@ export interface CreateSnapshotOptions {
 export interface SnapshotListOptions {
   limit?: number;
   offset?: number;
+}
+
+export interface MaterializeSnapshotOptions {
+  baseDir?: string;
+}
+
+export interface MaterializedCorpusSnapshot {
+  corpusPath: string;
+  documentCount: number;
+  cleanup: () => Promise<void>;
+}
+
+export class CorpusSnapshotMaterializationError extends Error {
+  constructor() {
+    super('Cannot generate profiles: selected corpus snapshot has no extracted text');
+    this.name = 'CorpusSnapshotMaterializationError';
+  }
 }
 
 // ============================================================
@@ -157,6 +177,44 @@ export class CorpusSnapshotService {
       .where(tenantWhere(corpusDocuments, tenantId));
 
     return docs.filter((d) => hashes.includes(d.contentHash));
+  }
+
+  /**
+   * Write a tenant-scoped snapshot to a temporary directory for engine input.
+   * The temp directory omits tenant and snapshot identifiers from its path.
+   */
+  async materializeSnapshot(
+    tenantId: string,
+    snapshotId: string,
+    options?: MaterializeSnapshotOptions,
+  ): Promise<MaterializedCorpusSnapshot> {
+    requireTenantId(tenantId);
+
+    const docs = await this.getSnapshotDocuments(tenantId, snapshotId);
+    const docsWithText = docs.filter(
+      (doc) => typeof doc.extractedText === 'string' && doc.extractedText.trim().length > 0,
+    );
+    if (docsWithText.length === 0) {
+      throw new CorpusSnapshotMaterializationError();
+    }
+
+    const parentDir = options?.baseDir ?? tmpdir();
+    await mkdir(parentDir, { recursive: true });
+    const corpusPath = await mkdtemp(join(parentDir, 'joyus-profile-corpus-'));
+
+    await Promise.all(
+      docsWithText.map((doc, index) => writeFile(
+        join(corpusPath, `document-${String(index + 1).padStart(4, '0')}.txt`),
+        doc.extractedText ?? '',
+        'utf8',
+      )),
+    );
+
+    return {
+      corpusPath,
+      documentCount: docsWithText.length,
+      cleanup: () => rm(corpusPath, { recursive: true, force: true }),
+    };
   }
 
   // ----------------------------------------------------------

--- a/joyus-ai-mcp-server/src/profiles/generation/engine-bridge.ts
+++ b/joyus-ai-mcp-server/src/profiles/generation/engine-bridge.ts
@@ -1,7 +1,7 @@
 /**
  * Profile Generation — Engine Bridge
  *
- * Subprocess bridge to the Spec 005 Python stylometric engine.
+ * Subprocess bridge to the configured profile engine CLI.
  * Invokes the engine via execFile (not exec) to avoid shell injection,
  * parses JSON from stdout, and surfaces structured errors.
  */
@@ -34,10 +34,12 @@ function execFileAsync(
 // ============================================================
 
 export interface EngineBridgeConfig {
-  /** Path to the Python interpreter. Defaults to 'python3'. */
-  pythonPath: string;
-  /** Absolute path to the Spec 005 engine entry script. */
-  engineScriptPath: string;
+  /** Executable profile engine command, e.g. "joyus-profile". */
+  engineCommand: string;
+  /** Fixed arguments before per-request generation flags, e.g. ["generate"]. */
+  engineArgs: string[];
+  /** Arguments for the health-check command, e.g. ["health-check"]. */
+  healthCheckArgs: string[];
   /** Maximum milliseconds to wait for the engine. Defaults to 360000 (6 min). */
   timeoutMs: number;
   /** Maximum stdout/stderr buffer in bytes. Defaults to 50 MB. */
@@ -79,9 +81,7 @@ export class EngineExecutionError extends Error {
   readonly stderr: string;
 
   constructor(authorId: string, exitCode: number | null, stderr: string) {
-    super(
-      `Engine execution failed for author "${authorId}" (exit ${exitCode ?? 'unknown'}): ${stderr.slice(0, 500)}`,
-    );
+    super(`Engine execution failed for author "${authorId}" (exit ${exitCode ?? 'unknown'})`);
     this.name = 'EngineExecutionError';
     this.exitCode = exitCode;
     this.stderr = stderr;
@@ -106,7 +106,7 @@ export class EngineOutputError extends Error {
 export class EngineNotConfiguredError extends Error {
   constructor() {
     super(
-      'Profile engine is not configured. Set ENGINE_SCRIPT_PATH after wiring the private joyus-profile-engine adapter.',
+      'Profile engine is not configured. Set PROFILE_ENGINE_COMMAND to the profile engine executable.',
     );
     this.name = 'EngineNotConfiguredError';
   }
@@ -117,8 +117,9 @@ export class EngineNotConfiguredError extends Error {
 // ============================================================
 
 const DEFAULT_CONFIG: EngineBridgeConfig = {
-  pythonPath: 'python3',
-  engineScriptPath: '',
+  engineCommand: '',
+  engineArgs: ['generate'],
+  healthCheckArgs: ['health-check'],
   timeoutMs: 360_000,
   maxBuffer: 50 * 1024 * 1024,
 };
@@ -135,11 +136,11 @@ export class EngineBridge {
   // ----------------------------------------------------------
 
   isConfigured(): boolean {
-    return this.config.engineScriptPath.trim().length > 0;
+    return this.config.engineCommand.trim().length > 0;
   }
 
   /**
-   * Invoke the Python stylometric engine for a single author.
+   * Invoke the configured profile engine for a single author.
    * Returns a structured EngineResult parsed from engine JSON stdout.
    */
   async generateProfile(
@@ -156,7 +157,7 @@ export class EngineBridge {
 
     let stdout: string;
     try {
-      const result = await execFileAsync(this.config.pythonPath, args, {
+      const result = await execFileAsync(this.config.engineCommand, args, {
         timeout: this.config.timeoutMs,
         maxBuffer: this.config.maxBuffer,
         env: process.env,
@@ -201,7 +202,7 @@ export class EngineBridge {
   }
 
   /**
-   * Verify the engine script is reachable and returns a valid response.
+   * Verify the configured profile engine is reachable.
    * Returns true on success, false if the engine is unreachable.
    */
   async healthCheck(): Promise<boolean> {
@@ -211,8 +212,8 @@ export class EngineBridge {
 
     try {
       await execFileAsync(
-        this.config.pythonPath,
-        [this.config.engineScriptPath, '--health-check'],
+        this.config.engineCommand,
+        this.config.healthCheckArgs,
         { timeout: 10_000, maxBuffer: 1024 * 1024, env: process.env },
       );
       return true;
@@ -231,7 +232,7 @@ export class EngineBridge {
     options?: EngineOptions,
   ): string[] {
     const args = [
-      this.config.engineScriptPath,
+      ...this.config.engineArgs,
       '--corpus-path', corpusPath,
       '--author-id', authorId,
       '--output-format', 'json',
@@ -260,20 +261,35 @@ export class EngineBridge {
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
+      !('authorId' in parsed) ||
       !('stylometricFeatures' in parsed) ||
+      !('markers' in parsed) ||
+      !('fidelityScore' in parsed) ||
       !('engineVersion' in parsed)
     ) {
       throw new EngineOutputError(authorId, trimmed);
     }
 
     const raw = parsed as Record<string, unknown>;
+    if (
+      raw['authorId'] !== authorId ||
+      !this.isNumberRecord(raw['stylometricFeatures']) ||
+      !Array.isArray(raw['markers']) ||
+      (
+        raw['fidelityScore'] !== null &&
+        typeof raw['fidelityScore'] !== 'number'
+      ) ||
+      typeof raw['engineVersion'] !== 'string'
+    ) {
+      throw new EngineOutputError(authorId, trimmed);
+    }
 
     return {
-      authorId,
-      stylometricFeatures: (raw['stylometricFeatures'] as Record<string, number>) ?? {},
-      markers: raw['markers'] ?? [],
-      fidelityScore: typeof raw['fidelityScore'] === 'number' ? raw['fidelityScore'] : null,
-      engineVersion: String(raw['engineVersion']),
+      authorId: raw['authorId'],
+      stylometricFeatures: raw['stylometricFeatures'],
+      markers: raw['markers'],
+      fidelityScore: raw['fidelityScore'],
+      engineVersion: raw['engineVersion'],
       durationMs,
     };
   }
@@ -285,5 +301,14 @@ export class EngineBridge {
       return msg.includes('etimedout') || msg.includes('timed out') || msg.includes('killed');
     }
     return false;
+  }
+
+  private isNumberRecord(value: unknown): value is Record<string, number> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.values(value).every((entry) => typeof entry === 'number')
+    );
   }
 }

--- a/joyus-ai-mcp-server/src/profiles/generation/pipeline.ts
+++ b/joyus-ai-mcp-server/src/profiles/generation/pipeline.ts
@@ -25,7 +25,7 @@ import {
 import { requireTenantId, tenantWhere } from '../tenant-scope.js';
 import type { PipelineResult, ProfileTier } from '../types.js';
 
-import type { CorpusSnapshotService } from './corpus-snapshot.js';
+import type { CorpusSnapshotService, MaterializedCorpusSnapshot } from './corpus-snapshot.js';
 import { EngineNotConfiguredError, type EngineBridge, type EngineOptions } from './engine-bridge.js';
 
 // ============================================================
@@ -33,7 +33,7 @@ import { EngineNotConfiguredError, type EngineBridge, type EngineOptions } from 
 // ============================================================
 
 export interface PipelineInput {
-  /** Corpus path passed to the engine (filesystem path or identifier). */
+  /** Fallback corpus path passed to the engine when no snapshot ID is provided. */
   corpusPath: string;
   /** Profile identities to generate, in `{tier}::{name}` format. */
   profileIdentities: string[];
@@ -165,7 +165,18 @@ export class ProfileGenerationPipeline {
           .where(tenantWhere(generationRuns, tenantId, eq(generationRuns.id, runId)));
 
         // Step 6: generate profiles
-        return this.generateProfiles(tenantId, runId, input);
+        const materialized = input.corpusSnapshotId
+          ? await this.snapshotService.materializeSnapshot(tenantId, input.corpusSnapshotId)
+          : null;
+
+        try {
+          return this.generateProfiles(tenantId, runId, {
+            ...input,
+            corpusPath: materialized?.corpusPath ?? input.corpusPath,
+          });
+        } finally {
+          await this.cleanupMaterializedSnapshot(materialized);
+        }
       });
 
       const durationMs = Date.now() - startMs;
@@ -475,5 +486,19 @@ export class ProfileGenerationPipeline {
     }
 
     return query;
+  }
+
+  private async cleanupMaterializedSnapshot(
+    materialized: MaterializedCorpusSnapshot | null,
+  ): Promise<void> {
+    if (!materialized) {
+      return;
+    }
+
+    try {
+      await materialized.cleanup();
+    } catch {
+      // Best-effort cleanup; the generation result should reflect engine behavior.
+    }
   }
 }

--- a/joyus-ai-mcp-server/src/profiles/index.ts
+++ b/joyus-ai-mcp-server/src/profiles/index.ts
@@ -34,10 +34,12 @@ import { ProfileVersionService } from './versioning/service.js';
 type DrizzleClient = ReturnType<typeof drizzle>;
 
 export interface ProfilesConfig {
-  /** Path to the Python interpreter. Defaults to 'python3'. */
-  pythonPath?: string;
-  /** Absolute path to the stylometric engine entry script. */
-  engineScriptPath?: string;
+  /** Executable profile engine command, e.g. "joyus-profile". */
+  engineCommand?: string;
+  /** Fixed arguments before per-request generation flags. */
+  engineArgs?: string[];
+  /** Arguments for the health-check command. */
+  healthCheckArgs?: string[];
 }
 
 export interface ProfilesModule {
@@ -101,8 +103,12 @@ export function initializeProfiles(
   const snapshotService = new CorpusSnapshotService();
 
   const engineBridge = new EngineBridge({
-    pythonPath: config?.pythonPath ?? 'python3',
-    engineScriptPath: config?.engineScriptPath ?? process.env.ENGINE_SCRIPT_PATH ?? '',
+    engineCommand: config?.engineCommand ?? process.env.PROFILE_ENGINE_COMMAND ?? '',
+    engineArgs: config?.engineArgs ?? parseProfileEngineArgs(process.env.PROFILE_ENGINE_ARGS, ['generate']),
+    healthCheckArgs: config?.healthCheckArgs ?? parseProfileEngineArgs(
+      process.env.PROFILE_ENGINE_HEALTH_ARGS,
+      ['health-check'],
+    ),
   });
 
   // ── Layer 4: Hierarchy + resolver ─────────────────────────────────────────
@@ -156,4 +162,9 @@ export function initializeProfiles(
     parserRegistry,
     dedupService,
   };
+}
+
+function parseProfileEngineArgs(raw: string | undefined, fallback: string[]): string[] {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed.split(/\s+/) : fallback;
 }

--- a/joyus-ai-mcp-server/src/tools/executors/profile-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/profile-executor.ts
@@ -195,7 +195,12 @@ export async function executeProfileTool(
 
       const snapshotService = new CorpusSnapshotService();
       const engine = new EngineBridge({
-        engineScriptPath: process.env.ENGINE_SCRIPT_PATH ?? '',
+        engineCommand: process.env.PROFILE_ENGINE_COMMAND ?? '',
+        engineArgs: parseProfileEngineArgs(process.env.PROFILE_ENGINE_ARGS, ['generate']),
+        healthCheckArgs: parseProfileEngineArgs(
+          process.env.PROFILE_ENGINE_HEALTH_ARGS,
+          ['health-check'],
+        ),
       });
       const pipeline = new ProfileGenerationPipeline(engine, snapshotService);
       const result = await pipeline.generate(tenantId, {
@@ -452,4 +457,9 @@ export async function executeProfileTool(
     default:
       throw new Error(`Unknown profile tool: ${toolName}`);
   }
+}
+
+function parseProfileEngineArgs(raw: string | undefined, fallback: string[]): string[] {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed.split(/\s+/) : fallback;
 }

--- a/joyus-ai-mcp-server/tests/profiles/edge-cases.test.ts
+++ b/joyus-ai-mcp-server/tests/profiles/edge-cases.test.ts
@@ -255,7 +255,7 @@ describe('EC-007: generation pipeline does not create empty profiles from zero d
     const { EngineBridge } = await import('../../src/profiles/generation/engine-bridge.js');
     const { CorpusSnapshotService } = await import('../../src/profiles/generation/corpus-snapshot.js');
 
-    const engine = new EngineBridge({ engineScriptPath: '/dev/null' });
+    const engine = new EngineBridge({ engineCommand: '/dev/null' });
     const snapshotService = new CorpusSnapshotService();
     const pipeline = new ProfileGenerationPipeline(engine, snapshotService);
 

--- a/joyus-ai-mcp-server/tests/profiles/generation/corpus-snapshot.test.ts
+++ b/joyus-ai-mcp-server/tests/profiles/generation/corpus-snapshot.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, readFile, readdir, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // ── Stub DB ────────────────────────────────────────────────────────────────
 //
@@ -40,7 +43,10 @@ vi.mock('../../../src/db/client.js', () => {
   };
 });
 
-import { CorpusSnapshotService } from '../../../src/profiles/generation/corpus-snapshot.js';
+import {
+  CorpusSnapshotMaterializationError,
+  CorpusSnapshotService,
+} from '../../../src/profiles/generation/corpus-snapshot.js';
 import { db } from '../../../src/db/client.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -72,6 +78,7 @@ function makeDoc(overrides: Record<string, unknown> = {}) {
     isActive: true,
     dataTier: 1,
     metadata: {},
+    extractedText: 'Snapshot document text.',
     createdAt: new Date(),
     ...overrides,
   };
@@ -245,5 +252,75 @@ describe('CorpusSnapshotService.hashContent', () => {
     const a = CorpusSnapshotService.hashContent('content-a');
     const b = CorpusSnapshotService.hashContent('content-b');
     expect(a).not.toBe(b);
+  });
+});
+
+describe('CorpusSnapshotService.materializeSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes only extracted snapshot text to a temporary corpus directory', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'joyus-snapshot-test-'));
+    try {
+      const snap = makeSnapshot({ documentHashes: ['hash1'] });
+      const doc = makeDoc({ contentHash: 'hash1', extractedText: 'Tenant-scoped text.' });
+
+      let callIndex = 0;
+      vi.mocked(db.select).mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) {
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue([snap]),
+          } as never;
+        }
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockResolvedValue([doc]),
+        } as never;
+      });
+
+      const svc = new CorpusSnapshotService();
+      const materialized = await svc.materializeSnapshot('tenant-abc', 'snap-001', { baseDir });
+
+      expect(materialized.documentCount).toBe(1);
+      const files = await readdir(materialized.corpusPath);
+      expect(files).toEqual(['document-0001.txt']);
+      await expect(readFile(join(materialized.corpusPath, files[0] ?? ''), 'utf8'))
+        .resolves.toBe('Tenant-scoped text.');
+
+      await materialized.cleanup();
+      await expect(readdir(materialized.corpusPath)).rejects.toThrow();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a generic materialization error when snapshot documents lack text', async () => {
+    const snap = makeSnapshot({ documentHashes: ['hash1'] });
+    const doc = makeDoc({ contentHash: 'hash1', extractedText: null });
+
+    let callIndex = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([snap]),
+        } as never;
+      }
+      return {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([doc]),
+      } as never;
+    });
+
+    const svc = new CorpusSnapshotService();
+    await expect(svc.materializeSnapshot('tenant-abc', 'snap-001')).rejects.toThrow(
+      CorpusSnapshotMaterializationError,
+    );
   });
 });

--- a/joyus-ai-mcp-server/tests/profiles/generation/engine-bridge.test.ts
+++ b/joyus-ai-mcp-server/tests/profiles/generation/engine-bridge.test.ts
@@ -82,7 +82,7 @@ function mockTimeout(): void {
 // ── Fixture ────────────────────────────────────────────────────────────────
 
 function makeBridge(): EngineBridge {
-  return new EngineBridge({ engineScriptPath: '/opt/engine/run.py' });
+  return new EngineBridge({ engineCommand: 'joyus-profile' });
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -106,6 +106,20 @@ describe('EngineBridge.generateProfile', () => {
     const bridge = makeBridge();
     const result = await bridge.generateProfile('/corpus', 'author-001');
 
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'joyus-profile',
+      [
+        'generate',
+        '--corpus-path',
+        '/corpus',
+        '--author-id',
+        'author-001',
+        '--output-format',
+        'json',
+      ],
+      expect.any(Object),
+      expect.any(Function),
+    );
     expect(result.authorId).toBe('author-001');
     expect(result.engineVersion).toBe('1.0.0');
     expect(result.fidelityScore).toBe(0.91);
@@ -137,6 +151,14 @@ describe('EngineBridge.generateProfile', () => {
     );
   });
 
+  it('throws EngineOutputError when the engine returns a different author', async () => {
+    mockSuccess(validEngineOutput('author-999'));
+    const bridge = makeBridge();
+    await expect(bridge.generateProfile('/corpus', 'author-001')).rejects.toThrow(
+      EngineOutputError,
+    );
+  });
+
   it('throws EngineExecutionError on non-zero exit', async () => {
     mockFailure(1, 'ImportError: no module named joyus_profile');
     const bridge = makeBridge();
@@ -153,11 +175,12 @@ describe('EngineBridge.generateProfile', () => {
     );
   });
 
-  it('fidelityScore is null when engine omits it', async () => {
+  it('fidelityScore may be null when the engine cannot score fidelity yet', async () => {
     const output = JSON.stringify({
       authorId: 'author-002',
       stylometricFeatures: {},
       markers: [],
+      fidelityScore: null,
       engineVersion: '1.0.0',
     });
     mockSuccess(output);
@@ -228,6 +251,12 @@ describe('EngineBridge.healthCheck', () => {
     mockSuccess('OK');
     const bridge = makeBridge();
     expect(await bridge.healthCheck()).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'joyus-profile',
+      ['health-check'],
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it('returns false when engine errors', async () => {

--- a/joyus-ai-mcp-server/tests/profiles/generation/pipeline.test.ts
+++ b/joyus-ai-mcp-server/tests/profiles/generation/pipeline.test.ts
@@ -82,6 +82,11 @@ function makeSnapshotService(): CorpusSnapshotService {
     getSnapshot: vi.fn(),
     listSnapshots: vi.fn(),
     getSnapshotDocuments: vi.fn(),
+    materializeSnapshot: vi.fn().mockResolvedValue({
+      corpusPath: '/tmp/materialized-corpus',
+      documentCount: 1,
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    }),
   } as unknown as CorpusSnapshotService;
 }
 
@@ -306,6 +311,11 @@ describe('ProfileGenerationPipeline.generate', () => {
       getSnapshot: vi.fn(),
       listSnapshots: vi.fn(),
       getSnapshotDocuments: vi.fn().mockResolvedValue([snapshotDoc]),
+      materializeSnapshot: vi.fn().mockResolvedValue({
+        corpusPath: '/tmp/materialized-corpus',
+        documentCount: 1,
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      }),
     } as unknown as CorpusSnapshotService;
     const engine = makeEngineBridge('author-999');
     const pipeline = makePipeline(engine, snapshotService);
@@ -318,8 +328,9 @@ describe('ProfileGenerationPipeline.generate', () => {
 
     expect(result.status).toBe('completed');
     expect(snapshotService.getSnapshotDocuments).toHaveBeenCalledWith('tenant-abc', 'snap-001');
+    expect(snapshotService.materializeSnapshot).toHaveBeenCalledWith('tenant-abc', 'snap-001');
     expect(engine.generateProfile).toHaveBeenCalledWith(
-      '/corpus',
+      '/tmp/materialized-corpus',
       'author-999',
       {},
     );


### PR DESCRIPTION
## Summary
- document the profile engine invocation, health-check, response, and failure contract
- update the TypeScript bridge to call a configured CLI command instead of a Python script path
- materialize tenant-scoped corpus snapshots to temporary engine input directories before generation
- prove unconfigured, failed, invalid-output, and snapshot-materialized paths do not create fake profile data

## Tests
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run db:check`
- `npm test -- --run tests/profiles/generation/engine-bridge.test.ts tests/profiles/generation/corpus-snapshot.test.ts tests/profiles/generation/pipeline.test.ts tests/tools/executors/profile-executor.test.ts`
- `npm test`

Closes #67
