### PR TITLE
fix(db): repair migration chain for stale-environment catch-up + replay CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,3 +60,37 @@ jobs:
 
       - name: Test
         run: npm test
+
+  migration-replay:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: joyus-ai-mcp-server
+    services:
+      postgres:
+        image: postgres:16-alpine # keep in sync with deploy/docker-compose.yml
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: joyus-ai-mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Replay migration chain against scratch Postgres
+        run: npm run db:replay-check
+        env:
+          PG_ADMIN_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented in this file. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Migration chain repair for stale-environment catch-up** (#96) — databases
+  that recorded migrations 0000–0007 against the pre-rewrite chain (production)
+  crashed on `0008` because the `pipelines` schema objects, created by the
+  rewritten `0001` they never actually ran, were missing. `0008` is now guarded,
+  and a new `0013_pipelines_baseline_repair` migration recreates the complete
+  final-state `pipelines` schema with existence guards (a no-op on healthy
+  databases). Journal `when` timestamps are monotonic again (`0009` and `0012`
+  were out of order and could be silently skipped by environments that migrated
+  past them), and `0009`/`0012` are idempotent so the reposition cannot
+  double-apply destructively.
+
+### Added
+
+- **Migration replay check** (#96) — `npm run db:replay-check`
+  (`scripts/migration-replay-check.mjs`) lints the journal, replays the full
+  chain against a scratch Postgres 16, verifies a second run applies nothing,
+  and replays the stale-environment catch-up shape that broke the v0.1.0
+  deploy. Runs in CI as the `migration-replay` job.
+
 ## [0.1.0] - 2026-06-10
 
 First tagged release of the open-core Joyus AI platform. Everything below was

--- a/joyus-ai-mcp-server/drizzle/migrations/0008_pipeline_name_not_unique.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0008_pipeline_name_not_unique.sql
@@ -1,2 +1,11 @@
-DROP INDEX IF EXISTS "pipelines"."pipelines_tenant_name_unique";--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "pipelines_tenant_name_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","name");--> statement-breakpoint
+-- Guarded for stale-environment catch-up (#96): environments whose migration
+-- position predates the chain rewrite have no "pipelines"."pipelines" table yet.
+-- For them this swap is a no-op; 0013_pipelines_baseline_repair creates the
+-- final-state index instead.
+DO $$
+BEGIN
+  IF to_regclass('pipelines.pipelines') IS NOT NULL THEN
+    DROP INDEX IF EXISTS "pipelines"."pipelines_tenant_name_unique";
+    CREATE INDEX IF NOT EXISTS "pipelines_tenant_name_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","name");
+  END IF;
+END $$;--> statement-breakpoint

--- a/joyus-ai-mcp-server/drizzle/migrations/0009_tenant_memberships.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0009_tenant_memberships.sql
@@ -1,14 +1,21 @@
 -- Tenant memberships
 -- Shared user-to-tenant grants for tenant resolution.
 -- Generated: 2026-05-25
+-- Idempotency guards added in #96: the journal `when` repair (1779710400000 ->
+-- 1779713480600) can re-apply this file on environments that recorded it under
+-- the old timestamp, so every statement must tolerate existing objects.
 
-CREATE TYPE "public"."tenant_role" AS ENUM(
-  'member',
-  'admin',
-  'operator'
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public' AND t.typname = 'tenant_role'
+  ) THEN
+    CREATE TYPE "public"."tenant_role" AS ENUM('member', 'admin', 'operator');
+  END IF;
+END $$;
 
