### PR TITLE
[codex] Add GitHub MCP PR tools

### DIFF
--- a/joyus-ai-mcp-server/README.md
+++ b/joyus-ai-mcp-server/README.md
@@ -189,6 +189,9 @@ docker-compose up
 | `github_search_code` | Search code |
 | `github_list_prs` | List pull requests |
 | `github_get_pr` | Get PR details |
+| `github_create_pr` | Create a pull request |
+| `github_request_reviewers` | Request PR reviewers |
+| `github_get_pr_checks` | Get PR check status |
 | `github_list_issues` | List issues |
 | `github_get_issue` | Get issue details |
 | `github_list_repos` | List org repos |

--- a/joyus-ai-mcp-server/src/tools/executors/github-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/github-executor.ts
@@ -23,33 +23,46 @@ export async function executeGithubTool(
     'X-GitHub-Api-Version': '2022-11-28'
   };
 
-  switch (toolName) {
-    case 'github_search_code':
-      return searchCode(headers, input);
+  try {
+    switch (toolName) {
+      case 'github_search_code':
+        return await searchCode(headers, input);
 
-    case 'github_list_prs':
-      return listPRs(headers, input);
+      case 'github_list_prs':
+        return await listPRs(headers, input);
 
-    case 'github_get_pr':
-      return getPR(headers, input);
+      case 'github_get_pr':
+        return await getPR(headers, input);
 
-    case 'github_list_issues':
-      return listIssues(headers, input);
+      case 'github_create_pr':
+        return await createPR(headers, input);
 
-    case 'github_get_issue':
-      return getIssue(headers, input);
+      case 'github_request_reviewers':
+        return await requestReviewers(headers, input);
 
-    case 'github_list_repos':
-      return listRepos(headers, input);
+      case 'github_get_pr_checks':
+        return await getPRChecks(headers, input);
 
-    case 'github_get_file':
-      return getFile(headers, input);
+      case 'github_list_issues':
+        return await listIssues(headers, input);
 
-    case 'github_create_issue_comment':
-      return createIssueComment(headers, input);
+      case 'github_get_issue':
+        return await getIssue(headers, input);
 
-    default:
-      throw new Error(`Unknown GitHub tool: ${toolName}`);
+      case 'github_list_repos':
+        return await listRepos(headers, input);
+
+      case 'github_get_file':
+        return await getFile(headers, input);
+
+      case 'github_create_issue_comment':
+        return await createIssueComment(headers, input);
+
+      default:
+        throw new Error(`Unknown GitHub tool: ${toolName}`);
+    }
+  } catch (error: any) {
+    throw normalizeGithubError(error, toolName, input);
   }
 }
 
@@ -139,6 +152,95 @@ async function getPR(headers: any, input: any): Promise<any> {
       additions: f.additions,
       deletions: f.deletions
     }))
