### PR TITLE
[codex] Add Jira MCP reviewer proposal helpers

### DIFF
--- a/joyus-ai-mcp-server/README.md
+++ b/joyus-ai-mcp-server/README.md
@@ -168,8 +168,12 @@ docker-compose up
 | `jira_get_issue` | Get issue details |
 | `jira_get_my_issues` | Get assigned issues |
 | `jira_add_comment` | Add a comment |
+| `jira_resolve_reviewers` | Resolve proposal reviewers from issue metadata |
+| `jira_post_proposal_comment` | Post a structured remediation proposal comment |
 | `jira_transition_issue` | Change issue status |
 | `jira_list_projects` | List all projects |
+
+Jira OAuth through the Auth Portal provisions Jira Cloud connections. The Jira executor also supports Server/Data Center-style connection metadata with `apiVariant: "server"` and `baseUrl` for deployments that provide those tokens through their own connection setup.
 
 ### Slack
 

--- a/joyus-ai-mcp-server/src/tools/executors/jira-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/jira-executor.ts
@@ -8,9 +8,48 @@ import axios from 'axios';
 import { ExecutorContext } from '../executor.js';
 
 const JIRA_API_BASE = 'https://api.atlassian.com/ex/jira';
+const DEFAULT_REVIEWER_FALLBACK_ORDER = ['customFields', 'assignee', 'reporter'] as const;
+
+type JiraApiVariant = 'cloud' | 'server';
+type ReviewerFallbackSource = typeof DEFAULT_REVIEWER_FALLBACK_ORDER[number];
 
 interface JiraMetadata {
-  resources?: { id: string; name?: string; url?: string }[];
+  apiVariant?: string;
+  baseUrl?: string;
+  resources?: { id?: string; name?: string; url?: string }[];
+}
+
+interface JiraApiContext {
+  variant: JiraApiVariant;
+  baseUrl: string;
+  browseBaseUrl?: string;
+}
+
+interface ResolvedReviewer {
+  source: string;
+  displayName: string;
+  accountId?: string;
+  username?: string;
+  key?: string;
+  active?: boolean;
+  fieldId?: string;
+}
+
+interface ProposalCommentInput {
+  issueKey: string;
+  summary: string;
+  affectedComponents: string[];
+  proposedChanges: string[];
+  riskLevel: string;
+  approvalPrompt: string;
+  details?: string;
+}
+
+interface AdfNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: AdfNode[];
+  text?: string;
 }
 
 /**
@@ -21,44 +60,93 @@ export async function executeJiraTool(
   input: any,
   context: ExecutorContext
 ): Promise<any> {
-  // Get cloud ID from metadata (set during OAuth)
-  const metadata = context.metadata as JiraMetadata | undefined;
-  const cloudId = metadata?.resources?.[0]?.id;
-  if (!cloudId) {
-    throw new Error('No Jira cloud ID found. Please reconnect Jira.');
-  }
-
-  const baseUrl = `${JIRA_API_BASE}/${cloudId}/rest/api/3`;
+  const api = resolveJiraApi(context.metadata);
   const headers = {
     Authorization: `Bearer ${context.accessToken}`,
+    Accept: 'application/json',
     'Content-Type': 'application/json'
   };
 
-  switch (toolName) {
-    case 'jira_search_issues':
-      return searchIssues(baseUrl, headers, input);
+  try {
+    switch (toolName) {
+      case 'jira_search_issues':
+        return await searchIssues(api.baseUrl, headers, input);
 
-    case 'jira_get_issue':
-      return getIssue(baseUrl, headers, input);
+      case 'jira_get_issue':
+        return await getIssue(api, headers, input);
 
-    case 'jira_get_my_issues':
-      return getMyIssues(baseUrl, headers, input);
+      case 'jira_get_my_issues':
+        return await getMyIssues(api.baseUrl, headers, input);
 
-    case 'jira_add_comment':
-      return addComment(baseUrl, headers, input);
+      case 'jira_add_comment':
+        return await addComment(api, headers, input);
 
-    case 'jira_transition_issue':
-      return transitionIssue(baseUrl, headers, input);
+      case 'jira_resolve_reviewers':
+        return await resolveReviewers(api, headers, input);
 
-    case 'jira_get_fields':
-      return getFields(baseUrl, headers);
+      case 'jira_post_proposal_comment':
+        return await postProposalComment(api, headers, input);
 
-    case 'jira_list_projects':
-      return listProjects(baseUrl, headers, input);
+      case 'jira_transition_issue':
+        return await transitionIssue(api.baseUrl, headers, input);
 
-    default:
-      throw new Error(`Unknown Jira tool: ${toolName}`);
+      case 'jira_get_fields':
+        return await getFields(api.baseUrl, headers);
+
+      case 'jira_list_projects':
+        return await listProjects(api.baseUrl, headers, input);
+
+      default:
+        throw new Error(`Unknown Jira tool: ${toolName}`);
+    }
+  } catch (error: unknown) {
+    throw normalizeJiraError(error);
   }
+}
+
+function resolveJiraApi(rawMetadata: unknown): JiraApiContext {
+  const metadata = rawMetadata as JiraMetadata | undefined;
+  const variant = normalizeApiVariant(metadata?.apiVariant, metadata);
+
+  if (variant === 'server') {
+    const browseBaseUrl = trimTrailingSlash(metadata?.baseUrl);
+    if (!browseBaseUrl) {
+      throw new Error('No Jira Server baseUrl found. Configure Jira metadata with apiVariant "server" and baseUrl, or reconnect Jira Cloud.');
+    }
+
+    return {
+      variant,
+      baseUrl: `${browseBaseUrl}/rest/api/2`,
+      browseBaseUrl
+    };
+  }
+
+  const resource = metadata?.resources?.[0];
+  const cloudId = resource?.id;
+  if (!cloudId) {
+    throw new Error('No Jira cloud ID found. Please reconnect Jira or configure Server metadata.');
+  }
+
+  return {
+    variant,
+    baseUrl: `${JIRA_API_BASE}/${cloudId}/rest/api/3`,
+    browseBaseUrl: trimTrailingSlash(resource?.url)
+  };
+}
+
+function normalizeApiVariant(apiVariant: string | undefined, metadata: JiraMetadata | undefined): JiraApiVariant {
+  if (!apiVariant && metadata?.baseUrl && !metadata.resources?.[0]?.id) {
+    return 'server';
+  }
+  if (!apiVariant || apiVariant === 'cloud') return 'cloud';
+  if (apiVariant === 'server' || apiVariant === 'data-center' || apiVariant === 'datacenter' || apiVariant === 'data_center') {
+    return 'server';
+  }
+  throw new Error(`Unsupported Jira API variant "${apiVariant}". Use "cloud" or "server".`);
+}
+
+function trimTrailingSlash(value: string | undefined): string | undefined {
+  return value?.replace(/\/+$/, '');
 }
 
 async function searchIssues(baseUrl: string, headers: any, input: any): Promise<any> {
@@ -79,17 +167,17 @@ async function searchIssues(baseUrl: string, headers: any, input: any): Promise<
   };
 }
 
-async function getIssue(baseUrl: string, headers: any, input: any): Promise<any> {
+async function getIssue(api: JiraApiContext, headers: any, input: any): Promise<any> {
   const { issueKey, expand } = input;
 
   const params = expand ? { expand: expand.join(',') } : {};
 
-  const response = await axios.get(`${baseUrl}/issue/${issueKey}`, {
+  const response = await axios.get(`${api.baseUrl}/issue/${issueKey}`, {
     headers,
     params
   });
 
-  return formatIssueDetailed(response.data);
+  return formatIssueDetailed(response.data, api.browseBaseUrl);
 }
 
 async function getMyIssues(baseUrl: string, headers: any, input: any): Promise<any> {
@@ -103,24 +191,128 @@ async function getMyIssues(baseUrl: string, headers: any, input: any): Promise<a
   return searchIssues(baseUrl, headers, { jql, maxResults });
 }
 
-async function addComment(baseUrl: string, headers: any, input: any): Promise<any> {
+async function addComment(api: JiraApiContext, headers: any, input: any): Promise<any> {
   const { issueKey, comment } = input;
 
-  const response = await axios.post(`${baseUrl}/issue/${issueKey}/comment`, {
-    body: {
-      type: 'doc',
-      version: 1,
-      content: [{
-        type: 'paragraph',
-        content: [{ type: 'text', text: comment }]
-      }]
-    }
+  const response = await axios.post(`${api.baseUrl}/issue/${issueKey}/comment`, {
+    body: api.variant === 'cloud'
+      ? createAdfDocument([paragraph(String(comment))])
+      : String(comment)
   }, { headers });
 
   return {
     success: true,
     commentId: response.data.id,
     message: `Comment added to ${issueKey}`
+  };
+}
+
+async function resolveReviewers(api: JiraApiContext, headers: any, input: any): Promise<any> {
+  const { issueKey } = input;
+  const reviewerFieldIds = toStringArray(input.reviewerFieldIds);
+  const fallbackOrder = normalizeFallbackOrder(input.fallbackOrder);
+  const fields = ['assignee', 'reporter', 'components', 'project', ...reviewerFieldIds];
+
+  const response = await axios.get(`${api.baseUrl}/issue/${issueKey}`, {
+    headers,
+    params: { fields: fields.join(',') }
+  });
+
+  const issue = response.data;
+  const issueFields = issue.fields ?? {};
+  const warnings: string[] = [];
+  let reviewers: ResolvedReviewer[] = [];
+
+  for (const source of fallbackOrder) {
+    const candidates = resolveReviewerSource(issueFields, source, reviewerFieldIds, warnings, issue.key ?? issueKey);
+    if (candidates.length > 0) {
+      reviewers = addUniqueReviewers(reviewers, candidates);
+      break;
+    }
+  }
+
+  const resolved = reviewers.length > 0;
+
+  return {
+    success: true,
+    issueKey: issue.key ?? issueKey,
+    resolved,
+    reviewers,
+    fallbackOrder,
+    warnings,
+    metadata: {
+      project: issueFields.project ? {
+        id: issueFields.project.id,
+        key: issueFields.project.key,
+        name: issueFields.project.name
+      } : undefined,
+      components: Array.isArray(issueFields.components)
+        ? issueFields.components.map((component: any) => component.name).filter(Boolean)
+        : []
+    },
+    message: resolved
+      ? `Resolved ${reviewers.length} reviewer(s) for ${issue.key ?? issueKey}.`
+      : `No reviewer could be resolved for ${issue.key ?? issueKey}. Ask a human to choose a reviewer or configure reviewerFieldIds.`
+  };
+}
+
+function resolveReviewerSource(
+  issueFields: any,
+  source: ReviewerFallbackSource,
+  reviewerFieldIds: string[],
+  warnings: string[],
+  issueKey: string
+): ResolvedReviewer[] {
+  if (source === 'customFields') {
+    return reviewerFieldIds.flatMap((fieldId) => {
+      if (!Object.prototype.hasOwnProperty.call(issueFields, fieldId)) {
+        warnings.push(`Reviewer field "${fieldId}" was not present on ${issueKey}. Check the field ID or Jira screen configuration.`);
+        return [];
+      }
+
+      const reviewers = normalizeReviewerValues(issueFields[fieldId], fieldId, fieldId);
+      if (reviewers.length === 0) {
+        warnings.push(`Reviewer field "${fieldId}" was present but empty on ${issueKey}.`);
+      }
+      return reviewers;
+    });
+  }
+
+  const reviewers = normalizeReviewerValues(issueFields[source], source);
+  if (reviewers.length === 0) {
+    warnings.push(`Reviewer source "${source}" was empty on ${issueKey}.`);
+  }
+  return reviewers;
+}
+
+async function postProposalComment(api: JiraApiContext, headers: any, input: any): Promise<any> {
+  const proposal = normalizeProposalCommentInput(input);
+  const body = api.variant === 'cloud'
+    ? buildProposalAdf(proposal)
+    : buildProposalText(proposal);
+
+  const response = await axios.post(`${api.baseUrl}/issue/${proposal.issueKey}/comment`, { body }, { headers });
+  const commentId = response.data.id;
+  const url = buildCommentUrl(api, proposal.issueKey, commentId);
+
+  return {
+    success: true,
+    commentId,
+    issueKey: proposal.issueKey,
+    url,
+    message: `Proposal comment posted to ${proposal.issueKey}.`
+  };
+}
+
+function normalizeProposalCommentInput(input: any): ProposalCommentInput {
+  return {
+    issueKey: String(input.issueKey),
+    summary: String(input.summary),
+    affectedComponents: toStringArray(input.affectedComponents),
+    proposedChanges: toStringArray(input.proposedChanges),
+    riskLevel: String(input.riskLevel),
+    approvalPrompt: String(input.approvalPrompt),
+    details: input.details ? String(input.details) : undefined
   };
 }
 
@@ -179,6 +371,227 @@ async function getFields(baseUrl: string, headers: any): Promise<any> {
   };
 }
 
+function normalizeFallbackOrder(input: unknown): ReviewerFallbackSource[] {
+  if (!Array.isArray(input) || input.length === 0) {
+    return [...DEFAULT_REVIEWER_FALLBACK_ORDER];
+  }
+
+  return input.map((source) => {
+    if (source === 'customFields' || source === 'assignee' || source === 'reporter') {
+      return source;
+    }
+    throw new Error(`Unsupported reviewer fallback source "${String(source)}". Use customFields, assignee, or reporter.`);
+  });
+}
+
+function normalizeReviewerValues(value: unknown, source: string, fieldId?: string): ResolvedReviewer[] {
+  if (value === undefined || value === null || value === '') return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => normalizeReviewerValues(item, source, fieldId));
+  }
+
+  if (typeof value === 'string') {
+    return [{
+      source,
+      displayName: value,
+      username: value,
+      fieldId
+    }];
+  }
+
+  if (typeof value === 'object') {
+    const candidate = value as Record<string, unknown>;
+    const displayName = firstString(candidate.displayName, candidate.name, candidate.emailAddress, candidate.accountId, candidate.key);
+    if (!displayName) return [];
+
+    return [{
+      source,
+      displayName,
+      accountId: stringOrUndefined(candidate.accountId),
+      username: stringOrUndefined(candidate.name),
+      key: stringOrUndefined(candidate.key),
+      active: typeof candidate.active === 'boolean' ? candidate.active : undefined,
+      fieldId
+    }];
+  }
+
+  return [];
+}
+
+function addUniqueReviewers(existing: ResolvedReviewer[], candidates: ResolvedReviewer[]): ResolvedReviewer[] {
+  const seen = new Set(existing.map(reviewerIdentityKey));
+  const merged = [...existing];
+
+  for (const candidate of candidates) {
+    const key = reviewerIdentityKey(candidate);
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(candidate);
+    }
+  }
+
+  return merged;
+}
+
+function reviewerIdentityKey(reviewer: ResolvedReviewer): string {
+  return reviewer.accountId ?? reviewer.username ?? reviewer.key ?? reviewer.displayName;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item)).filter((item) => item.trim().length > 0);
+}
+
+function buildProposalAdf(input: ProposalCommentInput): AdfNode {
+  return createAdfDocument([
+    heading('Remediation Proposal', 2),
+    heading('Summary', 3),
+    paragraph(input.summary),
+    heading('Affected components', 3),
+    ...listOrParagraph(input.affectedComponents),
+    heading('Proposed changes', 3),
+    ...listOrParagraph(input.proposedChanges),
+    heading('Risk level', 3),
+    paragraph(input.riskLevel),
+    heading('Approval prompt', 3),
+    paragraph(input.approvalPrompt),
+    ...(input.details ? [heading('Details', 3), paragraph(input.details)] : [])
+  ]);
+}
+
+function buildProposalText(input: ProposalCommentInput): string {
+  return [
+    'h2. Remediation Proposal',
+    '',
+    'h3. Summary',
+    input.summary,
+    '',
+    'h3. Affected components',
+    formatWikiList(input.affectedComponents),
+    '',
+    'h3. Proposed changes',
+    formatWikiList(input.proposedChanges),
+    '',
+    'h3. Risk level',
+    input.riskLevel,
+    '',
+    'h3. Approval prompt',
+    input.approvalPrompt,
+    ...(input.details ? ['', 'h3. Details', input.details] : [])
+  ].join('\n');
+}
+
+function createAdfDocument(content: AdfNode[]): AdfNode {
+  return {
+    type: 'doc',
+    version: 1,
+    content
+  } as AdfNode;
+}
+
+function heading(text: string, level: number): AdfNode {
+  return {
+    type: 'heading',
+    attrs: { level },
+    content: [{ type: 'text', text }]
+  };
+}
+
+function paragraph(text: string): AdfNode {
+  return {
+    type: 'paragraph',
+    content: [{ type: 'text', text }]
+  };
+}
+
+function listOrParagraph(items: string[]): AdfNode[] {
+  if (items.length === 0) {
+    return [paragraph('None specified')];
+  }
+
+  return [{
+    type: 'bulletList',
+    content: items.map((item) => ({
+      type: 'listItem',
+      content: [paragraph(item)]
+    }))
+  }];
+}
+
+function formatWikiList(items: string[]): string {
+  if (items.length === 0) return 'None specified';
+  return items.map((item) => `* ${item}`).join('\n');
+}
+
+function buildCommentUrl(api: JiraApiContext, issueKey: string, commentId: unknown): string | undefined {
+  if (!api.browseBaseUrl || !commentId) return undefined;
+  return `${api.browseBaseUrl}/browse/${issueKey}?focusedCommentId=${commentId}`;
+}
+
+function normalizeJiraError(error: unknown): Error {
+  const response = getErrorResponse(error);
+  if (!response) {
+    return error instanceof Error ? error : new Error('Jira tool failed with an unknown error.');
+  }
+
+  const detail = extractJiraErrorDetail(response.data);
+  switch (response.status) {
+    case 400:
+      return new Error(`Jira rejected the request payload. Check the tool inputs and Jira field configuration.${detail}`);
+    case 401:
+    case 403:
+      return new Error(`Jira authentication or permission error. Reconnect Jira or ask an administrator to grant access.${detail}`);
+    case 404:
+      return new Error(`Jira issue not found or not accessible. Check the issue key and permissions.${detail}`);
+    default:
+      return new Error(`Jira API request failed${response.status ? ` (${response.status})` : ''}. Check Jira connectivity and connection metadata.${detail}`);
+  }
+}
+
+function getErrorResponse(error: unknown): { status?: number; data?: unknown } | undefined {
+  if (!error || typeof error !== 'object' || !('response' in error)) {
+    return undefined;
+  }
+
+  const response = (error as { response?: unknown }).response;
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return response as { status?: number; data?: unknown };
+}
+
+function extractJiraErrorDetail(data: unknown): string {
+  if (!data || typeof data !== 'object') return '';
+
+  const record = data as Record<string, unknown>;
+  const messages: string[] = [];
+
+  if (typeof record.message === 'string') {
+    messages.push(record.message);
+  }
+
+  if (Array.isArray(record.errorMessages)) {
+    messages.push(...record.errorMessages.filter((message): message is string => typeof message === 'string'));
+  }
+
+  if (record.errors && typeof record.errors === 'object') {
+    messages.push(...Object.entries(record.errors as Record<string, unknown>)
+      .map(([field, message]) => `${field}: ${String(message)}`));
+  }
+
+  return messages.length > 0 ? ` Jira said: ${messages.join('; ')}` : '';
+}
+
 // Formatters
 function formatIssue(issue: any): any {
   return {
@@ -192,7 +605,7 @@ function formatIssue(issue: any): any {
   };
 }
 
-function formatIssueDetailed(issue: any): any {
+function formatIssueDetailed(issue: any, browseBaseUrl?: string): any {
   return {
     key: issue.key,
     summary: issue.fields.summary,
@@ -209,7 +622,7 @@ function formatIssueDetailed(issue: any): any {
       key: issue.fields.project?.key,
       name: issue.fields.project?.name
     },
-    url: `https://example-org.atlassian.net/browse/${issue.key}`
+    url: browseBaseUrl ? `${browseBaseUrl}/browse/${issue.key}` : undefined
   };
 }
 
@@ -237,7 +650,7 @@ function extractBlockText(block: any): string {
 
   if (block.type === 'bulletList' || block.type === 'orderedList') {
     return block.content?.map((item: any) =>
-      '• ' + extractBlockText(item)
+      '- ' + extractBlockText(item)
     ).join('\n') || '';
   }
 

--- a/joyus-ai-mcp-server/src/tools/jira-tools.ts
+++ b/joyus-ai-mcp-server/src/tools/jira-tools.ts
@@ -95,6 +95,70 @@ export const jiraTools: ToolDefinition[] = [
     }
   },
   {
+    name: 'jira_resolve_reviewers',
+    description: 'Resolve remediation proposal reviewers from Jira issue metadata such as custom reviewer fields, assignee, and reporter',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issueKey: {
+          type: 'string',
+          description: 'Issue key like PROJ-123'
+        },
+        reviewerFieldIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional Jira field IDs to check first, such as customfield_10010'
+        },
+        fallbackOrder: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Reviewer source order using customFields, assignee, and reporter'
+        }
+      },
+      required: ['issueKey']
+    }
+  },
+  {
+    name: 'jira_post_proposal_comment',
+    description: 'Post a structured remediation proposal comment to a Jira issue for reviewer approval',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issueKey: {
+          type: 'string',
+          description: 'Issue key like PROJ-123'
+        },
+        summary: {
+          type: 'string',
+          description: 'Short summary of the remediation proposal'
+        },
+        affectedComponents: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Components or areas affected by the proposal'
+        },
+        proposedChanges: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Specific proposed remediation changes'
+        },
+        riskLevel: {
+          type: 'string',
+          description: 'Risk level for the proposed change'
+        },
+        approvalPrompt: {
+          type: 'string',
+          description: 'Question or instruction asking the reviewer for approval'
+        },
+        details: {
+          type: 'string',
+          description: 'Optional supporting details to include after the required sections'
+        }
+      },
+      required: ['issueKey', 'summary', 'affectedComponents', 'proposedChanges', 'riskLevel', 'approvalPrompt']
+    }
+  },
+  {
     name: 'jira_transition_issue',
     description: 'Move a Jira issue to a different status (e.g., "In Progress", "Done")',
     inputSchema: {

--- a/joyus-ai-mcp-server/tests/tools.test.ts
+++ b/joyus-ai-mcp-server/tests/tools.test.ts
@@ -46,6 +46,8 @@ describe('Tool Definitions', () => {
       expect(toolNames).toContain('jira_search_issues');
       expect(toolNames).toContain('jira_get_issue');
       expect(toolNames).toContain('jira_add_comment');
+      expect(toolNames).toContain('jira_resolve_reviewers');
+      expect(toolNames).toContain('jira_post_proposal_comment');
     });
 
     it('should have required fields specified', () => {
@@ -54,6 +56,17 @@ describe('Tool Definitions', () => {
 
       const getIssueTool = jiraTools.find(t => t.name === 'jira_get_issue');
       expect(getIssueTool?.inputSchema.required).toContain('issueKey');
+
+      const resolveReviewersTool = jiraTools.find(t => t.name === 'jira_resolve_reviewers');
+      expect(resolveReviewersTool?.inputSchema.required).toContain('issueKey');
+
+      const proposalTool = jiraTools.find(t => t.name === 'jira_post_proposal_comment');
+      expect(proposalTool?.inputSchema.required).toContain('issueKey');
+      expect(proposalTool?.inputSchema.required).toContain('summary');
+      expect(proposalTool?.inputSchema.required).toContain('affectedComponents');
+      expect(proposalTool?.inputSchema.required).toContain('proposedChanges');
+      expect(proposalTool?.inputSchema.required).toContain('riskLevel');
+      expect(proposalTool?.inputSchema.required).toContain('approvalPrompt');
     });
   });
 

--- a/joyus-ai-mcp-server/tests/tools/jira-executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/jira-executor.test.ts
@@ -19,6 +19,14 @@ const context = {
   },
 };
 
+const serverContext = {
+  ...context,
+  metadata: {
+    apiVariant: 'server',
+    baseUrl: 'https://jira.example.test',
+  },
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -48,6 +56,9 @@ describe('executeJiraTool', () => {
     );
 
     expect(result).toBeDefined();
+    expect(vi.mocked(axios.post).mock.calls[0][0]).toBe(
+      'https://api.atlassian.com/ex/jira/cloud-123/rest/api/3/search',
+    );
   });
 
   it('jira_search_issues — can return raw issue fields', async () => {
@@ -163,6 +174,277 @@ describe('executeJiraTool', () => {
       message: 'Comment added to PROJ-1',
     });
     expect(vi.mocked(axios.post).mock.calls[0][1].body.content[0].content[0].text).toBe('Looks good');
+  });
+
+  it('jira_resolve_reviewers — resolves a custom reviewer field when provided', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-1',
+        fields: {
+          customfield_10010: [
+            { accountId: 'account-1', displayName: 'Reviewer A', active: true },
+          ],
+          assignee: { accountId: 'account-2', displayName: 'Assignee B' },
+          reporter: { accountId: 'account-3', displayName: 'Reporter C' },
+          components: [{ name: 'Navigation' }],
+          project: { id: '10000', key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-1', reviewerFieldIds: ['customfield_10010'] },
+      context,
+    );
+
+    expect(result.resolved).toBe(true);
+    expect(result.reviewers).toEqual([
+      {
+        source: 'customfield_10010',
+        displayName: 'Reviewer A',
+        accountId: 'account-1',
+        active: true,
+        fieldId: 'customfield_10010',
+      },
+    ]);
+    expect(result.metadata.components).toEqual(['Navigation']);
+    expect(vi.mocked(axios.get).mock.calls[0][1].params.fields).toContain('customfield_10010');
+  });
+
+  it('jira_resolve_reviewers — falls back to assignee', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-2',
+        fields: {
+          customfield_10010: null,
+          assignee: { accountId: 'account-2', displayName: 'Assignee B', active: true },
+          reporter: { accountId: 'account-3', displayName: 'Reporter C' },
+          components: [],
+          project: { key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-2', reviewerFieldIds: ['customfield_10010'] },
+      context,
+    );
+
+    expect(result.resolved).toBe(true);
+    expect(result.reviewers[0]).toMatchObject({
+      source: 'assignee',
+      displayName: 'Assignee B',
+      accountId: 'account-2',
+    });
+    expect(result.warnings).toContain('Reviewer field "customfield_10010" was present but empty on PROJ-2.');
+  });
+
+  it('jira_resolve_reviewers — falls back to reporter', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-3',
+        fields: {
+          assignee: null,
+          reporter: { name: 'reporter-b', displayName: 'Reporter B', active: true },
+          components: [],
+          project: { key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-3' },
+      context,
+    );
+
+    expect(result.resolved).toBe(true);
+    expect(result.reviewers[0]).toMatchObject({
+      source: 'reporter',
+      displayName: 'Reporter B',
+      username: 'reporter-b',
+    });
+    expect(result.warnings).toContain('Reviewer source "assignee" was empty on PROJ-3.');
+  });
+
+  it('jira_resolve_reviewers — returns a clear unresolved result when sources are empty', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-4',
+        fields: {
+          assignee: null,
+          reporter: null,
+          components: [],
+          project: { key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-4' },
+      context,
+    );
+
+    expect(result.resolved).toBe(false);
+    expect(result.reviewers).toEqual([]);
+    expect(result.message).toContain('Ask a human to choose a reviewer');
+  });
+
+  it('jira_resolve_reviewers — reports missing custom reviewer fields', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-5',
+        fields: {
+          assignee: { accountId: 'account-2', displayName: 'Assignee B' },
+          reporter: null,
+          components: [],
+          project: { key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-5', reviewerFieldIds: ['customfield_10099'] },
+      context,
+    );
+
+    expect(result.resolved).toBe(true);
+    expect(result.reviewers[0].source).toBe('assignee');
+    expect(result.warnings[0]).toContain('Reviewer field "customfield_10099" was not present');
+  });
+
+  it('jira_resolve_reviewers — uses Server API v2 metadata', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        key: 'PROJ-6',
+        fields: {
+          assignee: { name: 'reviewer-a', displayName: 'Reviewer A' },
+          reporter: null,
+          components: [],
+          project: { key: 'PROJ', name: 'Project' },
+        },
+      },
+    });
+
+    const result = await executeJiraTool(
+      'jira_resolve_reviewers',
+      { issueKey: 'PROJ-6' },
+      serverContext,
+    );
+
+    expect(result.reviewers[0]).toMatchObject({
+      source: 'assignee',
+      username: 'reviewer-a',
+    });
+    expect(vi.mocked(axios.get).mock.calls[0][0]).toBe(
+      'https://jira.example.test/rest/api/2/issue/PROJ-6',
+    );
+  });
+
+  it('jira_post_proposal_comment — posts Cloud ADF with required sections', async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: { id: '10001' },
+    });
+
+    const result = await executeJiraTool(
+      'jira_post_proposal_comment',
+      {
+        issueKey: 'PROJ-7',
+        summary: 'Improve keyboard focus handling.',
+        affectedComponents: ['Navigation', 'Checkout Form'],
+        proposedChanges: ['Add visible focus state', 'Preserve tab order'],
+        riskLevel: 'medium',
+        approvalPrompt: 'Approve this remediation plan?',
+      },
+      context,
+    );
+
+    const body = vi.mocked(axios.post).mock.calls[0][1].body;
+    const serializedBody = JSON.stringify(body);
+    expect(result).toMatchObject({
+      success: true,
+      commentId: '10001',
+      issueKey: 'PROJ-7',
+      url: 'https://test.atlassian.net/browse/PROJ-7?focusedCommentId=10001',
+    });
+    expect(body.type).toBe('doc');
+    expect(serializedBody).toContain('Summary');
+    expect(serializedBody).toContain('Affected components');
+    expect(serializedBody).toContain('Proposed changes');
+    expect(serializedBody).toContain('Risk level');
+    expect(serializedBody).toContain('Approval prompt');
+    expect(serializedBody).toContain('Checkout Form');
+  });
+
+  it('jira_post_proposal_comment — posts Server text with required sections', async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: { id: '20002' },
+    });
+
+    const result = await executeJiraTool(
+      'jira_post_proposal_comment',
+      {
+        issueKey: 'PROJ-8',
+        summary: 'Clarify form labels.',
+        affectedComponents: ['Checkout Form'],
+        proposedChanges: ['Associate labels with inputs'],
+        riskLevel: 'low',
+        approvalPrompt: 'Can this change proceed?',
+        details: 'Tested with keyboard-only navigation.',
+      },
+      serverContext,
+    );
+
+    const requestBody = vi.mocked(axios.post).mock.calls[0][1].body;
+    expect(result.url).toBe('https://jira.example.test/browse/PROJ-8?focusedCommentId=20002');
+    expect(vi.mocked(axios.post).mock.calls[0][0]).toBe(
+      'https://jira.example.test/rest/api/2/issue/PROJ-8/comment',
+    );
+    expect(requestBody).toContain('h3. Summary');
+    expect(requestBody).toContain('* Checkout Form');
+    expect(requestBody).toContain('h3. Proposed changes');
+    expect(requestBody).toContain('h3. Risk level');
+    expect(requestBody).toContain('h3. Approval prompt');
+    expect(requestBody).toContain('h3. Details');
+  });
+
+  it('maps Jira permission failures to a clear error', async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce({
+      response: { status: 403, data: { message: 'Forbidden' } },
+    });
+
+    await expect(
+      executeJiraTool(
+        'jira_post_proposal_comment',
+        {
+          issueKey: 'PROJ-9',
+          summary: 'Update status text.',
+          affectedComponents: ['Navigation'],
+          proposedChanges: ['Use clearer status message'],
+          riskLevel: 'low',
+          approvalPrompt: 'Approve?',
+        },
+        context,
+      ),
+    ).rejects.toThrow('Jira authentication or permission error');
+  });
+
+  it('maps Jira issue-not-found failures to a clear error', async () => {
+    vi.mocked(axios.get).mockRejectedValueOnce({
+      response: { status: 404, data: { errorMessages: ['Issue does not exist'] } },
+    });
+
+    await expect(
+      executeJiraTool(
+        'jira_resolve_reviewers',
+        { issueKey: 'PROJ-404' },
+        context,
+      ),
+    ).rejects.toThrow('Jira issue not found or not accessible');
   });
 
   it('jira_transition_issue — posts matching transition id', async () => {


### PR DESCRIPTION
## Summary
- add Jira MCP helper to resolve proposal reviewers from issue metadata
- add structured remediation proposal comments for Jira Cloud and Server-style API variants
- cover reviewer fallback, comment formatting, and common Jira failure modes in focused tests

## Tests
- npm test -- tests/tools/jira-executor.test.ts tests/tools.test.ts tests/tools/executor.test.ts
- npm run build
- npm run lint
- npm run db:check
- npm test
- ./scripts/check-client-abstraction.sh --staged
- git diff --cached --check

Closes #7
Part of #17