-CREATE TABLE "tenant_memberships" (
+CREATE TABLE IF NOT EXISTS "tenant_memberships" (
   "id"         TEXT PRIMARY KEY,
   "user_id"    TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
   "tenant_id"  TEXT NOT NULL,
@@ -18,18 +25,18 @@ CREATE TABLE "tenant_memberships" (
   "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE UNIQUE INDEX "tenant_memberships_user_tenant_unique"
+CREATE UNIQUE INDEX IF NOT EXISTS "tenant_memberships_user_tenant_unique"
   ON "tenant_memberships" ("user_id", "tenant_id");
 
-CREATE INDEX "tenant_memberships_tenant_id_idx"
+CREATE INDEX IF NOT EXISTS "tenant_memberships_tenant_id_idx"
   ON "tenant_memberships" ("tenant_id");
 
-CREATE INDEX "tenant_memberships_user_default_idx"
+CREATE INDEX IF NOT EXISTS "tenant_memberships_user_default_idx"
   ON "tenant_memberships" ("user_id", "is_default");
 
-CREATE INDEX "tenant_memberships_user_role_idx"
+CREATE INDEX IF NOT EXISTS "tenant_memberships_user_role_idx"
   ON "tenant_memberships" ("user_id", "role");
 
-CREATE UNIQUE INDEX "tenant_memberships_user_default_unique"
+CREATE UNIQUE INDEX IF NOT EXISTS "tenant_memberships_user_default_unique"
   ON "tenant_memberships" ("user_id")
   WHERE "is_default" = TRUE;

--- a/joyus-ai-mcp-server/drizzle/migrations/0012_jira_a11y_triage_scheduler.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0012_jira_a11y_triage_scheduler.sql
@@ -1,1 +1,4 @@
-ALTER TYPE "public"."task_type" ADD VALUE 'JIRA_A11Y_TRIAGE';--> statement-breakpoint
+-- IF NOT EXISTS added in #96: the journal `when` repair (1778505114112 ->
+-- 1779724808298) can re-apply this file on environments that recorded it under
+-- the old timestamp.
+ALTER TYPE "public"."task_type" ADD VALUE IF NOT EXISTS 'JIRA_A11Y_TRIAGE';--> statement-breakpoint

--- a/joyus-ai-mcp-server/drizzle/migrations/0013_pipelines_baseline_repair.sql
+++ b/joyus-ai-mcp-server/drizzle/migrations/0013_pipelines_baseline_repair.sql
@@ -1,0 +1,401 @@
+-- 0013_pipelines_baseline_repair (#96)
+--
+-- Baseline/repair migration for stale-environment catch-up.
+--
+-- Why: the production database recorded migrations 0000-0007 against the
+-- pre-rewrite chain (db:push era), so its actual schema never received the
+-- "pipelines" objects that the rewritten 0001 creates. The migrator's
+-- watermark skips 0001, and 0008+ then ALTER pipelines objects that do not
+-- exist there. This migration recreates the complete final-state "pipelines"
+-- schema with existence guards on every statement:
+--   * fresh replays (0001 already ran): every statement is a no-op
+--   * stale catch-up environments: schema, enums, tables, FKs, and indexes
+--     are created here, immediately before first use
+--
+-- DDL is copied verbatim from 0001_fine_young_avengers.sql, except the
+-- tenant/name index, which is created in its final post-0008 form
+-- ("pipelines_tenant_name_idx", non-unique). The pre-0008 unique index is
+-- intentionally NOT created.
+
+CREATE SCHEMA IF NOT EXISTS "pipelines";
+
+-- ============================================================
+-- ENUMS
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'concurrency_policy'
+  ) THEN
+    CREATE TYPE "pipelines"."concurrency_policy" AS ENUM('skip_if_running', 'queue', 'allow_concurrent');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'execution_status'
+  ) THEN
+    CREATE TYPE "pipelines"."execution_status" AS ENUM('pending', 'running', 'paused_at_gate', 'paused_on_failure', 'completed', 'failed', 'cancelled');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'execution_step_status'
+  ) THEN
+    CREATE TYPE "pipelines"."execution_step_status" AS ENUM('pending', 'running', 'completed', 'failed', 'skipped', 'no_op');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'pipeline_status'
+  ) THEN
+    CREATE TYPE "pipelines"."pipeline_status" AS ENUM('active', 'paused', 'disabled');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'review_decision_status'
+  ) THEN
+    CREATE TYPE "pipelines"."review_decision_status" AS ENUM('pending', 'approved', 'rejected');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'step_type'
+  ) THEN
+    CREATE TYPE "pipelines"."step_type" AS ENUM('profile_generation', 'fidelity_check', 'content_generation', 'source_query', 'review_gate', 'notification');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'trigger_event_status'
+  ) THEN
+    CREATE TYPE "pipelines"."trigger_event_status" AS ENUM('pending', 'acknowledged', 'processed', 'failed', 'expired');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'pipelines' AND t.typname = 'trigger_event_type'
+  ) THEN
+    CREATE TYPE "pipelines"."trigger_event_type" AS ENUM('corpus_change', 'schedule_tick', 'manual_request');
+  END IF;
+END $$;
+
+-- ============================================================
+-- TABLES
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "pipelines"."pipeline_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"category" text NOT NULL,
+	"definition" jsonb NOT NULL,
+	"parameters" jsonb NOT NULL,
+	"assumptions" jsonb NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pipeline_templates_name_unique" UNIQUE("name")
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."pipelines" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"trigger_type" "pipelines"."trigger_event_type" NOT NULL,
+	"trigger_config" jsonb NOT NULL,
+	"retry_policy" jsonb NOT NULL,
+	"concurrency_policy" "pipelines"."concurrency_policy" DEFAULT 'skip_if_running' NOT NULL,
+	"review_gate_timeout_hours" integer DEFAULT 48 NOT NULL,
+	"max_pipeline_depth" integer DEFAULT 10 NOT NULL,
+	"status" "pipelines"."pipeline_status" DEFAULT 'active' NOT NULL,
+	"template_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."pipeline_steps" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pipeline_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"name" text NOT NULL,
+	"step_type" "pipelines"."step_type" NOT NULL,
+	"config" jsonb NOT NULL,
+	"input_refs" jsonb NOT NULL,
+	"retry_policy_override" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."trigger_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"event_type" "pipelines"."trigger_event_type" NOT NULL,
+	"payload" jsonb NOT NULL,
+	"status" "pipelines"."trigger_event_status" DEFAULT 'pending' NOT NULL,
+	"pipelines_triggered" jsonb NOT NULL,
+	"received_at" timestamp DEFAULT now() NOT NULL,
+	"acknowledged_at" timestamp,
+	"processed_at" timestamp
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."pipeline_executions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pipeline_id" text NOT NULL,
+	"tenant_id" text NOT NULL,
+	"trigger_event_id" text NOT NULL,
+	"status" "pipelines"."execution_status" DEFAULT 'pending' NOT NULL,
+	"steps_completed" integer DEFAULT 0 NOT NULL,
+	"steps_total" integer NOT NULL,
+	"current_step_position" integer DEFAULT 0 NOT NULL,
+	"trigger_chain_depth" integer DEFAULT 0 NOT NULL,
+	"output_artifacts" jsonb NOT NULL,
+	"error_detail" jsonb,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"completed_at" timestamp
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."execution_steps" (
+	"id" text PRIMARY KEY NOT NULL,
+	"execution_id" text NOT NULL,
+	"step_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"status" "pipelines"."execution_step_status" DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"idempotency_key" text NOT NULL,
+	"input_data" jsonb,
+	"output_data" jsonb,
+	"error_detail" jsonb,
+	"started_at" timestamp,
+	"completed_at" timestamp
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."review_decisions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"execution_id" text NOT NULL,
+	"execution_step_id" text NOT NULL,
+	"tenant_id" text NOT NULL,
+	"artifact_ref" jsonb NOT NULL,
+	"profile_version_ref" text,
+	"reviewer_id" text,
+	"status" "pipelines"."review_decision_status" DEFAULT 'pending' NOT NULL,
+	"feedback" jsonb,
+	"decided_at" timestamp,
+	"escalated_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."pipeline_metrics" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pipeline_id" text NOT NULL,
+	"tenant_id" text NOT NULL,
+	"window_start" timestamp NOT NULL,
+	"window_end" timestamp NOT NULL,
+	"total_executions" integer DEFAULT 0 NOT NULL,
+	"success_count" integer DEFAULT 0 NOT NULL,
+	"failure_count" integer DEFAULT 0 NOT NULL,
+	"cancelled_count" integer DEFAULT 0 NOT NULL,
+	"mean_duration_ms" integer,
+	"p95_duration_ms" integer,
+	"failure_breakdown" jsonb NOT NULL,
+	"review_approval_rate" real,
+	"review_rejection_rate" real,
+	"mean_time_to_review_ms" integer,
+	"refreshed_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "pipelines"."quality_signals" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pipeline_id" text NOT NULL,
+	"tenant_id" text NOT NULL,
+	"signal_type" text NOT NULL,
+	"severity" text NOT NULL,
+	"message" text NOT NULL,
+	"metadata" jsonb NOT NULL,
+	"acknowledged_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- ============================================================
+-- FOREIGN KEYS
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipelines_template_id_pipeline_templates_id_fk'
+      AND conrelid = 'pipelines.pipelines'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."pipelines" ADD CONSTRAINT "pipelines_template_id_pipeline_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "pipelines"."pipeline_templates"("id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_steps_pipeline_id_pipelines_id_fk'
+      AND conrelid = 'pipelines.pipeline_steps'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."pipeline_steps" ADD CONSTRAINT "pipeline_steps_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "pipelines"."pipelines"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_executions_pipeline_id_pipelines_id_fk'
+      AND conrelid = 'pipelines.pipeline_executions'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."pipeline_executions" ADD CONSTRAINT "pipeline_executions_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "pipelines"."pipelines"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_executions_trigger_event_id_trigger_events_id_fk'
+      AND conrelid = 'pipelines.pipeline_executions'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."pipeline_executions" ADD CONSTRAINT "pipeline_executions_trigger_event_id_trigger_events_id_fk" FOREIGN KEY ("trigger_event_id") REFERENCES "pipelines"."trigger_events"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'execution_steps_execution_id_pipeline_executions_id_fk'
+      AND conrelid = 'pipelines.execution_steps'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."execution_steps" ADD CONSTRAINT "execution_steps_execution_id_pipeline_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "pipelines"."pipeline_executions"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'execution_steps_step_id_pipeline_steps_id_fk'
+      AND conrelid = 'pipelines.execution_steps'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."execution_steps" ADD CONSTRAINT "execution_steps_step_id_pipeline_steps_id_fk" FOREIGN KEY ("step_id") REFERENCES "pipelines"."pipeline_steps"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'review_decisions_execution_id_pipeline_executions_id_fk'
+      AND conrelid = 'pipelines.review_decisions'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."review_decisions" ADD CONSTRAINT "review_decisions_execution_id_pipeline_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "pipelines"."pipeline_executions"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'review_decisions_execution_step_id_execution_steps_id_fk'
+      AND conrelid = 'pipelines.review_decisions'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."review_decisions" ADD CONSTRAINT "review_decisions_execution_step_id_execution_steps_id_fk" FOREIGN KEY ("execution_step_id") REFERENCES "pipelines"."execution_steps"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_metrics_pipeline_id_pipelines_id_fk'
+      AND conrelid = 'pipelines.pipeline_metrics'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."pipeline_metrics" ADD CONSTRAINT "pipeline_metrics_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "pipelines"."pipelines"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_signals_pipeline_id_pipelines_id_fk'
+      AND conrelid = 'pipelines.quality_signals'::regclass
+  ) THEN
+    ALTER TABLE "pipelines"."quality_signals" ADD CONSTRAINT "quality_signals_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "pipelines"."pipelines"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+-- ============================================================
+-- INDEXES
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS "pipeline_templates_tenant_id_idx" ON "pipelines"."pipeline_templates" USING btree ("tenant_id");
+CREATE INDEX IF NOT EXISTS "pipeline_templates_category_active_idx" ON "pipelines"."pipeline_templates" USING btree ("category","is_active");
+CREATE INDEX IF NOT EXISTS "pipeline_templates_active_idx" ON "pipelines"."pipeline_templates" USING btree ("is_active");
+
+CREATE INDEX IF NOT EXISTS "pipelines_tenant_id_idx" ON "pipelines"."pipelines" USING btree ("tenant_id");
+CREATE INDEX IF NOT EXISTS "pipelines_tenant_status_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","status");
+CREATE INDEX IF NOT EXISTS "pipelines_tenant_trigger_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","trigger_type");
+-- Final-state form (0008): non-unique. The pre-0008 unique index is intentionally not created.
+CREATE INDEX IF NOT EXISTS "pipelines_tenant_name_idx" ON "pipelines"."pipelines" USING btree ("tenant_id","name");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "pipeline_steps_pipeline_position_unique" ON "pipelines"."pipeline_steps" USING btree ("pipeline_id","position");
+CREATE INDEX IF NOT EXISTS "pipeline_steps_pipeline_id_idx" ON "pipelines"."pipeline_steps" USING btree ("pipeline_id");
+
+CREATE INDEX IF NOT EXISTS "trigger_events_tenant_received_idx" ON "pipelines"."trigger_events" USING btree ("tenant_id","received_at");
+CREATE INDEX IF NOT EXISTS "trigger_events_status_received_idx" ON "pipelines"."trigger_events" USING btree ("status","received_at");
+CREATE INDEX IF NOT EXISTS "trigger_events_tenant_id_idx" ON "pipelines"."trigger_events" USING btree ("tenant_id");
+CREATE INDEX IF NOT EXISTS "trigger_events_unprocessed_idx" ON "pipelines"."trigger_events" USING btree ("status","received_at") WHERE processed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS "executions_pipeline_started_idx" ON "pipelines"."pipeline_executions" USING btree ("pipeline_id","started_at");
+CREATE INDEX IF NOT EXISTS "executions_tenant_started_idx" ON "pipelines"."pipeline_executions" USING btree ("tenant_id","started_at");
+CREATE INDEX IF NOT EXISTS "executions_tenant_status_idx" ON "pipelines"."pipeline_executions" USING btree ("tenant_id","status");
+CREATE INDEX IF NOT EXISTS "executions_status_idx" ON "pipelines"."pipeline_executions" USING btree ("status");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "exec_steps_execution_position_unique" ON "pipelines"."execution_steps" USING btree ("execution_id","position");
+CREATE INDEX IF NOT EXISTS "exec_steps_execution_id_idx" ON "pipelines"."execution_steps" USING btree ("execution_id");
+CREATE INDEX IF NOT EXISTS "exec_steps_execution_status_idx" ON "pipelines"."execution_steps" USING btree ("execution_id","status");
+
+CREATE INDEX IF NOT EXISTS "review_decisions_execution_step_idx" ON "pipelines"."review_decisions" USING btree ("execution_id","execution_step_id");
+CREATE INDEX IF NOT EXISTS "review_decisions_tenant_status_idx" ON "pipelines"."review_decisions" USING btree ("tenant_id","status");
+CREATE INDEX IF NOT EXISTS "review_decisions_step_status_idx" ON "pipelines"."review_decisions" USING btree ("execution_step_id","status");
+CREATE INDEX IF NOT EXISTS "review_decisions_tenant_id_idx" ON "pipelines"."review_decisions" USING btree ("tenant_id");
+
+CREATE INDEX IF NOT EXISTS "pipeline_metrics_pipeline_window_idx" ON "pipelines"."pipeline_metrics" USING btree ("pipeline_id","window_end");
+CREATE INDEX IF NOT EXISTS "pipeline_metrics_tenant_window_idx" ON "pipelines"."pipeline_metrics" USING btree ("tenant_id","window_end");
+CREATE INDEX IF NOT EXISTS "pipeline_metrics_tenant_id_idx" ON "pipelines"."pipeline_metrics" USING btree ("tenant_id");
+
+CREATE INDEX IF NOT EXISTS "quality_signals_pipeline_id_idx" ON "pipelines"."quality_signals" USING btree ("pipeline_id");
+CREATE INDEX IF NOT EXISTS "quality_signals_tenant_id_idx" ON "pipelines"."quality_signals" USING btree ("tenant_id");
+CREATE INDEX IF NOT EXISTS "quality_signals_unack_idx" ON "pipelines"."quality_signals" USING btree ("tenant_id","created_at") WHERE acknowledged_at IS NULL;