+  };
+}
+
+async function createPR(headers: any, input: any): Promise<any> {
+  const { repo, head, base, title, body, draft, maintainer_can_modify } = input;
+  const payload: any = { head, base, title };
+
+  if (body !== undefined) payload.body = body;
+  if (draft !== undefined) payload.draft = draft;
+  if (maintainer_can_modify !== undefined) payload.maintainer_can_modify = maintainer_can_modify;
+
+  const response = await axios.post(`${GITHUB_API_BASE}/repos/${repo}/pulls`, payload, { headers });
+  const pr = response.data;
+
+  return {
+    success: true,
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    draft: pr.draft,
+    base: pr.base.ref,
+    head: pr.head.ref,
+    url: pr.html_url
+  };
+}
+
+async function requestReviewers(headers: any, input: any): Promise<any> {
+  const { repo, prNumber, reviewers = [], teamReviewers = [] } = input;
+
+  if (reviewers.length === 0 && teamReviewers.length === 0) {
+    throw new Error('At least one user reviewer or team reviewer is required');
+  }
+
+  const response = await axios.post(
+    `${GITHUB_API_BASE}/repos/${repo}/pulls/${prNumber}/requested_reviewers`,
+    {
+      reviewers,
+      team_reviewers: teamReviewers
+    },
+    { headers }
+  );
+  const pr = response.data;
+
+  return {
+    success: true,
+    number: pr.number,
+    requestedReviewers: (pr.requested_reviewers ?? []).map((reviewer: any) => reviewer.login),
+    requestedTeams: (pr.requested_teams ?? []).map((team: any) => team.slug),
+    url: pr.html_url
+  };
+}
+
+async function getPRChecks(headers: any, input: any): Promise<any> {
+  const { repo, prNumber } = input;
+
+  const prResponse = await axios.get(`${GITHUB_API_BASE}/repos/${repo}/pulls/${prNumber}`, { headers });
+  const headSha = prResponse.data.head.sha;
+
+  const [checkRunsResponse, statusResponse] = await Promise.all([
+    axios.get(`${GITHUB_API_BASE}/repos/${repo}/commits/${headSha}/check-runs`, { headers }),
+    axios.get(`${GITHUB_API_BASE}/repos/${repo}/commits/${headSha}/status`, { headers })
+  ]);
+
+  const checkRuns = (checkRunsResponse.data.check_runs ?? []).map((run: any) => ({
+    name: run.name,
+    status: run.status,
+    conclusion: run.conclusion,
+    startedAt: run.started_at,
+    completedAt: run.completed_at,
+    detailsUrl: run.details_url,
+    url: run.html_url
+  }));
+  const statuses = (statusResponse.data.statuses ?? []).map((status: any) => ({
+    context: status.context,
+    state: status.state,
+    description: status.description,
+    targetUrl: status.target_url,
+    createdAt: status.created_at,
+    updatedAt: status.updated_at,
+    url: status.url
+  }));
+  const summary = summarizePRChecks(checkRuns, statuses);
+
+  return {
+    headSha,
+    overallState: summary.overallState,
+    checkRuns,
+    statuses,
+    summary
   };
 }
 
@@ -325,4 +427,103 @@ function formatIssue(issue: any): any {
     comments: issue.comments,
     url: issue.html_url
   };
