### PR TITLE
chore(release): v0.1.0 hygiene — state-package CI, README truth pass, CHANGELOG

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,3 +32,27 @@ jobs:
 
       - name: Test
         run: npm test
+
+  validate-state:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: joyus-ai-state
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: joyus-ai-state/package-lock.json
+
+      - name: Install dependencies
+        # --ignore-scripts skips the prepare hook (local git-hook installer).
+        run: npm ci --ignore-scripts
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,8 +48,12 @@ jobs:
           cache-dependency-path: joyus-ai-state/package-lock.json
 
       - name: Install dependencies
-        # --ignore-scripts skips the prepare hook (local git-hook installer).
+        # --ignore-scripts skips the prepare hook (local git-hook installer),
+        # so native modules must be rebuilt explicitly below.
         run: npm ci --ignore-scripts
+
+      - name: Rebuild native modules
+        run: npm rebuild better-sqlite3
 
       - name: Type check
         run: npm run typecheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-06-10
+
+First tagged release of the open-core Joyus AI platform. Everything below was
+previously available only as unversioned `main`.
+
+### Added
+
+- **`joyus-ai-state`** — local MCP server for session/context state and
+  workflow enforcement (features `002`, `004`): canonical context store,
+  divergence detection, state sharing, quality gates, skill enforcement, git
+  guardrails, audit trail, kill switch.
+- **`joyus-ai-mcp-server`** — remote multi-tenant MCP server (features `006`,
+  `009`, `010`): content infrastructure (connectors, sync, search,
+  entitlements, content-aware generation, mediation API), automated pipelines
+  runtime with review gates and scheduling, Inngest evaluation spike.
+- **Gateway event bus and multi-channel delivery** (#90).
+- **Mediation judge layer foundation** (#82) and AGUI mediation approval
+  evaluation (#83), with atomic cost accounting and per-session token-cost
+  tracking.
+- **Workflow approval state tools** (#87) — proposal-gated automation
+  primitives with clock-injectable approval lifecycle.
+- **GitHub MCP PR tools** (#85) and **CI check observability tools** (#93) —
+  PR creation, reviewer assignment, check-status snapshots, watch/polling, and
+  annotations for automated remediation loops.
+- **Jira MCP reviewer proposal helpers** (#86) and **Jira a11y triage
+  scheduler** (#89).
+- **Profile engine contract wiring** (#84) — subprocess bridge to the private
+  stylometric profile engine (`generate` / `health-check` CLI contract).
+- **Export download token persistence** (#80) — DB-backed signed download
+  tokens replacing in-memory tokens.
+- **Shared tenant resolution** with fail-closed lookup and tenant-scoped env
+  allowlisting.
+- CI now validates **both** public packages: `validate` (mcp-server) and
+  `validate-state` (state package) jobs.
+
+### Changed
+
+- README feature-status table reconciled against canonical `tasks.md` state
+  (feature `009` is complete; orchestrator and headroom missions labeled
+  honestly).
+
+### Closed evaluations
+
+- **Headroom MCP compression layer: NO_GO.** The WP01 spike and WP06
+  retrieval-rate re-gate showed the reversible compress→retrieve loop does not
+  engage on the real `/v1/messages` proxying path
+  (`eval/headroom-spike/FINDINGS-WP06.md`).
+
+[0.1.0]: https://github.com/zivtech/joyus-ai/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Status sources:
 
 - canonical task indexes in `kitty-specs/*/tasks.md`
 - lane data from flat `tasks/WP*.md` files where those exist
-- `python3 scripts/pride-status.py` run on April 5, 2026
+- last full reconciliation: June 10, 2026 (v0.1.0 release pass)
 
 | Feature | Scope | Status | Notes |
 | --- | --- | --- | --- |
@@ -118,10 +118,12 @@ Status sources:
 | `006` Content Infrastructure | Public code in `joyus-ai-mcp-server/` | Complete | `12/12` WPs complete |
 | `007` Org-Scale Agentic Governance | Public governance/docs stream | Planned | `0/6` WPs complete |
 | `008` Profile Isolation and Scale | Public planning stream | Planned | Canonical public plan is the `8`-WP inventory in `tasks.md` |
-| `009` Automated Pipelines Framework | Public code in `joyus-ai-mcp-server/` | In progress | `8/10` WPs complete by lane file status |
+| `009` Automated Pipelines Framework | Public code in `joyus-ai-mcp-server/` | Complete | `10/10` WPs complete per `tasks.md` (this row previously lagged at `8/10`) |
 | `010` Inngest Evaluation Spike | Public spike | Complete | `6/6` WPs complete |
 | `011` Inngest Migration | Public migration plan | Planned | `4` WPs defined; implementation not started |
 | `012` CMS Enrichment Delivery | Public placeholder | Stub only | Public placeholder for generic CMS enrichment primitives; Joyus Enrichment itself is a paid service outside this repo |
+| `platform-core-orchestrator-01KREQVK` | Public orchestration planning | Planning only | Task lanes were administratively force-closed; **no merged implementation exists**. Treat as roadmap, not shipped code. Shares feature number `013` with the headroom mission below (known numbering collision). |
+| `headroom-mcp-compression-layer-01KSZKMF` | Public evaluation spike | Closed — NO_GO | Compression evaluation concluded NO_GO (WP01 spike + WP06 re-gate; evidence in `eval/headroom-spike/FINDINGS-WP06.md`). Decision record lives in the private governance hub. |
 
 ## Public Work-Package Inventory
 

--- a/joyus-ai-state/README.md
+++ b/joyus-ai-state/README.md
@@ -1,0 +1,87 @@
+# joyus-ai-state
+
+Local MCP server for session/context state and workflow enforcement — the
+public foundation shipped by features `002 Session & Context Management` and
+`004 Workflow Enforcement`.
+
+It runs on the developer's machine (state lives in local SQLite), gives Claude
+sessions durable context across restarts, and enforces workflow guardrails
+(quality gates, skill checks, git guardrails, audit trail) before actions
+execute.
+
+## Quickstart
+
+```bash
+cd joyus-ai-state
+npm install
+npm run build
+```
+
+Two executables ship with the package:
+
+| Bin | Purpose |
+| --- | --- |
+| `joyus-ai-mcp` | stdio MCP server — wire this into your MCP client |
+| `joyus-ai-service` | companion service mode |
+
+### Wiring into Claude Code / Claude Desktop
+
+Add to your MCP configuration (`.mcp.json` in a project, or the Claude Desktop
+config):
+
+```json
+{
+  "mcpServers": {
+    "joyus-ai-state": {
+      "command": "node",
+      "args": ["/absolute/path/to/joyus-ai-state/bin/joyus-ai-mcp"]
+    }
+  }
+}
+```
+
+## MCP tools
+
+Session & context tools (feature `002`):
+
+| Tool | What it does |
+| --- | --- |
+| `get_context` | Load canonical context for the current session |
+| `save_state` | Persist session state to the local store |
+| `verify_action` | Check an intended action against canonical state before executing |
+| `check_canonical` | Inspect canonical-document state and divergence |
+| `share_state` | Share state across sessions |
+| `query_snapshots` | Query historical state snapshots |
+
+Workflow-enforcement tools (feature `004`) cover quality gates, branch and
+skill verification, upstream checks, corrections, audit queries, enforcement
+status, hygiene checks, and the kill switch. See `src/mcp/tools/` for the
+complete set — each tool is one file.
+
+## Development
+
+```bash
+npm run typecheck   # tsc --noEmit
+npm test            # vitest run
+npm run validate    # typecheck + test
+```
+
+Both checks also run in CI (`.github/workflows/validate.yml`, `validate-state`
+job).
+
+## Layout
+
+```
+src/
+├── collectors/    # state collectors
+├── core/          # core types and config
+├── enforcement/   # gates, skills, git guardrails, audit
+├── mcp/           # MCP server + tools (one file per tool)
+├── service/       # companion service mode
+├── state/         # canonical store, divergence, lock, share, store
+└── utils/
+```
+
+## License
+
+Apache-2.0, same as the repository root.

--- a/joyus-ai-state/src/enforcement/events/session-start.ts
+++ b/joyus-ai-state/src/enforcement/events/session-start.ts
@@ -20,10 +20,10 @@ export interface SessionStartReport {
 
 export async function onSessionStart(
   config: MergedEnforcementConfig,
-  ctx: { sessionId: string; auditDir: string },
+  ctx: { sessionId: string; auditDir: string; cwd?: string },
 ): Promise<SessionStartReport> {
-  const staleBranches = await detectStaleBranches(config.branchRules);
-  const branchCount = await checkBranchCount(config.branchRules);
+  const staleBranches = await detectStaleBranches(config.branchRules, ctx.cwd);
+  const branchCount = await checkBranchCount(config.branchRules, ctx.cwd);
 
   const suggestions: string[] = [];
 

--- a/joyus-ai-state/tests/integration/mcp-tools.test.ts
+++ b/joyus-ai-state/tests/integration/mcp-tools.test.ts
@@ -22,7 +22,8 @@ function parse(result: { content: Array<{ type: string; text: string }> }): Reco
 }
 
 function initGitRepo(dir: string): void {
-  execFileSync('git', ['init', dir], { stdio: 'ignore' });
+  // -b main: CI runners default init.defaultBranch to master.
+  execFileSync('git', ['init', '-b', 'main', dir], { stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir, stdio: 'ignore' });
   fs.writeFileSync(path.join(dir, 'README.md'), '# Test');

--- a/joyus-ai-state/tests/unit/events/session-start.test.ts
+++ b/joyus-ai-state/tests/unit/events/session-start.test.ts
@@ -4,9 +4,10 @@ import { listAuditFiles } from '../../../src/enforcement/audit/writer.js';
 import { EnforcementConfigSchema } from '../../../src/enforcement/schemas.js';
 import { mergeConfig } from '../../../src/enforcement/config.js';
 import type { DeveloperConfig } from '../../../src/enforcement/types.js';
-import { rmSync } from 'node:fs';
+import { rmSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 function makeConfig() {
   const project = EnforcementConfigSchema.parse({});
@@ -14,15 +15,32 @@ function makeConfig() {
   return mergeConfig(project, dev);
 }
 
+/** Hermetic git repo with exactly one local branch (main), so branch-count
+ * assertions don't depend on whatever repo the test process runs inside
+ * (CI checkouts are detached with zero local branches). */
+function makeGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'event-session-repo-'));
+  execFileSync('git', ['init', '-b', 'main', dir], { stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir, stdio: 'ignore' });
+  writeFileSync(join(dir, 'README.md'), '# Test');
+  execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
 describe('onSessionStart', () => {
   let auditDir: string;
+  let repoDir: string;
 
   beforeEach(() => {
     auditDir = join(tmpdir(), `event-session-test-${Date.now()}`);
+    repoDir = makeGitRepo();
   });
 
   afterEach(() => {
     rmSync(auditDir, { recursive: true, force: true });
+    rmSync(repoDir, { recursive: true, force: true });
   });
 
   it('returns hygiene report', async () => {
@@ -43,8 +61,8 @@ describe('onSessionStart', () => {
 
   it('returns suggestions when branch count is high', async () => {
     const config = makeConfig();
-    config.branchRules.maxActiveBranches = 0; // force over-limit
-    const report = await onSessionStart(config, { sessionId: 'test', auditDir });
+    config.branchRules.maxActiveBranches = 0; // force over-limit (repo has 1 branch)
+    const report = await onSessionStart(config, { sessionId: 'test', auditDir, cwd: repoDir });
     expect(report.branchCountWarning).toBe(true);
     expect(report.suggestions.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
Release-hygiene pass ahead of cutting v0.1.0 (the repo's first tagged release):

- **CI**: new `validate-state` job — `joyus-ai-state` (52 test files / 441 tests, verified locally) previously had zero CI coverage
- **README truth pass**: 009 marked Complete 10/10 per canonical tasks.md; `platform-core-orchestrator` labeled planning-only (force-closed lanes, no merged implementation); headroom mission labeled Closed — NO_GO; the 013 numbering collision documented
- **`joyus-ai-state/README.md`**: quickstart, MCP client wiring, tool reference — the package the root README tells users to install first previously had no landing doc
- **CHANGELOG.md** for v0.1.0 covering the platform surface plus today's 11-PR landing

Note: the audit-flagged health-check flag/subcommand mismatch needed no fix — merged #84 already ships `healthCheckArgs: ['health-check']`, matching the private CLI contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)