--- a/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
+++ b/joyus-ai-mcp-server/drizzle/migrations/meta/_journal.json
@@ -68,7 +68,7 @@
     {
       "idx": 9,
       "version": "7",
-      "when": 1779710400000,
+      "when": 1779713480600,
       "tag": "0009_tenant_memberships",
       "breakpoints": true
     },
@@ -89,8 +89,15 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1778505114112,
+      "when": 1779724808298,
       "tag": "0012_jira_a11y_triage_scheduler",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781049600000,
+      "tag": "0013_pipelines_baseline_repair",
       "breakpoints": true
     }
   ]

--- a/joyus-ai-mcp-server/package.json
+++ b/joyus-ai-mcp-server/package.json
@@ -16,6 +16,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:check": "drizzle-kit check",
+    "db:replay-check": "node scripts/migration-replay-check.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts --quiet",
     "lint:fix": "eslint src --ext .ts --fix --quiet",

--- a/joyus-ai-mcp-server/scripts/migration-replay-check.mjs
+++ b/joyus-ai-mcp-server/scripts/migration-replay-check.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Migration chain replay verifier (#96).
+ *
+ * Verifies the committed Drizzle migration chain stays honest:
+ *   1. journal lint   — idx contiguity, strictly increasing `when`,
+ *                       tag <-> file parity, unique tags
+ *   2. fresh replay   — full chain against an empty scratch database
+ *   3. idempotency    — a second migrate run applies nothing
+ *   4. stale catch-up — seed a database to journal position 0007, remove the
+ *                       pipelines schema (the production divergence behind
+ *                       #96, including the empty schema left by triage), then
+ *                       run the full chain and assert the converged state
+ *
+ * Requires a reachable Postgres superuser URL in PG_ADMIN_URL
+ * (default: postgres://postgres:postgres@localhost:5432/postgres).
+ * Scratch databases migration_replay_fresh / migration_replay_catchup are
+ * dropped and recreated on every run. Never point PG_ADMIN_URL at a real
+ * environment.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MIGRATIONS_DIR = path.join(ROOT, 'drizzle', 'migrations');
+const ADMIN_URL =
+  process.env.PG_ADMIN_URL ?? 'postgres://postgres:postgres@localhost:5432/postgres';
+const FRESH_DB = 'migration_replay_fresh';
+const CATCHUP_DB = 'migration_replay_catchup';
+// Last journal entry production had recorded before the divergence (#96).
+const SEED_MAX_IDX = 7;
+
+const PIPELINES_TABLES = [
+  'pipeline_templates',
+  'pipelines',
+  'pipeline_steps',
+  'trigger_events',
+  'pipeline_executions',
+  'execution_steps',
+  'review_decisions',
+  'pipeline_metrics',
+  'quality_signals',
+];
+
+let failures = 0;
+
+function check(ok, label) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) failures += 1;
+}
+
+function dbUrl(name) {
+  const url = new URL(ADMIN_URL);
+  url.pathname = `/${name}`;
+  return url.toString();
+}
+
+async function query(url, sql) {
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    return await client.query(sql);
+  } finally {
+    await client.end();
+  }
+}
+
+async function recreate(name) {
+  await query(ADMIN_URL, `DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+  await query(ADMIN_URL, `CREATE DATABASE ${name}`);
+}
+
+function runMigrate(url, configPath) {
+  const args = ['drizzle-kit', 'migrate'];
+  if (configPath) args.push('--config', configPath);
+  const res = spawnSync('npx', args, {
+    cwd: ROOT,
+    env: { ...process.env, DATABASE_URL: url },
+    encoding: 'utf8',
+  });
+  return { ok: res.status === 0, output: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+function readJournal() {
+  return JSON.parse(fs.readFileSync(path.join(MIGRATIONS_DIR, 'meta', '_journal.json'), 'utf8'));
+}
+
+function lintJournal() {
+  const { entries } = readJournal();
+  check(
+    entries.every((e, i) => e.idx === i),
+    'journal: idx values are contiguous from 0',
+  );
+  check(
+    entries.every((e, i) => i === 0 || entries[i - 1].when < e.when),
+    'journal: `when` strictly increasing (apply order matches watermark order)',
+  );
+  const tags = new Set(entries.map((e) => e.tag));
+  check(tags.size === entries.length, 'journal: tags are unique');
+  const missing = entries.filter((e) => !fs.existsSync(path.join(MIGRATIONS_DIR, `${e.tag}.sql`)));
+  check(
+    missing.length === 0,
+    `journal: every entry has a .sql file${missing.length ? ` (missing: ${missing.map((e) => e.tag).join(', ')})` : ''}`,
+  );
+  const orphans = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql') && !tags.has(f.replace(/\.sql$/, '')));
+  check(
+    orphans.length === 0,
+    `migrations dir: every .sql file is journaled${orphans.length ? ` (orphaned: ${orphans.join(', ')})` : ''}`,
+  );
+  return entries.length;
+}
+
+async function migrationCount(url) {
+  const res = await query(url, 'SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations');
+  return res.rows[0].n;
+}
+
+async function assertConverged(url, label) {
+  for (const table of PIPELINES_TABLES) {
+    const res = await query(url, `SELECT to_regclass('pipelines.${table}') AS reg`);
+    check(res.rows[0].reg !== null, `${label}: pipelines.${table} exists`);
+  }
+  const idx = await query(
+    url,
+    "SELECT indexname FROM pg_indexes WHERE schemaname = 'pipelines' AND tablename = 'pipelines'",
+  );
+  const names = idx.rows.map((r) => r.indexname);
+  check(
+    names.includes('pipelines_tenant_name_idx'),
+    `${label}: final-state index pipelines_tenant_name_idx exists`,
+  );
+  check(
+    !names.includes('pipelines_tenant_name_unique'),
+    `${label}: pre-0008 unique index is absent`,
+  );
+  const enumRow = await query(
+    url,
+    "SELECT 1 FROM pg_enum e JOIN pg_type t ON t.oid = e.enumtypid WHERE t.typname = 'task_type' AND e.enumlabel = 'JIRA_A11Y_TRIAGE'",
+  );
+  check(enumRow.rowCount === 1, `${label}: task_type contains JIRA_A11Y_TRIAGE (0012 applied)`);
+}
+
+function makeSeedConfig(tmpDir) {
+  const seedMigrations = path.join(tmpDir, 'migrations');
+  fs.cpSync(MIGRATIONS_DIR, seedMigrations, { recursive: true });
+  const journalPath = path.join(seedMigrations, 'meta', '_journal.json');
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+  journal.entries = journal.entries.filter((e) => e.idx <= SEED_MAX_IDX);
+  fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2));
+  const configPath = path.join(tmpDir, 'seed.config.mjs');
+  fs.writeFileSync(
+    configPath,
+    `export default { dialect: 'postgresql', out: ${JSON.stringify(seedMigrations)}, dbCredentials: { url: process.env.DATABASE_URL } };\n`,
+  );
+  return configPath;
+}
+
+async function phaseFreshReplay(entryCount) {
+  await recreate(FRESH_DB);
+  const fresh = runMigrate(dbUrl(FRESH_DB));
+  check(fresh.ok, 'fresh replay: full chain applies to an empty database');
+  if (!fresh.ok) {
+    console.log(fresh.output);
+    return false;
+  }
+  check(
+    (await migrationCount(dbUrl(FRESH_DB))) === entryCount,
+    `fresh replay: ${entryCount} journal rows recorded`,
+  );
+  await assertConverged(dbUrl(FRESH_DB), 'fresh replay');
+  return true;
+}
+
+async function phaseIdempotency() {
+  const before = await migrationCount(dbUrl(FRESH_DB));
+  const second = runMigrate(dbUrl(FRESH_DB));
+  check(second.ok, 'idempotency: second migrate run succeeds');
+  if (!second.ok) {
+    console.log(second.output);
+    return;
+  }
+  check(
+    (await migrationCount(dbUrl(FRESH_DB))) === before,
+    'idempotency: second run applies nothing',
+  );
+}
+
+async function phaseCatchup(entryCount) {
+  await recreate(CATCHUP_DB);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-replay-'));
+  try {
+    const seed = runMigrate(dbUrl(CATCHUP_DB), makeSeedConfig(tmpDir));
+    check(seed.ok, `catch-up: seeded to journal idx ${SEED_MAX_IDX}`);
+    if (!seed.ok) {
+      console.log(seed.output);
+      return;
+    }
+    await query(dbUrl(CATCHUP_DB), 'DROP SCHEMA pipelines CASCADE');
+    // Production triage left an empty pipelines schema behind; model that too.
+    await query(dbUrl(CATCHUP_DB), 'CREATE SCHEMA pipelines');
+    const catchup = runMigrate(dbUrl(CATCHUP_DB));
+    check(catchup.ok, `catch-up: full chain applies from journal position ${SEED_MAX_IDX}`);
+    if (!catchup.ok) {
+      console.log(catchup.output);
+      return;
+    }
+    check(
+      (await migrationCount(dbUrl(CATCHUP_DB))) === entryCount,
+      `catch-up: ${entryCount} journal rows recorded`,
+    );
+    await assertConverged(dbUrl(CATCHUP_DB), 'catch-up');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  console.log('--- Phase 1: journal lint');
+  const entryCount = lintJournal();
+
+  console.log('--- Phase 2: fresh replay');
+  const freshOk = await phaseFreshReplay(entryCount);
+
+  console.log('--- Phase 3: idempotency');
+  if (freshOk) {
+    await phaseIdempotency();
+  } else {
+    check(false, 'idempotency: skipped (fresh replay failed)');
+  }
+
+  console.log('--- Phase 4: stale-environment catch-up (#96 shape)');
+  await phaseCatchup(entryCount);
+
+  console.log(
+    failures === 0
+      ? '\nAll migration replay checks passed.'
+      : `\n${failures} migration replay check(s) FAILED.`,
+  );
+  process.exitCode = failures === 0 ? 0 : 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Fixes the v0.1.0 production deploy blocker (#96). Production's `__drizzle_migrations` log records 0000–0007 from the pre-rewrite chain (db:push era), but its actual schema never received the `pipelines` objects that the rewritten `0001` creates. The migrator skips by last-applied watermark, so pending work starts at `0008`, which ALTERs pipelines objects that don't exist there — crashlooping the boot-time runner.

Reproduced locally before changing anything (seed a scratch DB to journal idx 7, drop the pipelines schema, leave the empty schema triage created, run `drizzle-kit migrate`): fails with the exact prod error, `relation "pipelines.pipelines" does not exist` (42P01), failing on `0008`'s `CREATE INDEX`. With this PR the same state converges cleanly.

**One correction to the issue text:** the from-scratch replay path is currently *valid* on `main` — verified empirically on the unmodified chain (all 13 migrations apply to an empty database, because the rewritten `0001` creates the pipelines objects). The broken path is specifically **stale-environment catch-up**. The CI job added here exercises both.

While in here: the journal `when` timestamps for `0009` and `0012` were non-monotonic (hand-typed), which can silently skip them forever on environments that migrated past them — drizzle-kit applies in journal array order but skips by last-applied `created_at` watermark (confirmed empirically; a fresh replay records `0009`'s smaller timestamp *after* `0008`'s). Repaired and guarded.

## Changes

- `drizzle/migrations/0008_pipeline_name_not_unique.sql` — index swap wrapped in a `to_regclass('pipelines.pipelines')` guard; no-ops where the table doesn't exist yet
- `drizzle/migrations/0013_pipelines_baseline_repair.sql` (new) — complete final-state `pipelines` schema (8 enums, 9 tables, 10 FKs, 30 indexes) with an existence guard on every statement; DDL verbatim from `0001` except the tenant/name index, which is created in its final post-`0008` non-unique form. No-op on healthy databases.
- `drizzle/migrations/meta/_journal.json` — `0009` `when` 1779710400000 → 1779713480600 and `0012` `when` 1778505114112 → 1779724808298 (restores strict monotonicity); `0013` entry appended
- `drizzle/migrations/0009_tenant_memberships.sql`, `0012_jira_a11y_triage_scheduler.sql` — idempotency guards (`IF NOT EXISTS` / `DO` blocks) so the timestamp repositioning cannot double-apply destructively on environments that recorded them under the old timestamps
- `scripts/migration-replay-check.mjs` + `npm run db:replay-check` (new) — four-phase verifier: journal lint, fresh replay, idempotency, stale-environment catch-up; portable (node + `pg` only, no psql/docker dependency)
- `.github/workflows/validate.yml` — new `migration-replay` job with a `postgres:16-alpine` service (matching `deploy/docker-compose.yml`)
- `CHANGELOG.md` — Unreleased entry

## Test Plan

- [x] `npm run db:replay-check` against local postgres:16-alpine — **all 36 checks pass** (journal lint ×5, fresh replay ×14, idempotency ×2, prod-shaped catch-up ×15)
- [x] Reproduced the prod failure on the unmodified chain first with the same harness shape (fails at `0008`, 42P01)
- [x] Manually verified locally
- [x] Integration tests pass — `npm run validate`: typecheck, lint, 1601 tests passed (118 files; 50 pre-existing skips)
- [ ] Unit tests added or updated (n/a — verification lives in the replay harness, which CI runs on every PR)

## Deploy path for production

No host access needed beyond a normal redeploy of the v0.1.0 image built from this branch/main. Prod's watermark is at `0007`, so its pending set becomes `0008 (guarded no-op) → 0009 → 0010 → 0011 → 0012 → 0013 (creates all pipelines objects)`. The pending batch runs in a single transaction (verified: a failed batch records nothing, so the crashloop left no partial progress), and the empty `pipelines` schema left by triage is handled by `CREATE SCHEMA IF NOT EXISTS`.

Suggest keeping #96 open as the deploy tracker and closing it once the image starts cleanly against prod (`/health` 200 with migrations applied).

## Not covered / residual risks

- The catch-up simulation models the **pipelines gap only**. If prod diverges from the chain in other ways (e.g. `task_type` enum missing for `0012`), the deploy will surface it with a clear error; the same guarded-repair pattern applies.
- Long-lived push-managed dev databases (objects present, journal absent or stale) should keep using `db:push` or reset; `0010`/`0011` were not repositioned and stay unguarded by design.
- drizzle-kit `check`/`generate` snapshot debt (meta snapshots exist only through `0004`) is pre-existing and untouched. The journal-lint phase now pins tag/file/ordering integrity, which is the part that bites at deploy time.

## Checklist

- [x] All tests pass
- [x] TypeScript / Python types are valid (no new type errors)
- [x] Documentation updated if behavior changed (CHANGELOG)
- [x] No secrets, credentials, or client-specific content introduced (scratch-DB URLs are dummy localhost service-container credentials)
- [x] Follows the Client Abstraction rule (§2.10): no real names, client names, or domain-specific jargon
- [x] PR title is descriptive and follows conventional commit style if applicable
- [x] I classified this PR correctly:
  - [ ] Idea lane only (`ideas/**`), no governed spec changes
  - [ ] Governed spec change (`spec/**`, `kitty-specs/**`, `.claude/commands/**`, `.kittify/**`, `README.md`, or `ROADMAP.md`)
  - Neither lane applies: runtime migration + CI change only (no governed paths touched)

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