+}
+
+function summarizePRChecks(checkRuns: any[], statuses: any[]): any {
+  const pendingCheckRuns = checkRuns.filter((run) => run.status !== 'completed' || !run.conclusion);
+  const failedCheckRuns = checkRuns.filter((run) =>
+    ['failure', 'cancelled', 'timed_out', 'action_required'].includes(run.conclusion)
+  );
+  const successfulCheckRuns = checkRuns.filter((run) => run.conclusion === 'success');
+  const neutralCheckRuns = checkRuns.filter((run) => run.conclusion === 'neutral');
+  const skippedCheckRuns = checkRuns.filter((run) => run.conclusion === 'skipped');
+  const pendingStatuses = statuses.filter((status) => status.state === 'pending');
+  const failedStatuses = statuses.filter((status) => ['failure', 'error'].includes(status.state));
+  const successfulStatuses = statuses.filter((status) => status.state === 'success');
+
+  let overallState = 'unknown';
+  if (checkRuns.length > 0 || statuses.length > 0) {
+    if (failedCheckRuns.length > 0 || failedStatuses.length > 0) {
+      overallState = 'failure';
+    } else if (pendingCheckRuns.length > 0 || pendingStatuses.length > 0) {
+      overallState = 'pending';
+    } else {
+      overallState = 'success';
+    }
+  }
+
+  return {
+    overallState,
+    checkRunCount: checkRuns.length,
+    statusCount: statuses.length,
+    successful: successfulCheckRuns.length + successfulStatuses.length,
+    neutral: neutralCheckRuns.length,
+    skipped: skippedCheckRuns.length,
+    failed: failedCheckRuns.length + failedStatuses.length,
+    pending: pendingCheckRuns.length + pendingStatuses.length
+  };
+}
+
+function normalizeGithubError(error: any, toolName: string, input: any): Error {
+  if (!error.response) {
+    return error;
+  }
+
+  const status = error.response.status;
+  const repo = input?.repo ?? 'the repository';
+  const message = error.response.data?.message;
+  const details = formatGithubValidationErrors(error.response.data?.errors);
+  const rateLimitRemaining = error.response.headers?.['x-ratelimit-remaining'];
+
+  if (status === 401) {
+    return new Error('GitHub authentication failed. Reconnect GitHub and try again.');
+  }
+
+  if (status === 403) {
+    if (rateLimitRemaining === '0' || (typeof message === 'string' && message.toLowerCase().includes('rate limit'))) {
+      return new Error('GitHub rate limit reached. Wait for the limit to reset, then retry.');
+    }
+    return new Error(`GitHub permission denied for ${repo}. Confirm the connected account has repo access.`);
+  }
+
+  if (status === 404) {
+    if (toolName === 'github_create_pr') {
+      return new Error(`GitHub branch or repository not found for ${repo}. Confirm repo, head, and base branches.`);
+    }
+    if (toolName === 'github_request_reviewers' || toolName === 'github_get_pr_checks' || toolName === 'github_get_pr') {
+      return new Error(`GitHub pull request or repository not found for ${repo}. Confirm the PR number and repo.`);
+    }
+    return new Error(`GitHub resource not found for ${repo}.`);
+  }
+
+  if (status === 422) {
+    if (toolName === 'github_request_reviewers') {
+      return new Error(`GitHub reviewer request failed validation for ${repo}: ${message ?? 'invalid reviewer or team'}${details}`);
+    }
+    if (toolName === 'github_create_pr') {
+      return new Error(`GitHub pull request creation failed validation for ${repo}: ${message ?? 'invalid branch or duplicate pull request'}${details}`);
+    }
+    return new Error(`GitHub validation failed for ${repo}: ${message ?? 'invalid request'}${details}`);
+  }
+
+  if (message) {
+    return new Error(`GitHub API error (${status}) for ${repo}: ${message}${details}`);
+  }
+
+  return error;
+}
+
+function formatGithubValidationErrors(errors: any[] | undefined): string {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return '';
+  }
+
+  const formatted = errors
+    .map((validationError) => {
+      const field = validationError.field ? `${validationError.field}: ` : '';
+      return `${field}${validationError.message ?? validationError.code ?? 'invalid'}`;
+    })
+    .join('; ');
+
+  return ` (${formatted})`;
 }

