### PR TITLE
[codex] Add CI check observability tools

### DIFF
--- a/joyus-ai-mcp-server/README.md
+++ b/joyus-ai-mcp-server/README.md
@@ -192,6 +192,8 @@ docker-compose up
 | `github_create_pr` | Create a pull request |
 | `github_request_reviewers` | Request PR reviewers |
 | `github_get_pr_checks` | Get PR check status |
+| `github_watch_pr_checks` | Poll CI checks until complete or timeout |
+| `github_get_check_annotations` | Get check annotations and a11y failures |
 | `github_list_issues` | List issues |
 | `github_get_issue` | Get issue details |
 | `github_list_repos` | List org repos |

--- a/joyus-ai-mcp-server/src/tools/executors/github-a11y-parser.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/github-a11y-parser.ts
@@ -1,0 +1,183 @@
+/**
+ * Extract accessibility failures from common CI check output.
+ */
+
+export type A11yTool = 'axe-core' | 'lighthouse' | 'pa11y' | 'unknown-a11y';
+
+export interface A11yFindingInput {
+  source?: string;
+  path?: string;
+  url?: string;
+  message?: string;
+  title?: string;
+  rawDetails?: string;
+  annotationLevel?: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface A11yFailure {
+  source: A11yTool;
+  ruleId?: string;
+  severity?: string;
+  path?: string;
+  url?: string;
+  selector?: string;
+  message: string;
+  helpUrl?: string;
+  rawExcerpt: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+const A11Y_TERMS = /\b(a11y|accessibility|aria|wcag|axe(?:-core)?|lighthouse|pa11y|contrast|screen reader|keyboard|accessible name)\b/i;
+const HELP_URL_TERMS = /(dequeuniversity\.com|web\.dev|w3\.org\/WAI|pa11y\.org)/i;
+const MAX_EXCERPT_LENGTH = 500;
+const MAX_MESSAGE_LENGTH = 240;
+
+/**
+ * Parse one or more text blocks into structured accessibility failures.
+ */
+export function extractA11yFailures(inputs: A11yFindingInput[]): A11yFailure[] {
+  return inputs
+    .map(parseA11yFailure)
+    .filter((failure): failure is A11yFailure => failure !== null);
+}
+
+function parseA11yFailure(input: A11yFindingInput): A11yFailure | null {
+  const rawParts = [input.source, input.title, input.message, input.rawDetails].filter(Boolean);
+  const raw = rawParts.join('\n').trim();
+
+  if (!raw || !A11Y_TERMS.test(raw)) {
+    return null;
+  }
+
+  const source = detectTool(raw);
+  if (!source) {
+    return null;
+  }
+
+  const urls = extractUrls(raw);
+  const helpUrl = urls.find((url) => HELP_URL_TERMS.test(url));
+  const contentUrl = input.url ?? urls.find((url) => url !== helpUrl);
+  const ruleId = extractRuleId(raw, source);
+  const severity = extractSeverity(raw, input.annotationLevel);
+  const selector = extractSelector(raw);
+
+  return {
+    source,
+    ...(ruleId ? { ruleId } : {}),
+    ...(severity ? { severity } : {}),
+    ...(input.path ? { path: input.path } : {}),
+    ...(contentUrl ? { url: contentUrl } : {}),
+    ...(selector ? { selector } : {}),
+    message: buildMessage(input.title, input.message, input.rawDetails),
+    ...(helpUrl ? { helpUrl } : {}),
+    rawExcerpt: boundText(raw, MAX_EXCERPT_LENGTH),
+    ...(input.startLine !== undefined ? { startLine: input.startLine } : {}),
+    ...(input.endLine !== undefined ? { endLine: input.endLine } : {})
+  };
+}
+
+function detectTool(raw: string): A11yTool | null {
+  if (/\baxe(?:-core)?\b/i.test(raw) || /dequeuniversity\.com\/rules\/axe/i.test(raw)) {
+    return 'axe-core';
+  }
+
+  if (/\blighthouse\b/i.test(raw) || /web\.dev\/measure/i.test(raw)) {
+    return 'lighthouse';
+  }
+
+  if (/\bpa11y\b/i.test(raw) || /\bWCAG2[AAA]?\./i.test(raw)) {
+    return 'pa11y';
+  }
+
+  return A11Y_TERMS.test(raw) ? 'unknown-a11y' : null;
+}
+
+function extractRuleId(raw: string, source: A11yTool): string | undefined {
+  const helpRule = raw.match(/dequeuniversity\.com\/rules\/axe\/[^/\s]+\/([a-z0-9-]+)/i);
+  if (helpRule?.[1]) {
+    return cleanToken(helpRule[1]);
+  }
+
+  const pa11yCode = raw.match(/\b(WCAG2[AAA]?\.[A-Za-z0-9_.-]+)/i);
+  if (pa11yCode?.[1]) {
+    return cleanToken(pa11yCode[1]);
+  }
+
+  const labeledRule = raw.match(/\b(?:rule|rule id|id|audit|violation|code)[:=]\s*([A-Za-z0-9_.:-]+)/i);
+  if (labeledRule?.[1]) {
+    return cleanToken(labeledRule[1]);
+  }
+
+  const commonRule = raw.match(/\b(aria-[a-z0-9-]+|color-contrast|image-alt|label|link-name|button-name|document-title|html-has-lang|html-lang-valid|heading-order|landmark-one-main)\b/i);
+  if (commonRule?.[1]) {
+    return cleanToken(commonRule[1]);
+  }
+
+  if (source === 'lighthouse') {
+    const bracketedAudit = raw.match(/\[([a-z0-9-]+)\]/i);
+    if (bracketedAudit?.[1]) {
+      return cleanToken(bracketedAudit[1]);
+    }
+  }
+
+  return undefined;
+}
+
+function extractSeverity(raw: string, annotationLevel?: string): string | undefined {
+  const impact = raw.match(/\b(?:impact|severity|level)[:=]\s*(critical|serious|moderate|minor|error|warning|notice|failure)\b/i);
+  if (impact?.[1]) {
+    return impact[1].toLowerCase();
+  }
+
+  const inlineSeverity = raw.match(/\b(critical|serious|moderate|minor|error|warning|notice|failure)\b/i);
+  if (inlineSeverity?.[1]) {
+    return inlineSeverity[1].toLowerCase();
+  }
+
+  return annotationLevel?.toLowerCase();
+}
+
+function extractSelector(raw: string): string | undefined {
+  const selector = raw.match(/\b(?:selector|target|node)[:=]\s*(\[[^\n]+\]|`[^`]+`|"[^"]+"|'[^']+'|[^\n;,]+)/i);
+  if (!selector?.[1]) {
+    return undefined;
+  }
+
+  return selector[1]
+    .replace(/^[`'"]+/, '')
+    .replace(/[`'"]+$/, '')
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .trim();
+}
+
+function extractUrls(raw: string): string[] {
+  const matches = raw.match(/https?:\/\/[^\s)]+/g) ?? [];
+  return matches.map((url) => url.replace(/[.,;]+$/, ''));
+}
+
+function buildMessage(title?: string, message?: string, rawDetails?: string): string {
+  const text = [title, message, rawDetails]
+    .filter(Boolean)
+    .join(' — ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return boundText(text, MAX_MESSAGE_LENGTH);
+}
+
+function cleanToken(token: string): string {
+  return token.replace(/[.,;:)]+$/, '').trim();
+}
+
+function boundText(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 3).trim()}...`;
+}

--- a/joyus-ai-mcp-server/src/tools/executors/github-executor.ts
+++ b/joyus-ai-mcp-server/src/tools/executors/github-executor.ts
@@ -7,7 +7,11 @@ import axios from 'axios';
 
 import { ExecutorContext } from '../executor.js';
 
+import { extractA11yFailures, type A11yFindingInput } from './github-a11y-parser.js';
+
 const GITHUB_API_BASE = 'https://api.github.com';
+const DEFAULT_CHECK_POLL_INTERVAL_MS = 10000;
+const DEFAULT_CHECK_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
  * Execute a GitHub tool
@@ -42,6 +46,12 @@ export async function executeGithubTool(
 
       case 'github_get_pr_checks':
         return await getPRChecks(headers, input);
+
+      case 'github_watch_pr_checks':
+        return await watchPRChecks(headers, input);
+
+      case 'github_get_check_annotations':
+        return await getCheckAnnotations(headers, input);
 
       case 'github_list_issues':
         return await listIssues(headers, input);
@@ -205,26 +215,156 @@ async function requestReviewers(headers: any, input: any): Promise<any> {
 }
 
 async function getPRChecks(headers: any, input: any): Promise<any> {
-  const { repo, prNumber } = input;
+  return fetchCheckSnapshot(headers, input);
+}
 
-  const prResponse = await axios.get(`${GITHUB_API_BASE}/repos/${repo}/pulls/${prNumber}`, { headers });
-  const headSha = prResponse.data.head.sha;
+async function watchPRChecks(headers: any, input: any): Promise<any> {
+  const pollIntervalMs = clampNumber(
+    input.pollIntervalMs ?? DEFAULT_CHECK_POLL_INTERVAL_MS,
+    0,
+    60 * 1000
+  );
+  const timeoutMs = clampNumber(
+    input.timeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS,
+    0,
+    60 * 60 * 1000
+  );
+  const startedAt = Date.now();
+  let attempts = 0;
+  let snapshot: any;
+  let timedOut = false;
+
+  do {
+    attempts += 1;
+    snapshot = await fetchCheckSnapshot(headers, input);
+
+    if (!shouldContinuePolling(snapshot.overallState)) {
+      break;
+    }
+
+    const elapsedMs = Date.now() - startedAt;
+    const remainingMs = timeoutMs - elapsedMs;
+
+    if (remainingMs <= 0) {
+      timedOut = true;
+      break;
+    }
+
+    if (pollIntervalMs <= 0) {
+      break;
+    }
+
+    await delay(Math.min(pollIntervalMs, remainingMs));
+  } while (shouldContinuePolling(snapshot.overallState));
+
+  const elapsedMs = Date.now() - startedAt;
+
+  if (timedOut) {
+    return buildTimeoutSnapshot(snapshot, attempts, elapsedMs);
+  }
+
+  return {
+    ...snapshot,
+    pollAttempts: attempts,
+    elapsedMs,
+    timedOut: false
+  };
+}
+
+async function getCheckAnnotations(headers: any, input: any): Promise<any> {
+  const annotations = await fetchCheckRunAnnotations(headers, input);
+  const a11yFailures = extractA11yFailures(annotations.map(annotationToA11yInput));
+
+  return {
+    checkRunId: input.checkRunId,
+    count: annotations.length,
+    annotations,
+    a11yFailures,
+    remediationRecommended: a11yFailures.length > 0,
+    nextAction: determineAnnotationNextAction(annotations.length, a11yFailures)
+  };
+}
+
+async function fetchCheckSnapshot(headers: any, input: any): Promise<any> {
+  const { repo, includeAnnotations = false, annotationLimit = 50 } = input;
+  const headSha = await resolveHeadSha(headers, input);
 
   const [checkRunsResponse, statusResponse] = await Promise.all([
     axios.get(`${GITHUB_API_BASE}/repos/${repo}/commits/${headSha}/check-runs`, { headers }),
     axios.get(`${GITHUB_API_BASE}/repos/${repo}/commits/${headSha}/status`, { headers })
   ]);
 
-  const checkRuns = (checkRunsResponse.data.check_runs ?? []).map((run: any) => ({
+  const checkRuns = (checkRunsResponse.data.check_runs ?? []).map(normalizeCheckRun);
+  const statuses = (statusResponse.data.statuses ?? []).map(normalizeCommitStatus);
+  const annotations = includeAnnotations
+    ? await fetchBoundedAnnotations(headers, repo, checkRuns, annotationLimit)
+    : [];
+  const a11yFailures = extractA11yFailures([
+    ...checkRuns.flatMap(checkRunToA11yInputs),
+    ...statuses.map(statusToA11yInput),
+    ...annotations.map(annotationToA11yInput)
+  ]);
+  const summary = summarizePRChecks(checkRuns, statuses, a11yFailures.length);
+
+  return {
+    headSha,
+    overallState: summary.overallState,
+    checkRuns,
+    statuses,
+    ...(includeAnnotations ? { annotations } : {}),
+    a11yFailures,
+    remediationRecommended: a11yFailures.length > 0 && summary.overallState === 'failure',
+    nextAction: determineNextAction(summary.overallState, a11yFailures),
+    summary
+  };
+}
+
+async function resolveHeadSha(headers: any, input: any): Promise<string> {
+  const { repo, prNumber, sha } = input;
+
+  if (sha) {
+    return sha;
+  }
+
+  if (prNumber) {
+    const prResponse = await axios.get(`${GITHUB_API_BASE}/repos/${repo}/pulls/${prNumber}`, { headers });
+    return prResponse.data.head.sha;
+  }
+
+  throw new Error('Either prNumber or sha is required to inspect GitHub checks');
+}
+
+function normalizeCheckRun(run: any): any {
+  const output = normalizeCheckRunOutput(run.output);
+
+  return {
+    ...(run.id !== undefined ? { id: run.id } : {}),
     name: run.name,
     status: run.status,
     conclusion: run.conclusion,
     startedAt: run.started_at,
     completedAt: run.completed_at,
     detailsUrl: run.details_url,
-    url: run.html_url
-  }));
-  const statuses = (statusResponse.data.statuses ?? []).map((status: any) => ({
+    url: run.html_url,
+    ...(run.check_run_url ? { annotationsUrl: `${run.check_run_url}/annotations` } : {}),
+    ...(output ? { output } : {})
+  };
+}
+
+function normalizeCheckRunOutput(output: any): any | undefined {
+  if (!output || (!output.title && !output.summary && !output.text)) {
+    return undefined;
+  }
+
+  return {
+    title: output.title,
+    summary: output.summary ? boundText(output.summary, 2000) : undefined,
+    text: output.text ? boundText(output.text, 4000) : undefined
+  };
+}
+
+function normalizeCommitStatus(status: any): any {
+  return {
     context: status.context,
     state: status.state,
     description: status.description,
@@ -232,15 +372,99 @@ async function getPRChecks(headers: any, input: any): Promise<any> {
     createdAt: status.created_at,
     updatedAt: status.updated_at,
     url: status.url
-  }));
-  const summary = summarizePRChecks(checkRuns, statuses);
+  };
+}
 
+async function fetchBoundedAnnotations(headers: any, repo: string, checkRuns: any[], limit: number): Promise<any[]> {
+  const annotations: any[] = [];
+  const cappedLimit = clampNumber(limit, 0, 100);
+
+  for (const run of checkRuns) {
+    if (annotations.length >= cappedLimit || !run.id || run.conclusion === 'success') {
+      continue;
+    }
+
+    const remaining = cappedLimit - annotations.length;
+    const runAnnotations = await fetchCheckRunAnnotations(headers, {
+      repo,
+      checkRunId: run.id,
+      per_page: remaining
+    });
+
+    annotations.push(
+      ...runAnnotations.map((annotation) => ({
+        ...annotation,
+        checkRunId: run.id,
+        checkRunName: run.name
+      }))
+    );
+  }
+
+  return annotations;
+}
+
+async function fetchCheckRunAnnotations(headers: any, input: any): Promise<any[]> {
+  const { repo, checkRunId, page = 1, per_page = 100 } = input;
+
+  const response = await axios.get(
+    `${GITHUB_API_BASE}/repos/${repo}/check-runs/${checkRunId}/annotations`,
+    {
+      headers,
+      params: {
+        page,
+        per_page: Math.min(per_page, 100)
+      }
+    }
+  );
+
+  return (response.data ?? []).map(normalizeCheckAnnotation);
+}
+
+function normalizeCheckAnnotation(annotation: any): any {
   return {
-    headSha,
-    overallState: summary.overallState,
-    checkRuns,
-    statuses,
-    summary
+    path: annotation.path,
+    startLine: annotation.start_line,
+    endLine: annotation.end_line,
+    startColumn: annotation.start_column,
+    endColumn: annotation.end_column,
+    annotationLevel: annotation.annotation_level,
+    title: annotation.title,
+    message: annotation.message,
+    rawDetails: annotation.raw_details ? boundText(annotation.raw_details, 2000) : undefined,
+    blobUrl: annotation.blob_href
+  };
+}
+
+function checkRunToA11yInputs(run: any): A11yFindingInput[] {
+  return [
+    {
+      source: run.name,
+      title: run.output?.title,
+      message: run.output?.summary,
+      rawDetails: run.output?.text,
+      url: run.detailsUrl ?? run.url
+    }
+  ];
+}
+
+function statusToA11yInput(status: any): A11yFindingInput {
+  return {
+    source: status.context,
+    message: status.description,
+    url: status.targetUrl
+  };
+}
+
+function annotationToA11yInput(annotation: any): A11yFindingInput {
+  return {
+    source: annotation.checkRunName ?? annotation.title,
+    path: annotation.path,
+    message: annotation.message,
+    title: annotation.title,
+    rawDetails: annotation.rawDetails,
+    annotationLevel: annotation.annotationLevel,
+    startLine: annotation.startLine,
+    endLine: annotation.endLine
   };
 }
 
@@ -429,7 +653,7 @@ function formatIssue(issue: any): any {
   };
 }
 
-function summarizePRChecks(checkRuns: any[], statuses: any[]): any {
+function summarizePRChecks(checkRuns: any[], statuses: any[], a11yFailureCount = 0): any {
   const pendingCheckRuns = checkRuns.filter((run) => run.status !== 'completed' || !run.conclusion);
   const failedCheckRuns = checkRuns.filter((run) =>
     ['failure', 'cancelled', 'timed_out', 'action_required'].includes(run.conclusion)
@@ -460,8 +684,78 @@ function summarizePRChecks(checkRuns: any[], statuses: any[]): any {
     neutral: neutralCheckRuns.length,
     skipped: skippedCheckRuns.length,
     failed: failedCheckRuns.length + failedStatuses.length,
-    pending: pendingCheckRuns.length + pendingStatuses.length
+    pending: pendingCheckRuns.length + pendingStatuses.length,
+    a11yFailureCount
   };
+}
+
+function shouldContinuePolling(overallState: string): boolean {
+  return overallState === 'pending' || overallState === 'unknown';
+}
+
+function determineNextAction(overallState: string, a11yFailures: unknown[]): string {
+  if (overallState === 'success') {
+    return 'none';
+  }
+
+  if (overallState === 'pending' || overallState === 'unknown') {
+    return 'wait';
+  }
+
+  if (overallState === 'failure' && a11yFailures.length > 0) {
+    return 'rerun_remediation';
+  }
+
+  return 'manual_review';
+}
+
+function determineAnnotationNextAction(annotationCount: number, a11yFailures: unknown[]): string {
+  if (a11yFailures.length > 0) {
+    return 'rerun_remediation';
+  }
+
+  if (annotationCount > 0) {
+    return 'manual_review';
+  }
+
+  return 'none';
+}
+
+function buildTimeoutSnapshot(snapshot: any, pollAttempts: number, elapsedMs: number): any {
+  return {
+    ...snapshot,
+    overallState: 'timeout',
+    remediationRecommended: false,
+    nextAction: 'manual_review',
+    timedOut: true,
+    pollAttempts,
+    elapsedMs,
+    summary: {
+      ...snapshot.summary,
+      overallState: 'timeout'
+    }
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
+}
+
+function boundText(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 3).trim()}...`;
 }
 
 function normalizeGithubError(error: any, toolName: string, input: any): Error {
@@ -490,8 +784,16 @@ function normalizeGithubError(error: any, toolName: string, input: any): Error {
     if (toolName === 'github_create_pr') {
       return new Error(`GitHub branch or repository not found for ${repo}. Confirm repo, head, and base branches.`);
     }
-    if (toolName === 'github_request_reviewers' || toolName === 'github_get_pr_checks' || toolName === 'github_get_pr') {
+    if (
+      toolName === 'github_request_reviewers' ||
+      toolName === 'github_get_pr_checks' ||
+      toolName === 'github_watch_pr_checks' ||
+      toolName === 'github_get_pr'
+    ) {
       return new Error(`GitHub pull request or repository not found for ${repo}. Confirm the PR number and repo.`);
+    }
+    if (toolName === 'github_get_check_annotations') {
+      return new Error(`GitHub check run or repository not found for ${repo}. Confirm the check run ID and repo.`);
     }
     return new Error(`GitHub resource not found for ${repo}.`);
   }

--- a/joyus-ai-mcp-server/src/tools/github-tools.ts
+++ b/joyus-ai-mcp-server/src/tools/github-tools.ts
@@ -140,7 +140,7 @@ export const githubTools: ToolDefinition[] = [
   },
   {
     name: 'github_get_pr_checks',
-    description: 'Get commit statuses and check runs for a pull request head commit',
+    description: 'Get normalized commit statuses and check runs for a pull request head commit or commit SHA',
     inputSchema: {
       type: 'object',
       properties: {
@@ -150,10 +150,86 @@ export const githubTools: ToolDefinition[] = [
         },
         prNumber: {
           type: 'number',
-          description: 'Pull request number'
+          description: 'Pull request number. Required when sha is not provided'
+        },
+        sha: {
+          type: 'string',
+          description: 'Commit SHA to inspect. Required when prNumber is not provided'
+        },
+        includeAnnotations: {
+          type: 'boolean',
+          description: 'Fetch bounded annotations for non-successful check runs'
+        },
+        annotationLimit: {
+          type: 'number',
+          description: 'Maximum annotations to include when includeAnnotations is true (default: 50, max: 100)'
         }
       },
-      required: ['repo', 'prNumber']
+      required: ['repo']
+    }
+  },
+  {
+    name: 'github_watch_pr_checks',
+    description: 'Poll GitHub check runs and commit statuses until checks complete, fail, or time out',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Repository in owner/repo format (e.g., "example-org/example-app")'
+        },
+        prNumber: {
+          type: 'number',
+          description: 'Pull request number. Required when sha is not provided'
+        },
+        sha: {
+          type: 'string',
+          description: 'Commit SHA to inspect. Required when prNumber is not provided'
+        },
+        pollIntervalMs: {
+          type: 'number',
+          description: 'Milliseconds to wait between polls (default: 10000, max: 60000)'
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum milliseconds to poll before returning timeout (default: 600000)'
+        },
+        includeAnnotations: {
+          type: 'boolean',
+          description: 'Fetch bounded annotations for non-successful check runs'
+        },
+        annotationLimit: {
+          type: 'number',
+          description: 'Maximum annotations to include when includeAnnotations is true (default: 50, max: 100)'
+        }
+      },
+      required: ['repo']
+    }
+  },
+  {
+    name: 'github_get_check_annotations',
+    description: 'Get normalized annotations for a GitHub check run and extract accessibility failures',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Repository in owner/repo format (e.g., "example-org/example-app")'
+        },
+        checkRunId: {
+          type: 'number',
+          description: 'GitHub check run ID'
+        },
+        page: {
+          type: 'number',
+          description: 'Annotation page to fetch (default: 1)'
+        },
+        per_page: {
+          type: 'number',
+          description: 'Annotations per page (default: 100, max: 100)'
+        }
+      },
+      required: ['repo', 'checkRunId']
     }
   },
   {

--- a/joyus-ai-mcp-server/tests/tools.test.ts
+++ b/joyus-ai-mcp-server/tests/tools.test.ts
@@ -101,6 +101,8 @@ describe('Tool Definitions', () => {
       expect(toolNames).toContain('github_create_pr');
       expect(toolNames).toContain('github_request_reviewers');
       expect(toolNames).toContain('github_get_pr_checks');
+      expect(toolNames).toContain('github_watch_pr_checks');
+      expect(toolNames).toContain('github_get_check_annotations');
     });
 
     it('should have required fields specified', () => {
@@ -120,7 +122,13 @@ describe('Tool Definitions', () => {
 
       const checksTool = githubTools.find(t => t.name === 'github_get_pr_checks');
       expect(checksTool?.inputSchema.required).toContain('repo');
-      expect(checksTool?.inputSchema.required).toContain('prNumber');
+
+      const watchChecksTool = githubTools.find(t => t.name === 'github_watch_pr_checks');
+      expect(watchChecksTool?.inputSchema.required).toContain('repo');
+
+      const annotationsTool = githubTools.find(t => t.name === 'github_get_check_annotations');
+      expect(annotationsTool?.inputSchema.required).toContain('repo');
+      expect(annotationsTool?.inputSchema.required).toContain('checkRunId');
     });
   });
 

--- a/joyus-ai-mcp-server/tests/tools/github-a11y-parser.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/github-a11y-parser.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for GitHub CI accessibility failure extraction.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { extractA11yFailures } from '../../src/tools/executors/github-a11y-parser.js';
+
+describe('extractA11yFailures', () => {
+  it('extracts axe-core annotations into structured failures', () => {
+    const failures = extractA11yFailures([
+      {
+        source: 'axe-core',
+        path: 'src/components/Form.tsx',
+        title: 'axe-core violation',
+        message: 'Rule: color-contrast. Impact: serious. Selector: #submit',
+        rawDetails: 'Elements must meet minimum color contrast ratio. Help: https://dequeuniversity.com/rules/axe/4.9/color-contrast',
+        annotationLevel: 'failure',
+        startLine: 12,
+        endLine: 12,
+      },
+    ]);
+
+    expect(failures).toEqual([
+      expect.objectContaining({
+        source: 'axe-core',
+        ruleId: 'color-contrast',
+        severity: 'serious',
+        path: 'src/components/Form.tsx',
+        selector: '#submit',
+        helpUrl: 'https://dequeuniversity.com/rules/axe/4.9/color-contrast',
+        startLine: 12,
+        endLine: 12,
+      }),
+    ]);
+  });
+
+  it('extracts Lighthouse accessibility output', () => {
+    const failures = extractA11yFailures([
+      {
+        source: 'lighthouse accessibility',
+        title: 'Lighthouse accessibility audit failed',
+        message: '[color-contrast] Background and foreground colors do not have a sufficient contrast ratio. Severity: warning',
+        rawDetails: 'URL: https://example.test/page Help: https://web.dev/measure',
+      },
+    ]);
+
+    expect(failures).toEqual([
+      expect.objectContaining({
+        source: 'lighthouse',
+        ruleId: 'color-contrast',
+        severity: 'warning',
+        url: 'https://example.test/page',
+      }),
+    ]);
+  });
+
+  it('extracts pa11y WCAG codes and selectors', () => {
+    const failures = extractA11yFailures([
+      {
+        source: 'pa11y',
+        message: 'Error: Button has no accessible name. Code: WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name Selector: button.save',
+      },
+    ]);
+
+    expect(failures).toEqual([
+      expect.objectContaining({
+        source: 'pa11y',
+        ruleId: 'WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name',
+        severity: 'error',
+        selector: 'button.save',
+      }),
+    ]);
+  });
+
+  it('ignores non-accessibility text', () => {
+    const failures = extractA11yFailures([
+      {
+        source: 'unit tests',
+        message: 'Expected 2 to equal 3',
+      },
+    ]);
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/joyus-ai-mcp-server/tests/tools/github-executor.test.ts
+++ b/joyus-ai-mcp-server/tests/tools/github-executor.test.ts
@@ -288,6 +288,9 @@ describe('executeGithubTool', () => {
           url: 'https://api.github.com/repos/example-org/example-app/statuses/abc123',
         },
       ],
+      a11yFailures: [],
+      remediationRecommended: false,
+      nextAction: 'wait',
       summary: {
         overallState: 'pending',
         checkRunCount: 2,
@@ -296,6 +299,284 @@ describe('executeGithubTool', () => {
         neutral: 0,
         skipped: 0,
         failed: 0,
+        pending: 1,
+        a11yFailureCount: 0,
+      },
+    });
+  });
+
+  it('github_get_pr_checks — supports commit SHA checks with all passing state', async () => {
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          check_runs: [
+            {
+              id: 101,
+              name: 'validate',
+              status: 'completed',
+              conclusion: 'success',
+              started_at: '2026-05-25T12:00:00Z',
+              completed_at: '2026-05-25T12:01:00Z',
+              details_url: 'https://github.com/example-org/example-app/actions/runs/1',
+              html_url: 'https://github.com/example-org/example-app/runs/1',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { statuses: [] },
+      });
+
+    const result = await executeGithubTool(
+      'github_get_pr_checks',
+      {
+        repo: 'example-org/example-app',
+        sha: 'def456',
+      },
+      context,
+    );
+
+    expect(axios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://api.github.com/repos/example-org/example-app/commits/def456/check-runs',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(result).toMatchObject({
+      headSha: 'def456',
+      overallState: 'success',
+      remediationRecommended: false,
+      nextAction: 'none',
+      summary: {
+        overallState: 'success',
+        checkRunCount: 1,
+        statusCount: 0,
+        successful: 1,
+        failed: 0,
+        pending: 0,
+        a11yFailureCount: 0,
+      },
+    });
+  });
+
+  it('github_get_pr_checks — represents legacy commit status failure', async () => {
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: { check_runs: [] },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          statuses: [
+            {
+              context: 'legacy-ci',
+              state: 'failure',
+              description: 'Unit tests failed',
+              target_url: 'https://ci.example.test/build/2',
+              created_at: '2026-05-25T12:00:00Z',
+              updated_at: '2026-05-25T12:01:00Z',
+              url: 'https://api.github.com/repos/example-org/example-app/statuses/def456',
+            },
+          ],
+        },
+      });
+
+    const result = await executeGithubTool(
+      'github_get_pr_checks',
+      {
+        repo: 'example-org/example-app',
+        sha: 'def456',
+      },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      overallState: 'failure',
+      nextAction: 'manual_review',
+      summary: {
+        checkRunCount: 0,
+        statusCount: 1,
+        failed: 1,
+      },
+    });
+  });
+
+  it('github_get_pr_checks — extracts a11y failures from failed check output', async () => {
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          check_runs: [
+            {
+              id: 101,
+              name: 'Lighthouse accessibility',
+              status: 'completed',
+              conclusion: 'failure',
+              started_at: '2026-05-25T12:00:00Z',
+              completed_at: '2026-05-25T12:01:00Z',
+              details_url: 'https://github.com/example-org/example-app/actions/runs/1',
+              html_url: 'https://github.com/example-org/example-app/runs/1',
+              output: {
+                title: 'Lighthouse accessibility audit failed',
+                summary: '[color-contrast] Background and foreground colors do not have a sufficient contrast ratio. Severity: warning',
+                text: 'URL: https://example.test/page Help: https://web.dev/measure',
+              },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { statuses: [] },
+      });
+
+    const result = await executeGithubTool(
+      'github_get_pr_checks',
+      {
+        repo: 'example-org/example-app',
+        sha: 'def456',
+      },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      overallState: 'failure',
+      remediationRecommended: true,
+      nextAction: 'rerun_remediation',
+      a11yFailures: [
+        expect.objectContaining({
+          source: 'lighthouse',
+          ruleId: 'color-contrast',
+          severity: 'warning',
+        }),
+      ],
+      summary: {
+        a11yFailureCount: 1,
+      },
+    });
+  });
+
+  it('github_get_check_annotations — extracts axe-style annotation failures', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [
+        {
+          path: 'src/components/Form.tsx',
+          start_line: 12,
+          end_line: 12,
+          annotation_level: 'failure',
+          title: 'axe-core violation',
+          message: 'Rule: color-contrast. Impact: serious. Selector: #submit',
+          raw_details: 'Elements must meet minimum color contrast ratio. Help: https://dequeuniversity.com/rules/axe/4.9/color-contrast',
+          blob_href: 'https://github.com/example-org/example-app/blob/def456/src/components/Form.tsx#L12',
+        },
+      ],
+    });
+
+    const result = await executeGithubTool(
+      'github_get_check_annotations',
+      {
+        repo: 'example-org/example-app',
+        checkRunId: 101,
+      },
+      context,
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.github.com/repos/example-org/example-app/check-runs/101/annotations',
+      expect.objectContaining({
+        headers: expect.any(Object),
+        params: { page: 1, per_page: 100 },
+      }),
+    );
+    expect(result).toMatchObject({
+      checkRunId: 101,
+      count: 1,
+      remediationRecommended: true,
+      nextAction: 'rerun_remediation',
+      a11yFailures: [
+        expect.objectContaining({
+          source: 'axe-core',
+          ruleId: 'color-contrast',
+          severity: 'serious',
+          path: 'src/components/Form.tsx',
+          selector: '#submit',
+        }),
+      ],
+    });
+  });
+
+  it('github_get_check_annotations — sends non-a11y annotations to manual review', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [
+        {
+          path: 'src/math.ts',
+          start_line: 7,
+          end_line: 7,
+          annotation_level: 'failure',
+          title: 'unit test failure',
+          message: 'Expected total to equal 42',
+          raw_details: 'AssertionError: expected 41 to equal 42',
+        },
+      ],
+    });
+
+    const result = await executeGithubTool(
+      'github_get_check_annotations',
+      {
+        repo: 'example-org/example-app',
+        checkRunId: 102,
+      },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      count: 1,
+      remediationRecommended: false,
+      nextAction: 'manual_review',
+      a11yFailures: [],
+    });
+  });
+
+  it('github_watch_pr_checks — returns timeout without looping forever', async () => {
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          head: { sha: 'abc123' },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          check_runs: [
+            {
+              name: 'validate',
+              status: 'in_progress',
+              conclusion: null,
+              started_at: '2026-05-25T12:00:00Z',
+              completed_at: null,
+              details_url: 'https://github.com/example-org/example-app/actions/runs/1',
+              html_url: 'https://github.com/example-org/example-app/runs/1',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { statuses: [] },
+      });
+
+    const result = await executeGithubTool(
+      'github_watch_pr_checks',
+      {
+        repo: 'example-org/example-app',
+        prNumber: 12,
+        pollIntervalMs: 0,
+        timeoutMs: 0,
+      },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      overallState: 'timeout',
+      timedOut: true,
+      pollAttempts: 1,
+      nextAction: 'manual_review',
+      summary: {
+        overallState: 'timeout',
         pending: 1,
       },
     });


### PR DESCRIPTION
## Summary
- Add CI check snapshot and watch tools for PR head commits and direct commit SHAs.
- Normalize check runs, legacy commit statuses, annotations, a11y failures, and next-action signals for remediation loops.
- Extract axe-core, Lighthouse, and pa11y-style accessibility failures from check output and annotations.

## Notes
- Stacked on #85 because the GitHub MCP PR tools branch is still open.

## Validation
- npm test -- tests/tools/github-executor.test.ts tests/tools.test.ts tests/tools/github-a11y-parser.test.ts
- npm run build
- npm run lint
- npm run db:check
- npm test
- ./scripts/check-client-abstraction.sh --staged
- git diff --cached --check

Closes #9.
Part of #17.