--- a/joyus-ai-mcp-server/src/tools/github-tools.ts
+++ b/joyus-ai-mcp-server/src/tools/github-tools.ts
@@ -69,6 +69,94 @@ export const githubTools: ToolDefinition[] = [
     }
   },
   {
+    name: 'github_create_pr',
+    description: 'Create a pull request from an existing branch',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Repository in owner/repo format (e.g., "example-org/example-app")'
+        },
+        head: {
+          type: 'string',
+          description: 'Head branch or owner:branch ref for the proposed changes'
+        },
+        base: {
+          type: 'string',
+          description: 'Base branch that the pull request targets'
+        },
+        title: {
+          type: 'string',
+          description: 'Pull request title'
+        },
+        body: {
+          type: 'string',
+          description: 'Pull request body in GitHub markdown'
+        },
+        draft: {
+          type: 'boolean',
+          description: 'Create the pull request as a draft'
+        },
+        maintainer_can_modify: {
+          type: 'boolean',
+          description: 'Allow maintainers with push access to modify the pull request branch'
+        }
+      },
+      required: ['repo', 'head', 'base', 'title']
+    }
+  },
+  {
+    name: 'github_request_reviewers',
+    description: 'Request user and team reviewers for a pull request',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Repository in owner/repo format (e.g., "example-org/example-app")'
+        },
+        prNumber: {
+          type: 'number',
+          description: 'Pull request number'
+        },
+        reviewers: {
+          type: 'array',
+          description: 'GitHub usernames to request as reviewers',
+          items: {
+            type: 'string'
+          }
+        },
+        teamReviewers: {
+          type: 'array',
+          description: 'GitHub team slugs to request as reviewers',
+          items: {
+            type: 'string'
+          }
+        }
+      },
+      required: ['repo', 'prNumber']
+    }
+  },
+  {
+    name: 'github_get_pr_checks',
+    description: 'Get commit statuses and check runs for a pull request head commit',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Repository in owner/repo format (e.g., "example-org/example-app")'
+        },
+        prNumber: {
+          type: 'number',
+          description: 'Pull request number'
+        }
+      },
+      required: ['repo', 'prNumber']
+    }
+  },
+  {
     name: 'github_list_issues',
     description: 'List issues for a repository',
     inputSchema: {

--- a/joyus-ai-mcp-server/tests/tools.test.ts
+++ b/joyus-ai-mcp-server/tests/tools.test.ts
@@ -98,12 +98,29 @@ describe('Tool Definitions', () => {
       expect(toolNames).toContain('github_search_code');
       expect(toolNames).toContain('github_list_prs');
       expect(toolNames).toContain('github_get_pr');
+      expect(toolNames).toContain('github_create_pr');
+      expect(toolNames).toContain('github_request_reviewers');
+      expect(toolNames).toContain('github_get_pr_checks');
     });
 
     it('should have required fields specified', () => {
       const prTool = githubTools.find(t => t.name === 'github_get_pr');
       expect(prTool?.inputSchema.required).toContain('repo');
       expect(prTool?.inputSchema.required).toContain('prNumber');
+
+      const createPrTool = githubTools.find(t => t.name === 'github_create_pr');
+      expect(createPrTool?.inputSchema.required).toContain('repo');
+      expect(createPrTool?.inputSchema.required).toContain('head');
+      expect(createPrTool?.inputSchema.required).toContain('base');
+      expect(createPrTool?.inputSchema.required).toContain('title');
+
+      const reviewersTool = githubTools.find(t => t.name === 'github_request_reviewers');
+      expect(reviewersTool?.inputSchema.required).toContain('repo');
+      expect(reviewersTool?.inputSchema.required).toContain('prNumber');
+
+      const checksTool = githubTools.find(t => t.name === 'github_get_pr_checks');
+      expect(checksTool?.inputSchema.required).toContain('repo');
+      expect(checksTool?.inputSchema.required).toContain('prNumber');
     });
   });
 

--- a/joyus-ai-mcp-server/tests/tools/github-executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/github-executor.test.ts
@@ -17,6 +17,16 @@ const context = {
   metadata: {},
 };
 
+async function expectRejectedMessage(promise: Promise<unknown>, message: string): Promise<void> {
+  try {
+    await promise;
+    throw new Error('Expected promise to reject');
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(message);
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -74,6 +84,317 @@ describe('executeGithubTool', () => {
 
     expect(axios.get).toHaveBeenCalledOnce();
     expect(result).toBeDefined();
+  });
+
+  it('github_create_pr — creates a pull request and returns normalized metadata', async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: {
+        number: 12,
+        title: 'Improve form labels',
+        state: 'open',
+        draft: true,
+        base: { ref: 'main' },
+        head: { ref: 'remediation/form-labels' },
+        html_url: 'https://github.com/example-org/example-app/pull/12',
+      },
+    });
+
+    const result = await executeGithubTool(
+      'github_create_pr',
+      {
+        repo: 'example-org/example-app',
+        head: 'remediation/form-labels',
+        base: 'main',
+        title: 'Improve form labels',
+        body: 'Adds accessible names to inputs.',
+        draft: true,
+        maintainer_can_modify: false,
+      },
+      context,
+    );
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.github.com/repos/example-org/example-app/pulls',
+      {
+        head: 'remediation/form-labels',
+        base: 'main',
+        title: 'Improve form labels',
+        body: 'Adds accessible names to inputs.',
+        draft: true,
+        maintainer_can_modify: false,
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer ghp_test_token',
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      number: 12,
+      title: 'Improve form labels',
+      state: 'open',
+      draft: true,
+      base: 'main',
+      head: 'remediation/form-labels',
+      url: 'https://github.com/example-org/example-app/pull/12',
+    });
+  });
+
+  it('github_request_reviewers — sends user and team reviewer requests', async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: {
+        number: 12,
+        requested_reviewers: [{ login: 'reviewer-a' }, { login: 'reviewer-b' }],
+        requested_teams: [{ slug: 'accessibility-reviewers' }],
+        html_url: 'https://github.com/example-org/example-app/pull/12',
+      },
+    });
+
+    const result = await executeGithubTool(
+      'github_request_reviewers',
+      {
+        repo: 'example-org/example-app',
+        prNumber: 12,
+        reviewers: ['reviewer-a', 'reviewer-b'],
+        teamReviewers: ['accessibility-reviewers'],
+      },
+      context,
+    );
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.github.com/repos/example-org/example-app/pulls/12/requested_reviewers',
+      {
+        reviewers: ['reviewer-a', 'reviewer-b'],
+        team_reviewers: ['accessibility-reviewers'],
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer ghp_test_token',
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      number: 12,
+      requestedReviewers: ['reviewer-a', 'reviewer-b'],
+      requestedTeams: ['accessibility-reviewers'],
+      url: 'https://github.com/example-org/example-app/pull/12',
+    });
+  });
+
+  it('github_get_pr_checks — combines check runs and commit statuses', async () => {
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          head: { sha: 'abc123' },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          check_runs: [
+            {
+              name: 'validate',
+              status: 'completed',
+              conclusion: 'success',
+              started_at: '2026-05-25T12:00:00Z',
+              completed_at: '2026-05-25T12:01:00Z',
+              details_url: 'https://github.com/example-org/example-app/actions/runs/1',
+              html_url: 'https://github.com/example-org/example-app/runs/1',
+            },
+            {
+              name: 'lint',
+              status: 'queued',
+              conclusion: null,
+              started_at: null,
+              completed_at: null,
+              details_url: 'https://github.com/example-org/example-app/actions/runs/2',
+              html_url: 'https://github.com/example-org/example-app/runs/2',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          statuses: [
+            {
+              context: 'coverage',
+              state: 'success',
+              description: 'Coverage threshold met',
+              target_url: 'https://ci.example.test/build/1',
+              created_at: '2026-05-25T12:00:00Z',
+              updated_at: '2026-05-25T12:01:00Z',
+              url: 'https://api.github.com/repos/example-org/example-app/statuses/abc123',
+            },
+          ],
+        },
+      });
+
+    const result = await executeGithubTool(
+      'github_get_pr_checks',
+      {
+        repo: 'example-org/example-app',
+        prNumber: 12,
+      },
+      context,
+    );
+
+    expect(axios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://api.github.com/repos/example-org/example-app/pulls/12',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(axios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/example-org/example-app/commits/abc123/check-runs',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(axios.get).toHaveBeenNthCalledWith(
+      3,
+      'https://api.github.com/repos/example-org/example-app/commits/abc123/status',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(result).toEqual({
+      headSha: 'abc123',
+      overallState: 'pending',
+      checkRuns: [
+        {
+          name: 'validate',
+          status: 'completed',
+          conclusion: 'success',
+          startedAt: '2026-05-25T12:00:00Z',
+          completedAt: '2026-05-25T12:01:00Z',
+          detailsUrl: 'https://github.com/example-org/example-app/actions/runs/1',
+          url: 'https://github.com/example-org/example-app/runs/1',
+        },
+        {
+          name: 'lint',
+          status: 'queued',
+          conclusion: null,
+          startedAt: null,
+          completedAt: null,
+          detailsUrl: 'https://github.com/example-org/example-app/actions/runs/2',
+          url: 'https://github.com/example-org/example-app/runs/2',
+        },
+      ],
+      statuses: [
+        {
+          context: 'coverage',
+          state: 'success',
+          description: 'Coverage threshold met',
+          targetUrl: 'https://ci.example.test/build/1',
+          createdAt: '2026-05-25T12:00:00Z',
+          updatedAt: '2026-05-25T12:01:00Z',
+          url: 'https://api.github.com/repos/example-org/example-app/statuses/abc123',
+        },
+      ],
+      summary: {
+        overallState: 'pending',
+        checkRunCount: 2,
+        statusCount: 1,
+        successful: 2,
+        neutral: 0,
+        skipped: 0,
+        failed: 0,
+        pending: 1,
+      },
+    });
+  });
+
+  it('github_create_pr — maps missing branch errors to a clear message', async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce({
+      response: {
+        status: 404,
+        data: { message: 'Not Found' },
+      },
+    });
+
+    await expectRejectedMessage(
+      executeGithubTool(
+        'github_create_pr',
+        {
+          repo: 'example-org/example-app',
+          head: 'missing-branch',
+          base: 'main',
+          title: 'Improve form labels',
+        },
+        context,
+      ),
+      'GitHub branch or repository not found for example-org/example-app',
+    );
+  });
+
+  it('github_create_pr — maps validation errors to a clear message', async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce({
+      response: {
+        status: 422,
+        data: {
+          message: 'Validation Failed',
+          errors: [{ field: 'head', message: 'No commits between main and remediation/form-labels' }],
+        },
+      },
+    });
+
+    await expectRejectedMessage(
+      executeGithubTool(
+        'github_create_pr',
+        {
+          repo: 'example-org/example-app',
+          head: 'remediation/form-labels',
+          base: 'main',
+          title: 'Improve form labels',
+        },
+        context,
+      ),
+      'GitHub pull request creation failed validation',
+    );
+  });
+
+  it('github_request_reviewers — maps invalid reviewer errors to a clear message', async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce({
+      response: {
+        status: 422,
+        data: {
+          message: 'Validation Failed',
+          errors: [{ field: 'reviewers', message: 'reviewer-a is not a collaborator' }],
+        },
+      },
+    });
+
+    await expectRejectedMessage(
+      executeGithubTool(
+        'github_request_reviewers',
+        {
+          repo: 'example-org/example-app',
+          prNumber: 12,
+          reviewers: ['reviewer-a'],
+        },
+        context,
+      ),
+      'GitHub reviewer request failed validation',
+    );
+  });
+
+  it('github_get_pr_checks — maps permission errors to a clear message', async () => {
+    vi.mocked(axios.get).mockRejectedValueOnce({
+      response: {
+        status: 403,
+        data: { message: 'Resource not accessible by integration' },
+        headers: { 'x-ratelimit-remaining': '20' },
+      },
+    });
+
+    await expectRejectedMessage(
+      executeGithubTool(
+        'github_get_pr_checks',
+        {
+          repo: 'example-org/example-app',
+          prNumber: 12,
+        },
+        context,
+      ),
+      'GitHub permission denied for example-org/example-app',
+    );
   });
 
   it('github_list_repos — calls repos API', async () => {


### PR DESCRIPTION
## Summary
- add GitHub MCP tools for PR creation, reviewer requests, and PR check status
- normalize GitHub API responses into agent-readable result shapes
- cover success and common GitHub failure cases in focused executor tests

## Tests
- npm test -- tests/tools/github-executor.test.ts tests/tools.test.ts tests/tools/executor.test.ts
- npm run build
- npm run lint
- npm run db:check
- npm test

Closes #6

Part of #17
