### PR TITLE
kitty-spec 015: add-on/plugin architecture + feature entitlements (sanitized promotion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,9 @@ kitty-specs/**/.kittify/dossiers/
 # Vitest timestamp/cache artifacts
 vitest.config.ts.timestamp-*
 .vitest-cache/
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP01-core-extraction-schema.md
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP02-featuregate-decision-core.md
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP03-unforgeable-enforcement.md
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP04-operator-grant-admin.md
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP05-tool-seam-gating.md
+!kitty-specs/015-add-on-plugin-architecture/tasks/WP06-integration-validation.md

--- a/kitty-specs/015-add-on-plugin-architecture/data-model.md
+++ b/kitty-specs/015-add-on-plugin-architecture/data-model.md
@@ -1,0 +1,127 @@
+# Data Model: Add-on / Plugin Architecture and Feature Entitlements
+
+**Spec:** 015 | **Target repo:** joyus-ai (`joyus-ai-mcp-server`)
+**Date:** 2026-06-14
+
+This document defines the new persistence introduced by Spec 015 and how it relates to the existing entitlement schema. It does **not** restate existing tables except where contrast matters.
+
+---
+
+## 1. Relationship to the existing schema
+
+The existing entitlement system lives entirely in the `content` Postgres schema:
+
+- `content.products` (`src/content/schema.ts:133-144`) — `{id, tenantId, name, description, isActive}`. No `kind`/`tier`/`feature` discriminator.
+- `content.entitlements` (`src/content/schema.ts:166-179`) — `{id, tenantId, userId, sessionId, productId→products, resolvedFrom, resolvedAt, expiresAt}`. **Session-scoped, TTL-based.** A grant exists only for the life of a mediation session.
+
+These are **content-access** primitives (which data sources a session may query). They are the wrong granularity for **feature/add-on licensing**, which is a durable, subject-level fact ("Tenant X is licensed for add-on Y until 2027-01-01"), independent of any session.
+
+Spec 015 therefore introduces a **new, platform-level** schema (`entitlements`) rather than overloading `content.entitlements`. Both build on the same *generic* resolver/cache abstractions (see Research §2).
+
+> Proposed home: a new `entitlements` Postgres schema (`src/entitlements/schema.ts`), registered in `drizzle.config.ts` alongside the existing six schema files. The generic `EntitlementResolver` interface, `HttpEntitlementResolver`, and `EntitlementCache` are extracted to `src/entitlements/core/` and imported by both the content module and the new feature module (refactor, not rewrite).
+
+---
+
+## 2. New tables (Phase 1 — Entitlement layer)
+
+### `entitlements.feature_catalog`
+The catalog of licensable features/add-ons. The authoritative list of entitlement keys. Marketplace-ready identity, but no marketplace mechanics.
+
+| Column | Type | Notes |
+|---|---|---|
+| `feature_key` | `text` PK | Stable, reverse-DNS style, e.g. `com.joyus.addon.advanced-pipelines`. Never reused. |
+| `display_name` | `text` NOT NULL | Human label. |
+| `description` | `text` | |
+| `publisher` | `text` NOT NULL | `joyus` for first-party; publisher id for third-party (Phase 2). |
+| `capability_kinds` | `jsonb` NOT NULL | Which contribution kinds this add-on may provide: `["tool","provider","pipeline_step","connector","hook"]`. Advisory metadata for the catalog/marketplace. |
+| `status` | `text` NOT NULL | `active` \| `deprecated` \| `withdrawn`. |
+| `created_at` | `timestamp` | |
+| `updated_at` | `timestamp` | |
+
+### `entitlements.feature_entitlements`
+Persistent grants. The source of truth / local fallback for "who may use what." Distinct from `content.entitlements` in lifecycle (durable, not session-scoped) and semantics (explicit deny on absence).
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | cuid. |
+| `subject_type` | `text` NOT NULL | `tenant` \| `user`. **Billing-unit-agnostic.** **No DB default** — the application always supplies an explicit subject. Phase 1 issues `user` grants (individual-first, FR-019); `tenant` grants arrive with WP12. Do not encode a `tenant` default at the column level. |
+| `subject_id` | `text` NOT NULL | tenantId or userId per `subject_type`. |
+| `feature_key` | `text` NOT NULL | FK → `feature_catalog.feature_key` (RESTRICT on delete). |
+| `status` | `text` NOT NULL | `active` \| `suspended` \| `expired` \| `revoked`. |
+| `valid_from` | `timestamp` NOT NULL | |
+| `valid_until` | `timestamp` NULL | NULL = perpetual until revoked. |
+| `source` | `text` NOT NULL | `admin` \| `resolver` \| `trial` \| `import`. Provenance for audit. |
+| `limits` | `jsonb` NULL | Optional quota envelope, e.g. `{"maxRunsPerMonth":1000}`. Enforcement of limits is mostly out of scope (see spec §10); the column exists so the gate boundary can carry them later. |
+| `metadata` | `jsonb` NULL | Free-form (e.g. billing reference, plan id). |
+| `created_at` | `timestamp` NOT NULL | |
+| `updated_at` | `timestamp` NOT NULL | |
+
+**Indexes / constraints**
+- `UNIQUE (subject_type, subject_id, feature_key)` — one live grant row per subject+feature (status transitions update in place; history goes to the decision log / event stream).
+- `INDEX (subject_type, subject_id, status)` — the hot path for `resolve(subject)`.
+- `INDEX (feature_key)` — catalog-side queries ("who has add-on Y").
+- Partial index `(subject_type, subject_id) WHERE status = 'active'` for fast active-set resolution.
+
+**Query semantics (FR-017) — required, not optional.** Every read that decides entitlement (resolve *and* the resolver-outage DB fallback) MUST filter `status = 'active' AND (valid_until IS NULL OR valid_until > now())`. The existing content DB-fallback selects the most-recent row *without* an expiry filter (`content/entitlements/index.ts`); copying it verbatim would serve a lapsed paid grant during an outage. The cached resolved set is the post-filter set, and cache TTL is capped at time-to-next-expiry so no grant outlives `valid_until` by more than one TTL.
+
+**Write path (FR-015).** Rows are created/modified/revoked only through the authorized operator grant surface (operator REST endpoint and/or admin-only MCP tool), never by tenant-user code paths and not as a raw-SQL contract. Each write records actor identity to the decision/grant-history log. This is the attachment point for billing automation later (`source=resolver|import`).
+
+> Isolation note: `subject_id` is a naked string today (no `tenants` table — `orchestrator.ts:15`). When subject_type=`tenant`, `subject_id` is the same opaque `tenantId` used platform-wide. There is **no** FK to a tenants table because none exists (WP12). This table inherits the platform's current soft-isolation posture; see spec §3 Security and Dependencies.
+
+> **Effective-entitlement resolution (spec FR-019) — individual-first, org-layered.** The gate evaluates a *user*, whose effective set is the union of grants for `{user:U} ∪ {tenant:T | U ∈ members(T)}`. **Pre-WP12** there is no membership source, so the union degrades to `{user:U}` and the individual path works against this table alone. **Post-WP12** the resolver also reads tenant↔user membership (a WP12-owned table, not defined here) and unions in `tenant` grants — so one tenant row entitles every member with no per-user fan-out. This table needs **no change** to support inheritance; the union lives in the resolver/gate. Open sub-decision (spec §11.4): an optional per-grant `inheritable` flag if some tenant grants should *not* flow to all members.
+
+### `entitlements.entitlement_decisions` (append-only audit)
+Every gate decision is recorded. There is no dedicated entitlement-decision audit today; the existing `*.operation_logs` tables are operation audits, and `content.entitlements` is a live grant table, not append-only.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | |
+| `subject_type` | `text` NOT NULL | |
+| `subject_id` | `text` NOT NULL | |
+| `feature_key` | `text` NOT NULL | |
+| `decision` | `text` NOT NULL | `allow` \| `deny`. |
+| `reason` | `text` NOT NULL | `entitled` \| `not_entitled` \| `expired` \| `suspended` \| `limit_exceeded` \| `resolver_unavailable_fallback_deny`. |
+| `resolved_from` | `text` NOT NULL | `cache` \| `resolver` \| `db` \| `default_deny`. Mirrors the existing `resolvedFrom` convention. |
+| `capability` | `text` NULL | e.g. `tool:advanced_pipeline_run`. What was being gated. |
+| `actor_id` | `text` NULL | Who initiated the decision when it is an **admin action** (grant/revoke). NULL for routine gate checks (the subject is the actor). Required so FR-015 grant/revoke writes carry actor identity in an append-only record. |
+| `session_id` | `text` NULL | When available. |
+| `created_at` | `timestamp` NOT NULL | |
+
+**Constraints**: APPEND-ONLY (no UPDATE/DELETE), following the `orchestrator_events` precedent (`src/db/schema/events.ts`). Indexes: `(subject_type, subject_id, created_at)`, `(feature_key, created_at)`.
+
+---
+
+## 3. New persistence (Phase 2 — Plugin host)
+
+Plugin **identity and contributions** are mostly declared in code (the manifest is a TypeScript/JSON object shipped by the add-on package), so Phase 2 adds little schema. One operational table tracks load state:
+
+### `entitlements.installed_plugins`
+Operator-facing record of which plugin packages are configured to load and their last-known health. Distinct from entitlements (which gate *use*); this tracks *installation*.
+
+| Column | Type | Notes |
+|---|---|---|
+| `plugin_id` | `text` PK | Reverse-DNS, matches manifest `id`. |
+| `version` | `text` NOT NULL | semver, from manifest. |
+| `enabled` | `boolean` NOT NULL | Operator toggle. |
+| `core_api_range` | `text` NOT NULL | Declared compatible core API semver range. |
+| `provides` | `jsonb` NOT NULL | Contribution descriptors from the manifest. |
+| `requires_features` | `jsonb` NOT NULL | Entitlement keys the plugin's gated contributions require. |
+| `health` | `text` NOT NULL | `loaded` \| `failed` \| `incompatible` \| `disabled`. |
+| `last_error` | `text` NULL | |
+| `loaded_at` | `timestamp` NULL | |
+
+> A "tenant installs a plugin" model (per-tenant plugin install) is **out of scope** for Spec 015 — installation is operator/deployment-level here. Per-tenant install is a marketplace concern (W6).
+
+---
+
+## 4. Migration approach
+
+Follows the established pattern (Research §6): add `src/entitlements/schema.ts` to the `schema` array in `drizzle.config.ts`, generate with `drizzle-kit`, commit the SQL under `drizzle/migrations/00NN_*.sql` with a journal entry. No data backfill is required — Phase 1 starts with an empty catalog and grants created by admin/import. Existing `content.*` tables are untouched (additive only); the only change to existing code paths is the (mechanical) extraction of the generic resolver/cache into `src/entitlements/core/` with re-exports kept in `src/content/entitlements/` for source compatibility.
+
+---
+
+## 5. What is deliberately NOT modeled here
+
+- **No `tenants`/`plan`/`subscription` table.** Spec 015 consumes whatever produces grants (admin action, a billing resolver). Building the billing/subscription system is out of scope (spec §10); `feature_entitlements.source` and `metadata` carry the linkage.
+- **No token/cost usage tables.** Usage-based entitlements depend on W3 (cost capture); the `limits` column is a forward hook only.
+- **No RLS policies.** Isolation remains application-level (W5 dependency). The new tables follow the same "all queries MUST filter by subject" rule as the rest of the schema.

--- a/kitty-specs/015-add-on-plugin-architecture/meta.json
+++ b/kitty-specs/015-add-on-plugin-architecture/meta.json
@@ -1,0 +1,14 @@
+{
+  "feature_number": "015",
+  "slug": "015-add-on-plugin-architecture",
+  "friendly_name": "Add-on / Plugin Architecture and Feature Entitlements",
+  "mission": "software-dev",
+  "source_description": "A core/add-on extension boundary (plugin host + SDK) and a persistent feature-entitlement layer that extends the existing content-entitlement resolver from content access to feature/add-on licensing.",
+  "target_repo": "joyus-ai",
+  "created_at": "2026-06-14T00:00:00Z",
+  "vcs": "git",
+  "measurement_owner": "Engineering Operations",
+  "review_cadence": "weekly",
+  "risk_class": "critical",
+  "lifecycle_state": "planning"
+}

--- a/kitty-specs/015-add-on-plugin-architecture/plan.md
+++ b/kitty-specs/015-add-on-plugin-architecture/plan.md
@@ -1,0 +1,206 @@
+# Implementation Plan: Add-on Feature Entitlements — Phase 1 (Individual Path)
+
+**Branch**: `015-add-on-plugin-architecture` | **Date**: 2026-06-14 | **Spec**: [spec.md](spec.md)
+**Input**: `spec/015-add-on-plugin-architecture/spec.md` (FRs), [data-model.md](data-model.md), [research.md](research.md)
+**Scope of THIS plan**: **Phase 1 only — the individual path that ships without WP12.** Phase 1.5 (org seat-licensing via membership inheritance) and Phase 2 (plugin host + SDK) are explicitly out of scope here and get their own plans.
+
+---
+
+## Summary
+
+Build the feature-entitlement layer and gate that turns the open core into a licensable surface — for **individual subjects**, with no tenant system and no package split. Reuse the existing entitlement *resolution machinery* (`EntitlementResolver`, `HttpEntitlementResolver`, `EntitlementCache`) by extracting it to a shared `src/entitlements/core/`, then build a new persistent, explicit-deny system on top: three tables in a new `entitlements` PostgreSQL schema, a `FeatureGate` with structural (un-forgeable) enforcement, an operator grant-write path, and entitlement gating wired into the tools seam. The effective-entitlement **union (FR-019)** is built now with a `NullMembershipResolver` (returns `[]` pre-WP12), so Phase 1.5 activates org inheritance by swapping one implementation — no redesign.
+
+What this unblocks: an individual ("looking for answers") licenses an add-on for their own account; the gate shows and runs it for them and denies everyone else with an explicit "upgrade required."
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 20 LTS
+**Primary Dependencies**: Express.js, Drizzle ORM, Zod, `@paralleldrive/cuid2` — no new deps
+**Storage**: PostgreSQL 16 — new `entitlements` pgSchema (follows the `content`/`profiles` schema pattern)
+**Testing**: Vitest (unit + integration), existing infrastructure
+**Target Platform**: Linux server (Docker), same deployment as the rest of `joyus-ai-mcp-server`
+**Project Type**: Platform module within `joyus-ai-mcp-server` (single package — no monorepo split in Phase 1)
+**Performance Goals**: < 5ms gate cache hit p95; < 500ms cold resolve p95; < 10ms `tools/list` entitlement filter for ≤ 50 catalog entries
+**Constraints**: Reuse content entitlement machinery (no rewrite); no package extraction; **individual subject only** (`subject_type=user`, `tenantId == userId`); fail closed on access *and* lapsed grants
+**Scale/Scope**: Phase 1 is the entitlement layer + tool-seam gating + operator grant path. ~6 work packages.
+
+## Constitution Check
+
+*GATE: must pass before implementation. Re-check after Phase A.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| 2.1 Multi-Tenant from Day One | **CONDITIONAL** | Phase 1 operates on **individual subjects** (`tenantId == userId` interim). The schema (`subject_type`) and union resolver (FR-019) are multi-tenant-ready; org-scoped entitlement activates at WP12 (Phase 1.5). Not a violation — a sequenced, declared boundary. The gate takes an *explicit* subject and never infers from the collapse. |
+| 2.2 Skills as Guardrails | **PASS** | Entitlement is a guardrail: add-on capability is gated, default-deny, enforced in trusted core (FR-016). Operator grant action exposed as an admin-only MCP tool with explicit authz (FR-015). |
+| 2.3 Sandbox by Default | **PASS (Phase 1)** | Default-deny everywhere; absence/expiry/resolver-failure denies. *(In-process add-on sandboxing is a Phase 2 concern — flagged, not in scope.)* |
+| 2.4 Monitor Everything | **PASS** | Every allow/deny appended to `entitlement_decisions` (append-only, FR-006); grant/revoke audited with actor identity (FR-015). |
+| 2.5 Feedback Loops | **PASS** | Deny carries a structured "upgrade required" signal (FR-005) — the conversion loop. Decision log feeds conversion analytics. |
+| 3.2 Data Governance | **PASS** | Decision log append-only. Grant writes are authorized + audited. No new PII; `feature_entitlements` holds keys + windows, not content. |
+| 5.1 Technology Choices | **PASS** | Express + Drizzle + PostgreSQL + Zod — existing stack. **Reuses** existing entitlement machinery (extracted to shared `core/`), no new deps. |
+| 5.2 Cost Awareness | **PASS** | In-process cache (reused class), no external cache service in Phase 1. DB fallback is a single indexed query (partial index on active grants). Cross-instance pub/sub deferred pending the revocation-SLA decision (§11.5). |
+| 5.3 Reliability | **PASS** | Fail-closed on resolver outage (DB fallback → deny), expiry-aware so a lapsed grant is never served (FR-017). Content path untouched (additive + extraction with re-exports). |
+
+**One open gate item:** principle 2.1 is CONDITIONAL by design — Phase 1 is individual-scoped. Confirm this is an accepted, declared boundary (it is the whole point of the individual-first sequencing) before starting.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+spec/015-add-on-plugin-architecture/
+├── spec.md              # Feature specification (19 FRs, 2 layers, 3 phases)
+├── data-model.md        # entitlements schema + query/write rules
+├── research.md          # Code grounding (file:line evidence)
+├── plan.md              # This file — Phase 1 (individual path)
+├── tasks.md             # Phase 1 work-package decomposition
+└── meta.json
+```
+
+### Source Code (in joyus-ai-mcp-server)
+
+```
+src/
+├── entitlements/                     # NEW platform-level module
+│   ├── core/                         # EXTRACTED shared machinery (was src/content/entitlements/*)
+│   │   ├── resolver.interface.ts     #   EntitlementResolver, ResolverContext, *Config
+│   │   ├── http-resolver.ts          #   HttpEntitlementResolver (+ responseMapping.featuresField)
+│   │   ├── cache.ts                  #   EntitlementCache (key-generic)
+│   │   └── index.ts
+│   ├── schema.ts                     # entitlements pgSchema: feature_catalog, feature_entitlements, entitlement_decisions
+│   ├── types.ts                      # Subject, FeatureKey, EffectiveEntitlement, GateToken (opaque), GrantSource
+│   ├── validation.ts                 # Zod: grant create/modify/revoke, catalog entry
+│   ├── resolver.ts                   # FeatureEntitlementResolver (DB-leads, expiry-aware filter — FR-017)
+│   ├── membership.ts                 # MembershipResolver interface + NullMembershipResolver (returns [] pre-WP12)
+│   ├── gate.ts                       # FeatureGate: isEntitled/assertEntitled, GateToken mint, union (FR-016/019)
+│   ├── subject-cache.ts              # subject-keyed cache wiring + explicit invalidation (FR-004/018)
+│   ├── audit.ts                      # entitlement_decisions append-only writer (FR-006)
+│   ├── errors.ts                     # FeatureNotEntitledError (+ upgrade payload shape)
+│   ├── ownership.ts                  # static add-on-tool → feature_key map (Phase 1; replaced by registry in Phase 2)
+│   ├── admin/
+│   │   ├── grants.service.ts         # operator grant/modify/revoke (FR-015), idempotent, audited
+│   │   ├── routes.ts                 # operator-only REST endpoints
+│   │   └── tools.ts                  # admin-only MCP tools (catalog + grant management)
+│   └── index.ts                      # module barrel + initialization (wires gate, resolver, cache, membership)
+│
+├── content/entitlements/             # KEEPS thin re-exports from ../../entitlements/core (source-compat; no break)
+│
+├── tools/
+│   ├── index.ts                      # getAllTools(): filter add-on-owned tools by effective entitlement (FR-007)
+│   └── executor.ts                   # executeTool(): assertEntitled (GateToken) before add-on tool dispatch (FR-007)
+│
+└── index.ts                          # mount admin routes, register admin tools, init entitlements module
+
+drizzle/
+└── 00NN_entitlements_schema.sql      # generated migration (add schema.ts to drizzle.config.ts)
+
+tests/
+├── entitlements/
+│   ├── core-extraction.test.ts       # content path regression: existing entitlement tests still green
+│   ├── resolver.test.ts              # DB-leads, expiry filter, fail-closed
+│   ├── gate.test.ts                  # explicit deny, resolution order, GateToken un-forgeability
+│   ├── union.test.ts                 # FR-019: {user} pre-WP12; membership-stub union
+│   ├── subject-cache.test.ts         # subject key, TTL cap, invalidation
+│   ├── audit.test.ts                 # append-only decision log
+│   ├── admin-grants.test.ts          # FR-015 write path + authz + audit
+│   └── integration/
+│       ├── individual-licensing.test.ts   # grant → tool appears → call works; revoke → denies
+│       ├── explicit-deny.test.ts          # unentitled → upgrade-required, logged
+│       ├── fail-closed-lapsed-grant.test.ts    # resolver outage + expired grant → deny (FR-017)
+│       └── second-path-gating.test.ts     # gated capability via non-tools/call path still denied (FR-016)
+```
+
+**Structure Decision**: The entitlement module is promoted to **platform-level** (`src/entitlements/`) rather than living under `content/`, because feature licensing is not content-specific. The generic machinery is *extracted* to `src/entitlements/core/` and the content module keeps re-exports so its call sites and tests are untouched. This makes "extend the machinery, build the system" literal and low-risk.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                       joyus-ai-mcp-server (Express)                        │
+│                                                                            │
+│   Actor = individual user U  (Phase 1: tenantId == userId)                 │
+│        │                                                                   │
+│        ▼                                                                   │
+│   tools/list ──┐                       ┌── operator (admin role)           │
+│   tools/call ──┤                       │                                   │
+│        │       │                       ▼                                   │
+│        │       │              ┌──────────────────────┐                     │
+│        │       │              │  Admin Grant Path     │  FR-015            │
+│        │       │              │  admin/routes,tools   │  authz + audit     │
+│        │       │              │  grants.service ──────┼──▶ feature_*       │
+│        ▼       ▼              └──────────────────────┘     (write)         │
+│   ┌─────────────────────────────────────────────────────┐                 │
+│   │                  FeatureGate (gate.ts)               │  FR-005/016/019 │
+│   │  assertEntitled(subject, featureKey) → GateToken     │                 │
+│   │   effective set = UNION over actor's subjects:       │                 │
+│   │     { user:U } ∪ MembershipResolver(U)               │  FR-019         │
+│   │            (NullMembershipResolver → [] pre-WP12)     │                 │
+│   │   resolution order:                                  │                 │
+│   │     subject-cache → resolver → DB fallback → DENY     │  FR-004/005/017 │
+│   │   deny → FeatureNotEntitledError (upgrade payload)    │  explicit       │
+│   └───────┬─────────────────────┬───────────────┬────────┘                 │
+│           │ mints               │ reads          │ appends                 │
+│           ▼                     ▼                ▼                         │
+│     GateToken          FeatureEntitlement    entitlement_decisions         │
+│     (un-forgeable;     Resolver (DB-leads,   (append-only audit)           │
+│      required by       expiry-aware)              FR-006                    │
+│      gated seams)             │                                            │
+│           │                   ▼                                            │
+│           │            ┌──────────────────────────────────────────┐       │
+│           │            │  PostgreSQL  (entitlements schema)         │       │
+│           │            │  feature_catalog | feature_entitlements |  │       │
+│           │            │  entitlement_decisions                     │       │
+│           │            └──────────────────────────────────────────┘       │
+│           ▼                                                                │
+│   Gated seams (FR-007/008) — accept a GateToken, never a raw object:       │
+│     • tools/index.ts getAllTools  → hides unentitled add-on tools          │
+│     • tools/executor.ts execute   → asserts before add-on dispatch         │
+│     • (providers / steps / connectors: enumerated call sites)              │
+│                                                                            │
+│   Reused, unchanged:  src/entitlements/core/  (EntitlementResolver,        │
+│     HttpEntitlementResolver, EntitlementCache)  ◀── content path re-exports │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Phase Breakdown (this plan = Phase 1 only)
+
+### Phase A: Foundation (WP01–WP02)
+Extract the shared `core/`, create the `entitlements` schema + types + validation, and build the decision core (resolver + subject cache + `FeatureGate` + union seam + audit). Security-critical; nothing ships until default-deny and fail-closed are proven and the content path is still green.
+
+### Phase B: Enforcement & Write Path (WP03–WP04)
+The un-forgeable gated-path primitive (`GateToken`, enumerated call sites, quarantine the existing synthetic bypass) and the operator grant/catalog write path that creates grants.
+
+### Phase C: Seam Wiring & Validation (WP05–WP06)
+Wire entitlement gating into the tools seam (visibility + execution + upgrade response), then the integration tests and validation sweep proving the Phase 1 success criteria.
+
+## Security Considerations
+
+1. **Enforcement is structural, not procedural (FR-016).** Gated capabilities accept only a `GateToken` minted by `FeatureGate`; hand-constructed entitlement objects are un-typeable in the gated path. This directly closes the class of bug the codebase already demonstrates (`content-executor.ts:223` fabricates a `ResolvedEntitlements`). Phase 1 enumerates every gated call site so coverage is auditable.
+
+2. **Fail closed on access AND lapsed grants (FR-017).** Resolver outage → DB fallback → deny. The fallback filters `status='active' AND (valid_until IS NULL OR valid_until > now())` so a lapsed licensed feature is never served during an outage. The existing content fallback is *not* expiry-aware; do not copy it verbatim.
+
+3. **The gate takes an explicit subject.** It never infers from the `tenantId == userId` collapse. A test pins this so Phase 1.5 / WP12 cannot silently weaken it.
+
+4. **Grant-write is privileged and audited (FR-015).** Only an operator/admin role writes `feature_entitlements`, through a defined surface (not raw SQL), with actor identity recorded on every grant/revoke.
+
+5. **Decision audit is append-only (FR-006).** Only `logAllow`/`logDeny`; no UPDATE/DELETE in application code (follows the `orchestrator_events` precedent).
+
+6. **Bounded by tenant identity (declared).** Phase 1 entitlement strength for *individuals* is sound; org-scoped strength depends on WP12 + isolation hardening (Phase 1.5). This boundary is stated, not assumed away.
+
+## Future Considerations (NOT in this plan)
+
+- **Phase 1.5 — org seat-licensing**: swap `NullMembershipResolver` for a real one (reads WP12 tenant↔user membership); activate `subject_type=tenant` inheritance; couples with isolation/RLS hardening. Needs WP12.
+- **Phase 2 — plugin host + SDK**: extract `@joyus-ai/plugin-sdk`, plugin manifest + host + runtime loader, convert static tool registration and the closed `StepType` union to host-mediated registration with auto-gating; in-process loader threat model.
+- **Seat-capping** (vs site license): a seat-assignment table refining FR-019's union — open decision §11.8.
+- **Cross-instance invalidation bus**: pub/sub for immediate cross-node revocation — pending the revocation-SLA decision (§11.5); Phase 1 baseline is TTL-only across instances.
+- **Usage-based limits / metering**: needs cost capture; `limits` is a forward hook only.
+
+## Complexity Tracking
+
+| Item | Why it exists | Simpler alternative rejected |
+|------|---------------|------------------------------|
+| `core/` extraction | Make reuse literal; keep content path green | Duplicating resolver/cache — rejected (drift, two implementations) |
+| Union resolver + `NullMembershipResolver` now | Phase 1.5 activates by swap, not redesign | Hard-coding `{user:U}` — rejected (would force a later rewrite of the gate) |
+| `GateToken` un-forgeable primitive | Structural enforcement; the synthetic-bypass bug is already in-tree | Call-site discipline only — rejected (FR-016 / M1; one forgotten site ships a free licensed feature) |
+| Dedicated `entitlement_decisions` table | Compliance + conversion analytics; explicit-deny semantics | Reusing `content.operation_logs` — viable thinner path (§11.3); flagged for the build owner to confirm |
+
+*Open decision for the build owner (spec §11.3): adopt the full three-table schema, or a thinner first cut (single grants table + reuse `content.operation_logs` for audit) to ship the individual dollar faster. This plan assumes the full schema; downgrade is a scoped reduction of WP01.*

--- a/kitty-specs/015-add-on-plugin-architecture/spec.md
+++ b/kitty-specs/015-add-on-plugin-architecture/spec.md
@@ -1,0 +1,282 @@
+# Specification: Add-on / Plugin Architecture and Feature Entitlements
+
+**Project:** Joyus AI Platform
+**Phase:** Foundation — Add-on Extensibility & Feature Entitlements
+**Date:** June 14, 2026
+**Status:** Draft for review
+**Target repo:** joyus-ai (`joyus-ai-mcp-server`)
+**Supporting docs:** `data-model.md` (schema)
+
+---
+
+## 1. Overview
+
+### Problem
+
+Joyus AI is open core (Apache 2.0) with a productization model of proprietary add-ons plus hosting/services. The code has no mechanism for that: there is no core/add-on boundary, no way for a proprietary capability to attach without forking the open core, and no way to license a capability to one subject (user or tenant) and withhold it from another.
+
+An entitlement system **does** exist (`src/content/entitlements/`), but it gates **content access** (which data sources a session may query), is **session-scoped and TTL-based** (`content.entitlements`, `schema.ts:166-179`), and **denies silently** (no `check`/`assert`; non-entitled yields empty results). Feature/add-on licensing needs the opposite on all three axes: a **durable, subject-level** grant, an **explicit** allow/deny with an "upgrade required" signal, and a gate that is **enforced in trusted core code**, not by the add-on itself.
+
+Until this exists, licensed add-ons cannot be offered at all: there is no mechanism to grant a capability, to gate it, or to attach proprietary code to the open core without forking.
+
+### Solution
+
+Build the add-on extensibility foundation in two layers, delivered in two phases so licensed add-ons become possible before the full ecosystem is built.
+
+- **Extension layer** — *how add-on code attaches.* A unified registration surface over the existing seams (tools, providers, connectors, pipeline steps, hooks) so a capability can be added without editing core dispatch code.
+- **Entitlement layer** — *how add-on access is licensed.* A persistent, subject-scoped feature-entitlement service that **reuses** the existing generic resolver/cache abstractions (`EntitlementResolver`, `HttpEntitlementResolver`, `EntitlementCache`) but introduces its own durable table and **explicit-deny** gate.
+
+> **Design principle — individual-first, org-layered.** The individual user is the **primary actor and a first-class subject from day one**; organizations are groupings that hold entitlements which *layer on top*. A user's **effective entitlement is the union** of (a) their own user-grants and (b) the grants of every org they belong to (FR-019). The architecture therefore never gates the individual experience behind org/tenant identity — orgs add capability to a member, they are not a precondition for one.
+
+**Phasing — individual-first, org-layered.**
+
+- **Phase 1 — Feature Entitlement + Gate (individual-first; ships *without* WP12).** The entitlement layer (FR-001..019) and gate at the existing seams, with the **individual user as the primary subject**. A user can hold a feature grant for their own account **today** — `subject_type=user`, `tenantId == userId`, no tenant system required. No package split.
+- **Phase 1.5 — Org-level entitlement (layers on; requires WP12).** Once tenant identity lands (real `tenants` table + tenant↔user membership + tenant resolution replacing the `tenantId == userId` collapse), an org holds an add-on grant **once** and **every member inherits it** via the effective-entitlement union (FR-019). This gates **org-level entitlement — not the individual path**; individuals never wait on it. The tenant-identity prerequisite is **already specced as Spec 013 — Tenant Identity Resolution** (currently spec-only): its WP01 adds the tenants/membership schema the union needs. Org-level entitlement sequences behind Spec 013's implementation, alongside isolation hardening (and overlaps Spec 008, profile-layer isolation).
+- **Phase 2 — Plugin Host + SDK (ecosystem; out-of-tree, proprietary, marketplace-ready).** Extract a stable `@joyus-ai/plugin-sdk`, define a plugin manifest + host + runtime loader, and convert the static surfaces (MCP tool registration; the closed `StepType` union) into host-mediated registration. The host binds entitlement enforcement to plugin contributions automatically. This is what makes truly-proprietary, separately-distributed add-ons and a future marketplace possible.
+
+The subject-type-agnostic `subject_type` plus union resolution (FR-019) means the entitlement layer is **built once** and serves individuals immediately, then lights up for orgs when WP12 lands — a sequencing dependency, not a redesign.
+
+**Isolation coupling (scoped to org-level entitlement, not the individual path).** Phase 1.5 introduces multiple users per tenant, so a cross-tenant bug would expose one tenant's data/features to another — coupling WP12 with isolation hardening (RLS) on the org path. The Phase 1 individual path keeps each user as its own subject and is not gated on RLS for first-party use; public/untrusted exposure still is (§8). The entitlement gate is only as trustworthy as the tenant boundary beneath it — which is why org exposure waits on isolation, while individuals do not.
+
+### Users
+
+- **Platform operators** — enable/disable add-ons per subject; install plugin packages; monitor plugin health.
+- **Tenant administrators / end users** — see only the capabilities they are licensed for; get a clear upgrade path when they hit a gated feature.
+- **First-party Joyus engineers** — ship licensed capabilities behind an entitlement without forking core (Phase 1).
+- **Third-party / proprietary add-on authors** — build against a stable, Apache-licensed SDK and ship an independent package the open core never vendors (Phase 2).
+- **External grant sources** — billing/admin automation writes entitlement grants (directly or via a resolver endpoint) when a subject acquires, trials, or relinquishes an add-on.
+
+---
+
+## 2. Functional Requirements
+
+### Phase 1 — Entitlement layer
+
+#### FR-001: Feature Catalog
+A catalog of licensable features/add-ons (`entitlements.feature_catalog`) keyed by a stable, reverse-DNS `feature_key` (e.g. `com.joyus.addon.advanced-pipelines`). Each entry carries display name, description, publisher, the contribution kinds it may provide, and a lifecycle status (`active`/`deprecated`/`withdrawn`). Feature keys are **never reused**. This is distinct from `content.products` (which is content-routing, not licensing) and is the authoritative list of entitlement keys.
+
+#### FR-002: Persistent Feature Entitlements
+A durable grant table (`entitlements.feature_entitlements`) recording that a **subject** holds a **feature** for a validity window. A subject is `{subject_type ∈ {tenant,user}, subject_id}` — **subject-agnostic**, so a per-tenant vs per-seat choice maps onto `subject_type` without a redesign. Grants carry `status`, `valid_from`, `valid_until` (nullable = perpetual), `source` (`admin`/`resolver`/`trial`/`import`), and an optional `limits` envelope. Grants are **persistent and independent of any session** — explicitly contrasting `content.entitlements`. Exactly one live grant row per `(subject_type, subject_id, feature_key)` (unique constraint); lifecycle changes update status in place, history goes to the decision log (FR-006).
+
+#### FR-003: Feature Entitlement Resolver (reuse the existing contract)
+Resolve the set of feature keys a subject is entitled to, using the **existing** `EntitlementResolver` contract (`interface.ts:47-53`) — which is already generic over opaque IDs. Provide a `FeatureEntitlementResolver` whose default implementation reads `feature_entitlements` (DB-leads). Optionally, an `HttpEntitlementResolver` (the existing one, `http-resolver.ts`) may front an external grant source, extended only by adding a `featuresField` to its `responseMapping`. Resolution is **fail-closed**: resolver failure never grants. To make reuse literal, extract the generic `EntitlementResolver` interface, `HttpEntitlementResolver`, and `EntitlementCache` into a shared `src/entitlements/core/` consumed by both the content module and this one (mechanical refactor; re-exports preserved).
+
+#### FR-004: Subject-Scoped Entitlement Cache
+Cache resolved feature sets keyed by **subject** (`subject_type:subject_id`), not by session — because licensing does not change per session. Reuse the `EntitlementCache` class (`cache.ts`) parameterized by key. TTL is expiry-aware per FR-017 (default 1h, capped by next grant expiry). Provide **explicit invalidation** on entitlement change (grant/revoke/suspend/expire) — unlike the content cache, which only invalidates on session close (`mediation/router.ts:259`). A grant or revocation must take effect within one TTL window even absent explicit invalidation. **Multi-instance caveat:** the cache is in-process, so explicit invalidation is single-node; cross-node propagation is governed by FR-018.
+
+#### FR-005: FeatureGate Service (explicit deny)
+A single enforcement service exposing:
+- `isEntitled(subject, featureKey): Promise<boolean>` — non-throwing check.
+- `assertEntitled(subject, featureKey, capability?): Promise<void>` — throws `FeatureNotEntitledError` carrying the `featureKey` and a machine-readable reason, which the API/MCP layer maps to a structured **"upgrade required"** response (HTTP 402/403 with an `upgrade` payload; a non-empty MCP tool error) — **not** a silent empty result. Resolution order mirrors the existing stack: **cache → resolver → DB fallback → default deny**, with every step expiry-aware (FR-017). `FeatureGate` is the *only* place entitlement is decided; no add-on decides its own access — and in Phase 1 that guarantee is made structural, not procedural, via FR-016.
+
+#### FR-006: Entitlement Decision Audit
+Every gate decision (allow and deny) is appended to `entitlements.entitlement_decisions` with subject, feature key, decision, reason (`entitled`/`not_entitled`/`expired`/`suspended`/`limit_exceeded`/`resolver_unavailable_fallback_deny`), `resolved_from` (`cache`/`resolver`/`db`/`default_deny`), the capability being gated, and session id when available. The table is **append-only** (following the `orchestrator_events` precedent, `events.ts`). There is no entitlement-decision audit today; this creates one for compliance, debugging, and conversion analytics.
+
+### Phase 1 — Gate enforcement at existing seams
+
+#### FR-007: Entitlement-Gated MCP Tools
+Tool *visibility* and *execution* become entitlement-aware:
+- `getAllTools(userId)` (`tools/index.ts:32-62`), which already filters by connected service, additionally **omits add-on-owned tools** the subject is not entitled to, so `tools/list` shows only licensed capabilities.
+- `executeTool(...)` (`tools/executor.ts`) calls `FeatureGate.assertEntitled` **before dispatching** any add-on-owned tool, returning an explicit upgrade error on deny. Core (free) tools are unaffected. Tools declare their owning `feature_key` via the registry (FR-011) or, in Phase 1, a static ownership map for in-tree add-on tools.
+
+#### FR-008: Entitlement-Gated Providers, Steps, and Connectors
+Non-tool contributions are gated at their invocation boundary: a generation/search provider, pipeline step handler, or content connector may declare a required `feature_key`; the core asserts entitlement before invoking it. Because these run inside trusted core services (`GenerationService` DI `content/index.ts:69-74`; `StepRegistry` `pipelines/steps/registry.ts`; `ConnectorRegistry` `connectors/registry.ts`), the gate lives in those call sites, not in the contribution. **These call sites are a finite, enumerated set** (FR-016) — not "wherever contributions are invoked" — and each is reached only through the un-forgeable gated path, so coverage is auditable rather than dependent on every author remembering the check.
+
+### Phase 2 — Plugin host + SDK
+
+#### FR-009: Plugin SDK Package (`@joyus-ai/plugin-sdk`, Apache-2.0)
+Extract the stable extension interfaces into a separately-publishable, Apache-2.0 package that add-ons depend on **without** pulling in the full server: `ToolDefinition` + tool-executor signature, `GenerationProvider`, `SearchProvider`, `ContentConnector`, `SkillResolver`, `PipelineStepHandler`, `Pre/PostGenerationHook`, the `FeatureGate`-facing types, and the `JoyusPlugin` + `PluginManifest` + `PluginHost` contracts. Today everything is one package with no core/add-on split (`package.json:2-4`); this requires introducing a workspace and moving interfaces behind a published surface with a versioned **core API**.
+
+#### FR-010: Plugin Manifest and Identity
+Each add-on declares a manifest: stable `id` (reverse-DNS, marketplace-ready), `version` (semver), `publisher`, `displayName`, the `provides` contributions, the `requiresFeatures` entitlement keys its gated contributions need, and a `coreApiRange` (compatible core API semver range). Identity is stable and versioned so a future marketplace can build on it without redesign — but no marketplace mechanics are in scope here.
+
+#### FR-011: Plugin Host and Registration Contract
+A `PluginHost` exposes scoped registration methods — `registerTool`, `registerToolExecutor`, `registerProvider`, `registerConnector`, `registerPipelineStep`, `registerSkillResolver`, `registerPreHook`/`registerPostHook`, `registerEventType` — and calls each plugin's `register(host)` at boot. This requires converting the static surfaces into registries:
+- **MCP tools:** add a mutable tool registry feeding `getAllTools()` and a `registerToolExecutor(prefix|ownerId, handler)` path in `executor.ts` (today both are hard-coded — `tools/index.ts:32-62`, `executor.ts:47-54`).
+- **Pipeline steps:** widen `StepType` from a closed union (`pipelines/types.ts:25-27`) to `string` (preserving built-in autocomplete) so `StepRegistry.register()` accepts new types.
+- **Safety hooks:** expose the `SafetyService` instance (private to `index.ts:353`) to the host.
+- Connectors, providers, skill resolvers, and event types already support registration/DI and need only host wiring.
+
+#### FR-012: Runtime Plugin Loader with Failure Isolation
+Load a **config-driven allowlist** of plugin packages at boot (env/config pattern, mirroring `SKILLS_DIR`/skill-loader configurability, `skill-loader.service.ts`). For each: validate the manifest, check `coreApiRange` compatibility, and call `register(host)` inside a try/catch. A plugin that throws, is incompatible, or declares an unknown `feature_key` is marked unhealthy in `entitlements.installed_plugins` and **does not crash boot or affect other plugins or core**. Plugin load state is operator-visible.
+
+#### FR-013: Host-Enforced Entitlement Binding
+When a plugin contributes a capability that declares `requiresFeatures`, the **host wraps the contribution** so `FeatureGate.assertEntitled` runs in trusted core code at every invocation. A plugin **cannot** self-grant, bypass, or weaken its own gate, and cannot read entitlement state for other subjects. This is the security keystone: enforcement is structurally outside the (possibly third-party, possibly proprietary) add-on.
+
+#### FR-014: Open-Core / Proprietary Boundary, Guard, and Capability Floor
+The SDK and all registration contracts are **Apache-2.0** (anyone may build add-ons). Proprietary add-on implementations ship as **independent packages, loaded at runtime via the stable interface, and are never vendored into the open-core repo.** Loading separately-licensed code in-process via a published Apache-2.0 interface carries **no copyleft-contamination risk** — Apache-2.0 is permissive and has no viral term to trigger; reviewers should *not* spend worry on license contamination. The governance risk that is real, and that this FR defends, is **core hollowing over time**: the claim that "the open core stays fully functional and forkable" is meaningless if add-ons accrete the load-bearing capability until a fork with zero add-ons does nothing worth running. Therefore:
+- **Vendoring guard (mechanical):** a CI guard in the open repo fails the build if a configured proprietary package namespace or non-Apache license header appears in tree. (Catches accidental vendoring; cannot detect hollowing.)
+- **Capability floor (policy + release gate):** enumerate the capability set the open core must always deliver **with zero proprietary add-ons**, and make "a fork with no add-ons boots and delivers floor capability X" a release-gate check. Core APIs must not *require* a proprietary add-on to be useful. This is the structural defense of the freedom-first posture that a grep cannot provide.
+- The in-process plugin loader (FR-012) executes allowlisted third-party packages **with full core privileges** (DB, secrets). That supply-chain/threat surface is acknowledged here and routed to a threat model before Phase 2 (see §8, §10); "operator vets the package" is the entire current control.
+
+### Phase 1 — Hardening (added after proposal-critic review; numbered here to preserve existing FR references)
+
+#### FR-015: Operator Grant Administration *(Phase 1 — the write path that creates grants)*
+An authenticated, authorized surface for operators (and, later, billing automation) to **create, modify, and revoke** `feature_entitlements` rows. Without this, Phase 1 can *enforce* grants but cannot *create* them through any specified interface — and Scenario 1 has no implementation. Specify: the surface (operator REST endpoint and/or an admin-only MCP tool — **not** raw SQL as the contract), the authorization model (who may grant; an operator/admin role distinct from tenant users), the audit of every grant/revoke (write to `entitlement_decisions` or a grant-history log with actor identity), and idempotency. This is the boundary where billing integration later attaches via `source=resolver|import`. *(This is distinct from out-of-scope billing: it is the grant action, not payment collection.)*
+
+#### FR-016: Un-forgeable Gated-Path Enforcement *(Phase 1 — makes FR-005/FR-008 structural, not procedural)*
+For Phase 2 plugins, the host wraps contributions (FR-013) so enforcement is structural. **Phase 1 in-tree add-ons have no host** — FR-008 as stated relies on every call site remembering to call `assertEntitled`, which is *procedural* enforcement. The codebase already contains a counterexample that proves the risk: `content_search` **fabricates a `ResolvedEntitlements` object and passes it straight to the search service, bypassing the resolver/cache/`EntitlementService` entirely** (`tools/executors/content-executor.ts:223-231`). To prevent a licensed feature shipping ungated because one call site forgot the gate:
+- A gated capability MUST be reachable **only** via a `FeatureGate`-minted, non-constructible token/handle (e.g. an opaque `GateToken` that gated services require and that only `FeatureGate.assertEntitled` can mint). **Hand-constructed entitlement/grant objects are forbidden in the gated path** and should be made un-typeable there.
+- **Enumerate** every Phase-1 gated call site — derived from `executeTool` dispatch (`content_`, `profile_`, `pipeline_`, and the OAuth path; `tools/executor.ts:99-130`) plus the provider / step / connector invocation points (FR-008) — so a reviewer can verify coverage is complete. (Note: pipeline-step execution runs via Inngest functions, not `executeTool`; the gate belongs inside those functions before the step adapter runs.)
+- The existing `content_search` synthetic-entitlement path is a **known exception**: fix it to go through `EntitlementService`, or explicitly quarantine and document it, so the plan does not inherit it as a template.
+
+#### FR-017: Expiry-Aware Resolution and DB Fallback *(Phase 1 — fail closed on lapsed grants, not just on access)*
+The reused `ResolvedEntitlements` contract is a flat key set + one `ttlSeconds` (`content/types.ts:76-84`) — it carries **no per-grant validity**. So `valid_until` enforcement must live at resolve time, and the fallback path must be expiry-aware (the existing content DB-fallback selects the most-recent row **without** filtering `expiresAt`, `content/entitlements/index.ts`):
+- The `FeatureEntitlementResolver` filters `status='active' AND (valid_until IS NULL OR valid_until > now)` at resolve time; the cached set is the **post-filter** set, and the cache TTL is `min(resolverTtl, time-to-next-grant-expiry)` so a grant never outlives `valid_until` by more than one TTL.
+- The **DB fallback** (FR-005) MUST apply the same active+non-expired filter. Naively reusing the content fallback would **grant a lapsed licensed feature during a resolver outage** — failing *open on a lapsed grant*. Fail closed on both access and lapsed grants.
+
+#### FR-018: Cross-Instance Invalidation and Revocation Latency *(Phase 1)*
+The reused `EntitlementCache` is an in-process `Map` (`cache.ts`). In a multi-instance deployment (the platform targets multi-tenant cloud), invalidating one node's cache (FR-004) does nothing for the others — a revoked grant stays live on every other node until its TTL. Specify the multi-instance story explicitly: either (a) accept **TTL-only** propagation across instances as the baseline guarantee (so SC-1 "revocation denies within one TTL" is the real SLA and "explicit invalidation" is a single-node optimization), or (b) add a pub/sub invalidation bus for immediate cross-node revocation. State the **maximum acceptable revocation latency** (a relinquished/abusive subject retaining a licensed or security-sensitive feature for up to one TTL — default 1h — may or may not be acceptable) and let it constrain the default TTL.
+
+#### FR-019: Individual-First Effective Entitlement (union over the actor's subjects) *(Phase 1 core)*
+The **actor is always an individual user**; entitlement is evaluated for that user. A user's **effective entitlement for a feature is the union** of grants whose subject is `user:U` **or** `tenant:T` for any org `T` the user is a member of — all active and non-expired (FR-017). Concretely, the gate resolves the actor's subject set `{ user:U } ∪ { tenant:T | U ∈ members(T) }`, resolves/caches each subject (reusing FR-003/FR-004 per subject), and unions the results; `assertEntitled` allows if the feature is present in any. Consequences that make the design principle real:
+- **Pre-WP12**, the membership set is empty, so the set is just `{ user:U }` — the **individual path works day one** with no tenant system.
+- **Post-WP12**, an org grant (one row, `subject_type=tenant`) is **inherited by every member** with no per-user rows — this is the org-entitlement mechanism, and it *adds* capability to an individual rather than gating them.
+- **Invalidation** (FR-004/FR-018) must fire on the user's own grant changes **and** on changes to any of their orgs' grants or to membership itself; the simplest correct implementation invalidates per-subject and lets the gate re-union, accepting the FR-018 cross-instance TTL bound.
+- **Audit** (FR-006) records *which* subject (user vs which tenant) satisfied an allow, so inherited-vs-personal entitlement is traceable.
+- **Seat-cap boundary (open — see §11.8).** Pure membership-union implements an **org-wide site license** (every member inherits). It does **not** implement a **capped N-of-M seat license** (only N assigned members). If seat-capped licensing is required, the union must become "user grant ∪ tenant grant *where the user holds an assigned seat*," which needs a seat-assignment table (a WP12/billing concern). Phase 1 ships site-license inheritance; seat-capping is an explicit, deferred extension — do not assume the word "seats" means a cap until §11.8 is decided.
+
+---
+
+## 3. Non-Functional Requirements
+
+### Performance
+- `FeatureGate` check on cache hit: < 5ms p95 (in-process map, same class as the content cache).
+- Cold resolve (resolver or DB): < 500ms p95 (matches the existing resolver target SC-004; existing default timeout 2000ms, `http-resolver.ts`).
+- `tools/list` entitlement filtering adds < 10ms for a tenant with ≤ 50 catalog entries (single cached resolve + set filter).
+- Plugin loading happens at boot only; it must not add to per-request latency.
+
+### Security
+- Entitlement is an **authorization boundary**. Enforcement is always in trusted core — structurally, not by convention: Phase 2 via the host wrap (FR-013), Phase 1 via the un-forgeable gated path (FR-016). Never delegated to an add-on.
+- Default-deny everywhere: absence of a grant, an expired/suspended grant, or any resolver failure denies — and the gate fails closed on **lapsed grants** too (no lapsed grant served on fallback, FR-017), not just on access.
+- The gate takes an **explicit subject**; it must not infer the subject from ambient `tenantId == userId` collapse (`executor.ts:104`). Strength of the boundary is bounded by tenant-identity work (WP12) and isolation hardening (RLS) — stated as dependencies, not assumed away.
+- Decision audit is append-only and tenant-scoped (FR-006).
+- A proprietary add-on runs in-process with core privileges; this spec does **not** sandbox add-on code. Trust in third-party code is an operator decision until a sandboxing model exists (out of scope; noted as residual risk).
+
+### Availability
+- Resolver/grant-source outage degrades to DB fallback, then default deny — never to "grant everything." Free/core capabilities remain fully available regardless of entitlement-system health.
+- One failing plugin cannot crash boot or disable other plugins or core (FR-012).
+- Entitlement changes propagate within one cache TTL even if explicit invalidation is missed.
+
+### Cost
+- No external resolver call on the hot path when cached. DB fallback is a single indexed query (partial index on active grants, see `data-model.md`).
+- Decision-log volume is bounded by gated-call frequency; reuse the existing audit retention/partitioning approach.
+
+---
+
+## 4. User Scenarios
+
+1. **Operator enables a licensed add-on.** An operator grants `com.joyus.addon.advanced-pipelines` to subject A through the authorized operator grant surface (FR-015; `source=admin`) — not raw SQL. The subject cache is invalidated; on subject A's next `tools/list`, the add-on's tools appear. Subject B sees nothing change. *(In Phase 1 the subject is an individual user, `subject_type=user`; the same flow gates an org once WP12 makes `subject_type=tenant` meaningful — see §1.)*
+
+2. **Unentitled subject hits a gated tool.** A subject without the grant invokes a gated add-on tool. `executeTool` calls `FeatureGate.assertEntitled`, which denies (`reason=not_entitled`), logs a decision row, and returns a structured **"upgrade required"** error naming the feature — no execution, no silent empty result.
+
+3. **Entitlement lapses.** A subject's grant `valid_until` passes. Within one TTL the resolve no longer includes the feature; the tool disappears from `tools/list` and any in-flight call is denied with `reason=expired`. The grant row flips to `status=expired`; history is in the decision log.
+
+4. **Proprietary add-on as a separate package (Phase 2).** An operator adds `@acme/joyus-addon-x` to the plugin allowlist. At boot the loader validates its manifest and `coreApiRange`, calls `register(host)`; the host registers its tool and **wraps it with the entitlement gate** declared in `requiresFeatures`. The open-core repo never contains Acme's code.
+
+5. **Bad plugin fails safely (Phase 2).** `@acme/joyus-addon-y` throws during `register`. The loader catches it, marks it `health=failed` in `installed_plugins` with `last_error`, and continues. Core and all other plugins start normally.
+
+6. **Individual first, org-level entitlement later (FR-019).** A user gets value as an **individual** (Phase 1, pre-WP12; their effective set is `{user:U}`) and may hold a personal grant for an add-on. Later their organization (Phase 1.5, post-WP12) holds that same add-on grant **once** at the tenant level; now every member — including U — **inherits** it via the effective-entitlement union, with no per-user grants written. U's experience never waited on the org; the org *added* capability to U. The audit (FR-006) shows whether an allow came from U's personal grant or the inherited tenant grant.
+
+---
+
+## 5. Key Entities
+
+| Entity | Description |
+|--------|-------------|
+| FeatureCatalogEntry | A licensable feature/add-on identified by a stable `feature_key` |
+| FeatureEntitlement | A durable grant: a subject holds a feature for a validity window |
+| Subject | `{subject_type ∈ {tenant,user}, subject_id}` — what a grant attaches to (subject-agnostic). The **actor** is always an individual user; `tenant` is a grouping whose grants are inherited |
+| EffectiveEntitlement | A user's resolved capability set: the **union** over `{user:U} ∪ {tenant:T \| U ∈ members(T)}` (FR-019). The thing the gate actually checks |
+| FeatureEntitlementResolver | Resolves a subject's licensed feature keys; reuses the existing resolver contract |
+| FeatureGate | The single enforcement service: `isEntitled` / `assertEntitled` over a user's effective entitlement (explicit deny) |
+| EntitlementDecision | Append-only audit record of an allow/deny decision |
+| JoyusPlugin | An add-on package: a `register(host)` entry point + manifest (Phase 2) |
+| PluginManifest | Declares id, version, publisher, `provides`, `requiresFeatures`, `coreApiRange` |
+| PluginHost | The scoped registration surface plugins attach to; binds the gate to contributions |
+| Contribution | A single registered capability (tool, provider, connector, step, hook) |
+| InstalledPlugin | Operator-facing load/health record for a configured plugin package |
+
+---
+
+## 6. Success Criteria
+
+1. **Durable licensing works** — a grant created by admin survives session end and server restart; revocation denies within one TTL.
+2. **Individual-first + org inheritance (FR-019)** — (a) pre-WP12, an individual with a `user` grant and no org is entitled (the path works with zero tenant system); (b) post-WP12, a single `tenant` grant entitles **every member** with no per-user rows, and removing a user from the org revokes their inherited access on the next resolve.
+3. **Explicit deny** — an unentitled gated call returns a structured upgrade error (not an empty result), and the decision is logged.
+4. **Reuse is real** — the generic resolver/cache are shared between content and feature entitlements (one implementation, two consumers); the content path's existing tests still pass.
+5. **Tool gating** — `tools/list` shows add-on tools only to entitled subjects; `tools/call` on an unentitled add-on tool is denied. Core tools are unaffected for everyone.
+6. **Trusted enforcement (structural)** — an add-on cannot grant itself access. (Phase 2) a test proves a host-wrapped contribution invoked without entitlement is blocked by the host. (Phase 1, FR-016) a test proves a gated capability **invoked via a second path** — not just `tools/call`, but e.g. a pipeline step or provider call — is still denied, and that a hand-constructed entitlement object cannot reach the gated path.
+7. **Fail closed on lapsed grants** — during a simulated resolver outage, a subject whose grant has **expired** is denied (the DB fallback does not serve a lapsed grant); a subject with a valid grant is still served. (FR-017)
+8. **Grant path exists** — an operator can create and revoke a grant through the specified authorized surface (FR-015), not raw SQL, and the action is audited with actor identity.
+9. **(Phase 2) Out-of-tree add-on** — a sample add-on shipped as a separate package depending only on `@joyus-ai/plugin-sdk` registers a gated tool that works when entitled and is denied otherwise, with no change to the open-core repo.
+10. **(Phase 2) Failure isolation** — a deliberately-broken plugin is quarantined (`health=failed`) without affecting boot, core, or other plugins.
+11. **License boundary + capability floor hold** — the CI guard fails when proprietary/non-Apache code is introduced into the open repo; and a fork with **zero proprietary add-ons** boots and delivers the enumerated floor capability set (FR-014).
+12. **Auditability** — every allow/deny is queryable per subject and per feature for a defined retention window.
+
+---
+
+## 7. Assumptions
+
+- The generic `EntitlementResolver` / `HttpEntitlementResolver` / `EntitlementCache` are reusable for feature entitlements (verified in the codebase: content-coupling is isolated to two private `EntitlementService` methods).
+- Something upstream produces grants — an operator admin action and/or a billing system. This spec **consumes** grants; it does not collect payment or model subscriptions.
+- For the MCP path, `tenantId == userId` is acceptable interim subject identity (each user is their own tenant) **provided** the gate API takes an explicit subject and does not bake in the collapse.
+- Add-on code is trusted-by-operator (no sandbox). Operators vet third-party packages before allowlisting them.
+- PostgreSQL + Drizzle migration mechanics support an additive `entitlements` schema (verified in the codebase).
+- A single, versioned **core API** can be defined for the SDK surface (Phase 2). The interfaces to extract already emit `.d.ts`.
+
+---
+
+## 8. Dependencies
+
+- **Existing entitlement module** (`src/content/entitlements/`) — its *resolution machinery* (the `EntitlementResolver` interface, `HttpEntitlementResolver`, and `EntitlementCache` class) is reused via a shared `core/` extraction. **Be precise about scope:** this spec reuses the machinery but **builds a new feature-entitlement *system* on top of it** — a new `entitlements` schema and tables, a net-new `FeatureGate` service (no `assertEntitled`/gating precedent exists in the codebase), and inverted semantics on every behavioral axis (explicit vs silent deny; subject- vs session-keyed cache; invalidate-on-grant-change vs on-session-close). "Extend" describes the plumbing, not the system; the plan must size the Phase 1 build from the new-build surface (`data-model.md` + FR-001..018), not as a thin extension.
+- **WP12 / tenant identity** — *prerequisite for ORG-level entitlement (Phase 1.5), NOT for the individual path (Phase 1).* The individual experience and individual add-on grants ship without it (FR-019 unions over `{user:U}` alone pre-WP12). But org-level entitlement cannot be exercised until a real `tenants` table + tenant↔user membership + tenant resolution replace `tenantId == userId` (verified in the codebase); then one tenant grant is inherited by every member (FR-019). **Status:** this prerequisite is already specced as **Spec 013 — Tenant Identity Resolution** (spec-only), including the tenants/membership schema; sequence its implementation after Phase 1 ships individuals and before org-level entitlement, alongside isolation hardening (overlaps Spec 008).
+- **Isolation hardening (RLS)** — *coupled to org-level entitlement, not to individuals.* Phase 1.5 puts multiple users in one tenant, so a cross-tenant leak exposes one tenant's data/features to another; the gate is only as trustworthy as the tenant boundary beneath it. Sequence isolation hardening alongside WP12 **before exposing org tenants**. The Phase 1 individual path (each user its own subject) is not gated on RLS for first-party use; any *public/untrusted* exposure still is.
+- **Cost/usage capture** — *soft.* Usage-based entitlement limits need token/cost capture (`AnthropicGenerationProvider` returns no usage today, verified in the codebase). `limits` is a forward hook; metering is out of scope.
+- **Governance + license posture** — FR-014 operationalizes the Apache-core posture; governance docs should land consistently with it.
+- **Spec 014 (safety guardrails)** and **Spec 009 (pipelines)** — provide two of the seams (hooks; step registry) the host unifies in Phase 2.
+- **Threat model (before Phase 2)** — the in-process plugin loader (FR-012) runs allowlisted third-party code with full core privileges. Route the loader/supply-chain surface to a threat-modeling pass, and (for any third-party add-ons) the maintainer/bus-factor question to an ownership/bus-factor analysis, before Phase 2 plans land.
+- **Billing unit + marketplace** — *downstream.* Decided after Phase 1 lands; the `subject_type` and stable plugin/feature identity are the forward-compatible hooks.
+
+---
+
+## 9. Edge Cases
+
+- **Resolver down, no DB grant** → default deny (`reason=resolver_unavailable_fallback_deny`). Fail-closed, explicit (contrast content path's fail-closed-*silent*).
+- **Entitlement without capability** — a subject is granted a feature whose plugin/tool isn't installed → harmless no-op; nothing to show or gate.
+- **Capability without entitlement** — an add-on tool is installed but the subject has no grant → hidden in `tools/list`, denied on call (default deny).
+- **`tenantId == userId` collapse** — gate must still receive an explicit subject; never infer. A test pins this.
+- **Two plugins, same tool name** — registration conflict resolved by namespacing on plugin/owner id; a hard duplicate is rejected at load and the second plugin marked unhealthy.
+- **Plugin `coreApiRange` incompatible** — not loaded; `health=incompatible`; logged; boot continues.
+- **Plugin declares unknown `feature_key`** — registration of its gated contributions rejected; loader records the error (a gated capability with no catalog entry must never be silently ungated).
+- **Grant flips mid-session** (revoke during an active session) — next gated call re-resolves (cache invalidated on change) and denies; in-flight already-authorized operations are not retroactively killed (document the boundary).
+- **`limits` set but metering absent (pre-cost-capture)** → treat as boolean entitlement; do not fabricate usage. Limit enforcement is inert until cost capture lands.
+- **Clock/TTL skew** — `valid_until` is authoritative on resolve (FR-017): the resolver filters expired grants and the cache TTL is capped at time-to-next-expiry, so cache TTL only bounds staleness and never extends a grant past `valid_until`.
+- **Resolver outage with an expired grant on file** — DB fallback must NOT serve it; the fallback filters active+non-expired (FR-017). Naive reuse of the content fallback (most-recent row, no expiry filter) would fail *open on a lapsed grant*.
+- **Feature key reuse** — `feature_catalog.feature_key` is the primary key and `withdrawn` rows are retained, so a withdrawn key cannot be re-inserted (PK collision); "never reused" is enforced by the PK, not by policy alone.
+
+---
+
+## 10. Out of Scope
+
+- **Billing / payment collection / subscription modeling** — this spec consumes grants; it does not price, charge, invoice, or model plans. The resolver/`source` field is the integration point.
+- **Marketplace** — discovery, third-party publishing, vetting, ratings, revenue share, per-tenant self-serve install (downstream).
+- **Tenant identity system (WP12)** — depended upon, not built here.
+- **RLS / isolation hardening** — separate workstream; a dependency for *public/untrusted* exposure, not for first-party Phase 1.
+- **Token/cost usage capture** — required for usage-based limits; only a forward hook here.
+- **Add-on code sandboxing** — add-ons run in-process with core trust; isolating untrusted add-on execution is a future hardening effort.
+- **The proprietary add-ons themselves** — this spec is the *framework and the boundary*, not any specific licensed feature.
+- **UI/admin console** for entitlement management — API/MCP and operator-level config only; an admin UI is a later feature.
+
+---
+
+## 11. Open Decisions for Planning (carry into plan.md / tasks)
+
+1. **Individual-first, org-layered (settled 2026-06-14).** The architecture serves individuals first (Phase 1, no tenant identity) and layers org-level entitlement on top via membership inheritance (FR-019, Phase 1.5, requires tenant identity). The tenant-identity prerequisite is on the critical path for org-level entitlement and is **already specced as Spec 013 (Tenant Identity Resolution, spec-only)** — sequence its implementation *after* Phase 1 ships individuals and *before* org-level entitlement. *Remaining sub-decision: implement Spec 013 standalone, or alongside the isolation-hardening / Spec 008 work?*
+2. **DB-leads vs resolver-leads** for the source of truth (does admin/billing write `feature_entitlements` and the resolver read it, or is an external billing API authoritative with DB as cache?). Spec assumes DB-leads with optional external resolver; confirm with the grant-source owner. (If resolver-leads is ever chosen, the expiry-fallback and per-key-validity gaps — FR-017 — get harder; decide before the schema lands.)
+3. **Thinner vs fuller Phase 1.** The fuller design (dedicated `feature_catalog` + `feature_entitlements` + `entitlement_decisions` + resolver-fronting) is the right *destination* — needed for billing integration and compliance. A thinner first cut (single grants table + `FeatureGate` + reuse `content.operation_logs` for audit) could ship the individual path faster. The plan should explicitly adopt or reject the thinner path rather than defaulting to the full schema.
+4. **Subject model** — settled by FR-019: the **actor is always the individual user**, and `tenant` grants are *inherited via membership union*, not an alternative subject the user picks. Not "either/or." Phase 1 issues `user` grants; Phase 1.5 adds `tenant` grants that flow to members. Remaining sub-decision: do we ever allow a feature to be *user-only* (non-inheritable, e.g. a personal-seat add-on) — i.e. a per-grant "inheritable" flag — or is every tenant grant always inherited?
+5. **Revocation latency SLA** — max acceptable time a revoked/expired grant stays live (bounds the default cache TTL and decides whether the cross-instance pub/sub bus of FR-018 is needed now or deferred to TTL-only).
+6. **Phase 1 in-tree ownership map vs minimal registry** — Phase 1 can gate in-tree add-on tools with a static ownership map; decide whether to ship the mutable tool registry early (smooths Phase 2) or defer it. (Note: the static map is a manual-sync risk — a new add-on tool added without an ownership entry ships ungated; consider a registration-time assertion.)
+7. **Core API versioning policy** — semver discipline and deprecation window for the SDK surface (Phase 2).
+8. **Inheritance granularity — site license vs capped seats (architecture).** Does an org add-on grant mean **every member inherits** (org-wide site license — what FR-019's union ships) or **N assigned seats of M members** (capped)? Capped seats need a seat-assignment table and change FR-019's union to "tenant grant *where the user holds a seat*." A productization choice with a direct schema consequence — resolve before Phase 1.5. Phase 1 (individuals) is unaffected.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks.md
@@ -1,0 +1,176 @@
+# Work Packages: Add-on Feature Entitlements — Phase 1 (Individual Path)
+*Feature 015 — Phase 1 task decomposition*
+
+**Scope**: Phase 1 only (individual subject; ships without WP12). Phase 1.5 (org inheritance) and Phase 2 (plugin host + SDK) are separate plans.
+**Total**: 6 work packages, 40 subtasks
+**Parallelization**: 5 layers — up to 2 WPs (WP03, WP04) run concurrently at peak
+**Per-WP prompt files** (`tasks/WP0N-*.md`): not yet generated — say the word and I'll expand each WP into an implement-ready prompt.
+
+## Dependency Graph
+
+```
+Layer 0: WP01 (core extraction + schema)
+Layer 1: WP02 (FeatureGate decision core)            depends WP01
+Layer 2: WP03 (un-forgeable enforcement) ┐ parallel  depends WP02
+         WP04 (operator grant write path)┘ parallel  depends WP01, WP02
+Layer 3: WP05 (tool-seam gating)                     depends WP02, WP03
+Layer 4: WP06 (integration & validation)             depends all
+```
+
+---
+
+## Subtask Index
+
+| ID | Description | WP | Parallel |
+|----|-------------|-----|----------|
+| T001 | Extract `EntitlementResolver` iface + `HttpEntitlementResolver` + `EntitlementCache` to `src/entitlements/core/`; add re-exports in `src/content/entitlements/` | WP01 | |
+| T002 | Add `responseMapping.featuresField` to `HttpEntitlementResolver` | WP01 | [P] |
+| T003 | Create `entitlements` Drizzle schema — `feature_catalog`, `feature_entitlements`, `entitlement_decisions` (indexes, unique, partial-active) | WP01 | |
+| T004 | Create `types.ts` — `Subject`, `FeatureKey`, `EffectiveEntitlement`, opaque `GateToken`, `GrantSource`, `GrantStatus` | WP01 | [P] |
+| T005 | Create Zod validation (`validation.ts`) — grant create/modify/revoke, catalog entry | WP01 | [P] |
+| T006 | Register schema in `drizzle.config.ts`; generate migration (`drizzle/00NN_entitlements_schema.sql`) | WP01 | |
+| T007 | Verify typecheck + **existing content entitlement tests pass** (extraction regression gate) | WP01 | |
+| T008 | `FeatureEntitlementResolver` — DB-leads, expiry-aware filter `active AND (valid_until IS NULL OR > now)` (FR-017) | WP02 | |
+| T009 | `MembershipResolver` interface + `NullMembershipResolver` returning `[]` (pre-WP12 seam, FR-019) | WP02 | [P] |
+| T010 | Subject-scoped cache wiring (key `subject_type:subject_id`; TTL capped to next expiry; explicit invalidate) — reuse `EntitlementCache` (FR-004/017/018) | WP02 | |
+| T011 | `entitlement_decisions` append-only audit writer — `logAllow`/`logDeny` only (FR-006) | WP02 | [P] |
+| T012 | `FeatureGate` — `isEntitled`/`assertEntitled`; effective **union** over `{user:U} ∪ membership`; order cache→resolver→DB-fallback→deny; expiry-aware fallback (FR-005/016/017/019) | WP02 | |
+| T013 | `FeatureNotEntitledError` + structured "upgrade required" payload (402/403 + MCP error mapping) | WP02 | [P] |
+| T014 | Unit tests — resolver expiry/fail-closed, union `{user}` pre-WP12, cache TTL/invalidate, audit, gate order | WP02 | |
+| T015 | Define opaque `GateToken` — non-constructible outside `FeatureGate`, minted only by `assertEntitled` (FR-016) | WP03 | |
+| T016 | Make gated entrypoints **require** a `GateToken`; forbid raw entitlement objects in the gated path (type-level) | WP03 | |
+| T017 | **Enumerate** Phase-1 gated call sites — `content_`/`profile_`/`pipeline_` dispatch (`executor.ts:99-130`) + provider/step/connector invocation points; document the list | WP03 | [P] |
+| T018 | Fix **or** quarantine the `content_search` synthetic-entitlement bypass (`content-executor.ts:223-231`) so it isn't a template | WP03 | [P] |
+| T019 | Unit tests — hand-constructed entitlement object cannot reach a gated path; second-path gating | WP03 | |
+| T020 | `GrantsService` — create/modify/revoke `feature_entitlements` (idempotent); write grant-history with **actor identity** (FR-015) | WP04 | |
+| T021 | Catalog service — create/list `feature_catalog` entries (FR-001) | WP04 | [P] |
+| T022 | Operator REST routes (admin-only) for grants + catalog | WP04 | |
+| T023 | Admin-only MCP tools for grants + catalog (FR-015 surface) | WP04 | [P] |
+| T024 | Authorization — operator/admin role **distinct from tenant users**; enforce on routes + tools | WP04 | |
+| T025 | Cache invalidation on grant/revoke (hook into subject-cache) | WP04 | |
+| T026 | Unit tests — authz, idempotency, audited writes, invalidation-on-change | WP04 | |
+| T027 | `ownership.ts` — static add-on-tool → `feature_key` map (Phase 1; registry replaces it in Phase 2) | WP05 | [P] |
+| T028 | `getAllTools()` — omit add-on-owned tools the subject's effective set lacks (FR-007); core/free tools untouched | WP05 | |
+| T029 | `executeTool()` — `assertEntitled` (GateToken) before add-on tool dispatch; explicit upgrade error on deny (FR-007) | WP05 | |
+| T030 | Provider/step/connector gating at the enumerated call sites — declare required `feature_key`, assert before invoke (FR-008) | WP05 | [P] |
+| T031 | Module init (`entitlements/index.ts`) + mount admin routes / register admin tools in `src/index.ts` | WP05 | |
+| T032 | Unit tests — core tools unaffected for everyone; add-on tools gated on both list + call | WP05 | |
+| T033 | Integration — individual licensing: grant → `tools/list` shows → call works; revoke → denies within TTL (SC-1, SC-2a) | WP06 | [P] |
+| T034 | Integration — explicit deny: unentitled gated call → upgrade-required (not empty), logged (SC-3) | WP06 | [P] |
+| T035 | Integration — fail-closed on lapsed grants: resolver outage + expired grant → deny; valid grant still served (SC-6) | WP06 | [P] |
+| T036 | Integration — structural enforcement: gated capability via a non-`tools/call` path denied; un-forgeable object (SC-5) | WP06 | [P] |
+| T037 | Integration — union: returns `{user}` pre-WP12; membership-stub adds a tenant grant (SC-2 seam) | WP06 | [P] |
+| T038 | Content path regression: existing entitlement + search tests green (SC reuse) | WP06 | [P] |
+| T039 | Auditability — every allow/deny queryable per subject + per feature (SC-11) | WP06 | [P] |
+| T040 | Validation sweep — `npm run validate` (typecheck + lint + test), zero regressions | WP06 | |
+
+---
+
+## Phase A: Foundation
+
+### WP01 — Core Extraction & Entitlements Schema
+**Priority**: P0 (blocks everything) | **Dependencies**: none | **Est. ~450 lines**
+
+Extract the generic resolution machinery into `src/entitlements/core/` with re-exports preserved in `src/content/entitlements/`, then create the new `entitlements` schema, types, and validation. The extraction must leave the content path bit-for-bit behavioral.
+
+**Subtasks**: T001–T007 (see index).
+
+**Parallel opportunities**: T002, T004, T005 are independent of the extraction mechanics once T001 lands.
+**Risks**: The extraction is the one place this plan touches existing code. Re-exports must keep `src/content/entitlements/` import paths valid; **T007 is a hard gate** — existing entitlement/search tests must stay green before anything else proceeds. Drizzle `pgSchema('entitlements')` needs `CREATE SCHEMA IF NOT EXISTS` in the migration (per the `content`/`profiles` precedent).
+
+---
+
+### WP02 — FeatureGate Decision Core
+**Priority**: P0 (security core) | **Dependencies**: WP01 | **Est. ~550 lines**
+
+The resolver, subject-scoped cache, decision audit, and the `FeatureGate` itself — including the effective-entitlement union (FR-019) with a `NullMembershipResolver` so Phase 1.5 activates org inheritance by swapping one class.
+
+**Subtasks**: T008–T014.
+
+**Parallel opportunities**: T009 (membership stub), T011 (audit), T013 (error type) are independent of the resolver/gate core.
+**Risks**: Must mirror the existing **fail-closed** philosophy but with **explicit** deny — and the DB fallback must be **expiry-aware** (the content fallback is not; copying it ships a lapsed licensed feature on outage — FR-017). The union must take an **explicit subject** and never infer from `tenantId == userId`.
+
+---
+
+## Phase B: Enforcement & Write Path
+
+### WP03 — Un-forgeable Gated-Path Enforcement
+**Priority**: P0 (the security keystone) | **Dependencies**: WP02 | **Est. ~350 lines**
+
+Make Phase 1 enforcement structural, not procedural: a `GateToken` only `FeatureGate` can mint, required by every gated entrypoint, with the call-site set enumerated and the existing synthetic-entitlement bypass closed.
+
+**Subtasks**: T015–T019.
+
+**Parallel opportunities**: T017 (enumerate) and T018 (quarantine the bypass) can run in parallel with the token typing (T015–T016).
+**Risks**: This is the response to the live counterexample (`content-executor.ts:223`). The "forbid raw objects in the gated path" must be enforced at the **type** level, not by convention, or the FR-016 guarantee is theater. Closing `content_search`'s bypass must not regress content search — pair with WP06 T038.
+
+---
+
+### WP04 — Operator Grant Administration (write path)
+**Priority**: P1 (creates grants — Scenario 1) | **Dependencies**: WP01, WP02 | **Est. ~450 lines**
+
+The authorized surface to create/modify/revoke grants and manage the catalog — the thing that turns "enforceable" into "licensable."
+
+**Subtasks**: T020–T026.
+
+**Parallel opportunities**: Runs in parallel with WP03. T021 (catalog) and T023 (admin tools) are independent tracks.
+**Risks**: Authorization is the crux — the grant role must be **distinct from tenant users** (a tenant user must never grant themselves). Every write audited with actor identity. Revoke must invalidate the subject cache (T025) or revocation appears not to take effect until TTL.
+
+---
+
+## Phase C: Seam Wiring & Validation
+
+### WP05 — Tool-Seam Gating
+**Priority**: P1 | **Dependencies**: WP02, WP03 | **Est. ~400 lines**
+
+Wire entitlement gating into the tools seam (visibility + execution) and the provider/step/connector call sites, with the structured upgrade response. Phase 1 uses a static ownership map; Phase 2 replaces it with the registry.
+
+**Subtasks**: T027–T032.
+
+**Parallel opportunities**: T027 (ownership map) and T030 (provider/step/connector) are independent of the tool-list/exec changes.
+**Risks**: Must touch **only add-on-owned** tools — core/free tools stay unaffected for everyone (a regression here breaks the free product). `getAllTools` already filters by connected service; layer the entitlement filter without disturbing that. All gated invocations go through a `GateToken` (WP03), not a raw check.
+
+---
+
+### WP06 — Integration & Validation
+**Priority**: P1 | **Dependencies**: WP01–WP05 | **Est. ~500 lines**
+
+End-to-end proof of the Phase 1 success criteria, the content-path regression gate, and the full validation sweep.
+
+**Subtasks**: T033–T040.
+
+**Parallel opportunities**: T033–T039 are independent test suites.
+**Risks**: Integration tests need clock manipulation (expiry/TTL), a fake resolver (outage simulation), and an operator-role fixture. The union test (T037) must prove both the pre-WP12 `{user}` behavior **and** that a stubbed membership adds a tenant grant — that's the seam Phase 1.5 depends on. T038 is the non-negotiable regression gate.
+
+---
+
+## Dependency Graph
+
+```
+WP01 (Core Extraction & Schema)
+  └──▶ WP02 (FeatureGate Decision Core)
+         ├──▶ WP03 (Un-forgeable Enforcement) ──┐
+         └──▶ WP04 (Operator Grant Write Path) ─┤   (WP03 ∥ WP04)
+                                                 ▼
+                                        WP05 (Tool-Seam Gating)
+                                                 │
+                                                 ▼
+                                        WP06 (Integration & Validation)
+```
+
+**Parallelization**: After WP02, WP03 and WP04 run in parallel. WP05 needs WP02+WP03. WP06 needs everything.
+
+## Summary
+
+| WP | Title | Subtasks | Est. Lines | Priority |
+|----|-------|----------|-----------|----------|
+| WP01 | Core Extraction & Entitlements Schema | 7 (T001–T007) | ~450 | P0 |
+| WP02 | FeatureGate Decision Core | 7 (T008–T014) | ~550 | P0 |
+| WP03 | Un-forgeable Gated-Path Enforcement | 5 (T015–T019) | ~350 | P0 |
+| WP04 | Operator Grant Administration | 7 (T020–T026) | ~450 | P1 |
+| WP05 | Tool-Seam Gating | 6 (T027–T032) | ~400 | P1 |
+| WP06 | Integration & Validation | 8 (T033–T040) | ~500 | P1 |
+
+**Total**: 6 work packages, 40 subtasks
+**MVP scope (the individual path)**: WP01 + WP02 + WP03 + WP04 + WP05 — schema + gate + un-forgeable enforcement + operator grant + tool gating = an operator can license an add-on to an individual and the gate shows/runs it for them, denies everyone else. WP06 hardens and proves it.
+**Deferred by design**: org inheritance activation (Phase 1.5 / WP12), plugin host + SDK (Phase 2), seat-capping (§11.8), cross-instance invalidation bus (§11.5).

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP01-core-extraction-schema.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP01-core-extraction-schema.md
@@ -1,0 +1,603 @@
+---
+work_package_id: "WP01"
+title: "Core Extraction & Entitlements Schema"
+lane: "planned"
+dependencies: []
+subtasks: ["T001", "T002", "T003", "T004", "T005", "T006", "T007"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP01: Core Extraction & Entitlements Schema
+
+**Implementation command**: `spec-kitty implement WP01`
+**Target repo**: `joyus-ai` (path: `joyus-ai-mcp-server/`)
+**Dependencies**: None
+**Priority**: P0 (Foundation — every other WP in Spec 015 depends on this)
+
+## Objective
+
+Extract the generic entitlement resolution machinery (`EntitlementResolver`, `HttpEntitlementResolver`, `EntitlementCache`) from `src/content/entitlements/` into a shared `src/entitlements/core/` location so both the existing content module and the new feature-entitlement system can consume it without duplication. Simultaneously introduce the `entitlements` PostgreSQL schema (`feature_catalog`, `feature_entitlements`, `entitlement_decisions`) along with the shared TypeScript types and Zod validation the rest of Phase 1 builds on. The extraction is a **mechanical refactor only** — re-exports in `src/content/entitlements/` must keep all existing import paths valid, and T007 is a hard gate: existing content entitlement tests must stay green before anything else in Spec 015 proceeds.
+
+## Context
+
+### Patterns to follow
+
+The codebase uses a consistent Drizzle + PostgreSQL schema convention established in `src/content/schema.ts` and `src/profiles/schema.ts`. Follow it exactly:
+
+- **Schema namespace**: `pgSchema('entitlements')` — analogous to `pgSchema('content')` (`src/content/schema.ts:32`) and `pgSchema('profiles')` (`src/profiles/schema.ts`).
+- **Primary keys**: `text('id').primaryKey().$defaultFn(() => createId())` from `@paralleldrive/cuid2` — NOT uuid. See `contentProducts` (`src/content/schema.ts:134`) and every other table in the repo.
+- **Tenant IDs**: `text('tenant_id').notNull()` — plain text, no FK to a tenants table (none exists yet; WP12 is a future dependency). `subject_id` follows the same pattern for the same reason.
+- **Type exports**: `export type FeatureCatalogEntry = typeof featureCatalog.$inferSelect` and `export type NewFeatureCatalogEntry = typeof featureCatalog.$inferInsert` — NOT `InferSelectModel`. See `src/content/schema.ts:374-408`.
+- **Index names**: prefixed with the table name, e.g. `entitlements_feature_entitlements_subject_idx`. Follow the `content_products_tenant_id_idx` naming pattern.
+- **drizzle.config.ts**: the `schema` array currently has 6 entries (`src/content/schema.ts:4-11`); add `'./src/entitlements/schema.ts'` as a seventh.
+- **Migration naming**: migrations use sequential 4-digit prefixes (`0000_`, `0001_`, ..., `0007_` is the current highest). The next migration is `0008_entitlements_schema.sql`. `CREATE SCHEMA IF NOT EXISTS "entitlements"` must appear at the top — the `content`/`pipelines` migration (`0001_fine_young_avengers.sql:1,3`) uses `IF NOT EXISTS`; use that form (some later migrations omit it — prefer the safe form).
+
+### The extraction target
+
+Three items currently live in `src/content/entitlements/` and are only loosely coupled to content:
+
+1. **`interface.ts`** — exports `EntitlementResolver` (interface, lines 47–53), `ResolverContext`, `EntitlementResolverConfig`. The `resolve()` signature takes `(userId: string, tenantId: string, context: ResolverContext): Promise<ResolvedEntitlements>` — note it is typed against `ResolvedEntitlements` from `../types.js`, which is a content-specific type. The new `src/entitlements/core/interface.ts` must either keep this import or introduce a generic resolver result type; see T001 for the decision.
+2. **`cache.ts`** — exports `EntitlementCache`, a keyed in-process TTL `Map`. The key is currently `sessionId: string` (content-specific). For feature entitlements, the key will be `subject_type:subject_id`. The class is generic enough to move as-is; the new consumer uses a different key string.
+3. **`http-resolver.ts`** — exports `HttpEntitlementResolver` and `HttpResolverConfig`. The `responseMapping` currently has `productsField` and optional `ttlField`. T002 adds `featuresField` to this config so the same class can drive feature-key resolution from an external billing endpoint.
+
+### Load-bearing constraint
+
+The extraction must leave the content path **behaviorally identical**. `src/content/entitlements/index.ts` currently re-exports `EntitlementCache`, `HttpEntitlementResolver`, `HttpResolverConfig`, `EntitlementResolver`, and `ResolverContext` (lines 224–228). After the move, those re-exports must point to the new `core/` location, and every file that currently imports from `src/content/entitlements/` must continue to compile and behave without change. **T007 is a hard gate**: do not proceed to WP02 until the existing content entitlement test suite is green.
+
+---
+
+## Subtasks
+
+### T001: Extract `EntitlementResolver` interface + `HttpEntitlementResolver` + `EntitlementCache` to `src/entitlements/core/`
+
+**Purpose**: Move the three generic resolution primitives to a location neither module owns, then add re-exports in `src/content/entitlements/` so existing import paths continue to resolve.
+
+**Steps**:
+
+1. Create directory `src/entitlements/core/`.
+2. Create `src/entitlements/core/interface.ts`. Copy `EntitlementResolverConfig`, `ResolverContext`, and `EntitlementResolver` from the existing `src/content/entitlements/interface.ts`. The `resolve()` return type is currently `Promise<ResolvedEntitlements>` — that couples the shared interface to the content-specific `ResolvedEntitlements` shape. For Phase 1, keep this coupling (the feature resolver will return a compatible shape with `featureKeys` mapped into `productIds` to reuse the cache); add a `// TODO(spec-015-WP02): generalize resolver result type` comment so WP02 knows to revisit. Remove the `// Re-export for convenience` block at line 11 — that lived here because the content module owned it; the new location is the source.
+3. Create `src/entitlements/core/cache.ts`. Copy `EntitlementCache` verbatim from `src/content/entitlements/cache.ts`. No changes to logic — the cache is key-agnostic (it stores against any string key). Add a JSDoc comment: `* Key is caller-defined: sessionId for content, 'subject_type:subject_id' for feature entitlements.`
+4. Create `src/entitlements/core/http-resolver.ts`. Copy `HttpEntitlementResolver` and `HttpResolverConfig` from `src/content/entitlements/http-resolver.ts`. Do **not** add `featuresField` here — that is T002.
+5. Create `src/entitlements/core/index.ts` barrel:
+
+```typescript
+// src/entitlements/core/index.ts
+export type { EntitlementResolver, EntitlementResolverConfig, ResolverContext } from './interface.js';
+export { EntitlementCache } from './cache.js';
+export { HttpEntitlementResolver } from './http-resolver.js';
+export type { HttpResolverConfig } from './http-resolver.js';
+```
+
+6. Update `src/content/entitlements/interface.ts` to re-export from core instead of defining:
+
+```typescript
+// src/content/entitlements/interface.ts
+// Re-exported from shared core; content module re-exports for backward compatibility.
+export type { EntitlementResolver, EntitlementResolverConfig, ResolverContext } from '../../entitlements/core/interface.js';
+```
+
+7. Update `src/content/entitlements/cache.ts` to re-export:
+
+```typescript
+// src/content/entitlements/cache.ts
+export { EntitlementCache } from '../../entitlements/core/cache.js';
+```
+
+8. Update `src/content/entitlements/http-resolver.ts` to re-export:
+
+```typescript
+// src/content/entitlements/http-resolver.ts
+export { HttpEntitlementResolver } from '../../entitlements/core/http-resolver.js';
+export type { HttpResolverConfig } from '../../entitlements/core/http-resolver.js';
+```
+
+9. `src/content/entitlements/index.ts` already re-exports these (lines 224–228). Verify those re-exports still resolve through the shim files. No change needed if the shims export correctly.
+
+**Files**:
+- `src/entitlements/core/interface.ts` (new)
+- `src/entitlements/core/cache.ts` (new)
+- `src/entitlements/core/http-resolver.ts` (new)
+- `src/entitlements/core/index.ts` (new)
+- `src/content/entitlements/interface.ts` (modified — replaced with re-export shim)
+- `src/content/entitlements/cache.ts` (modified — replaced with re-export shim)
+- `src/content/entitlements/http-resolver.ts` (modified — replaced with re-export shim)
+
+**Validation checklist**:
+- [ ] `tsc --noEmit` passes with zero errors after the move
+- [ ] `src/content/entitlements/index.ts` exports are unchanged at the public surface
+- [ ] `import { EntitlementCache } from '../../content/entitlements/index.js'` still resolves in `EntitlementService`
+- [ ] No circular imports: `core/` must not import from `content/`
+
+**Edge cases**:
+- `interface.ts` currently has `export type { ResolvedEntitlements }` as a re-export (line 11). After moving, `ResolvedEntitlements` stays in `src/content/types.ts`. The shim in `src/content/entitlements/interface.ts` does not need to re-export it — callers that need it import from `../types.js` directly. Remove that line from the core version.
+- `http-resolver.ts` imports `ResolvedEntitlements` from `'../types.js'` (content-relative). In `src/entitlements/core/http-resolver.ts`, adjust the import path to `'../../content/types.js'`. This is a temporary coupling acknowledged by the TODO comment in T001.
+
+---
+
+### T002: Add `responseMapping.featuresField` to `HttpEntitlementResolver`
+
+**Purpose**: Extend `HttpResolverConfig.responseMapping` so the same HTTP resolver class can drive feature-key resolution from an external billing API endpoint (FR-003), reading a `featuresField` array alongside the existing `productsField` array.
+
+**Steps**:
+
+1. In `src/entitlements/core/http-resolver.ts`, extend the `responseMapping` config:
+
+```typescript
+responseMapping: {
+  /** Top-level field in the JSON response containing the products array (content use) */
+  productsField: string;
+  /** Top-level field in the JSON response containing feature keys array (feature-entitlement use) */
+  featuresField?: string;
+  /** Optional top-level field for TTL value (seconds) */
+  ttlField?: string;
+};
+```
+
+2. In the `resolve()` method, after extracting `productIds`, optionally extract `featureKeys`:
+
+```typescript
+const featureKeys: string[] = [];
+if (this.config.responseMapping.featuresField) {
+  const rawFeatures = response[this.config.responseMapping.featuresField];
+  if (Array.isArray(rawFeatures)) {
+    featureKeys.push(...rawFeatures.filter((f): f is string => typeof f === 'string'));
+  }
+}
+```
+
+3. Surface `featureKeys` on the returned `ResolvedEntitlements`. `ResolvedEntitlements` currently has `productIds`, `sourceIds`, `profileIds`, `resolvedFrom`, `resolvedAt`, `ttlSeconds` (`src/content/types.ts:76-84`). Add an optional `featureKeys?: string[]` field to `ResolvedEntitlements` in `src/content/types.ts`:
+
+```typescript
+export interface ResolvedEntitlements {
+  productIds: string[];
+  sourceIds: string[];
+  profileIds: string[];
+  /** Feature/add-on keys resolved for this subject. Populated by FeatureEntitlementResolver. */
+  featureKeys?: string[];
+  resolvedFrom: string;
+  resolvedAt: Date;
+  ttlSeconds?: number;
+}
+```
+
+4. In `HttpEntitlementResolver.resolve()`, set `featureKeys` in the returned object:
+
+```typescript
+return {
+  productIds,
+  featureKeys,        // populated from featuresField; empty array when featuresField not configured
+  sourceIds: [],
+  profileIds: [],
+  resolvedFrom: this.config.name,
+  resolvedAt: new Date(),
+  ttlSeconds,
+};
+```
+
+**Files**:
+- `src/entitlements/core/http-resolver.ts` (modified — add `featuresField`, extract feature keys)
+- `src/content/types.ts` (modified — add optional `featureKeys?: string[]` to `ResolvedEntitlements`)
+
+**Validation checklist**:
+- [ ] Existing callers of `HttpResolverConfig` compile without changes (field is optional)
+- [ ] `ResolvedEntitlements` with no `featureKeys` is still valid (optional field, backward compatible)
+- [ ] `featuresField` absent → `featureKeys` is `[]` in the returned object, not undefined
+- [ ] `tsc --noEmit` passes
+
+**Edge cases**:
+- `productsField` must remain required (content path depends on it). If a caller configures only `featuresField`, they must still provide `productsField` — or accept an empty `productIds` array (which is fine for the feature-entitlement path). Do not make `productsField` optional; document this in a JSDoc comment.
+
+---
+
+### T003: Create `entitlements` Drizzle schema — `feature_catalog`, `feature_entitlements`, `entitlement_decisions`
+
+**Purpose**: Define the three new Phase 1 tables in their own `entitlements` PostgreSQL schema, following content schema conventions exactly (createId, pgSchema, text tenant/subject IDs, $inferSelect/$inferInsert).
+
+**Steps**:
+
+1. Create `src/entitlements/schema.ts`.
+2. Declare the schema namespace: `export const entitlementsSchema = pgSchema('entitlements');`
+3. Define the three tables as shown below (columns, types, indexes, and constraints taken directly from `data-model.md §2`).
+
+```typescript
+// src/entitlements/schema.ts
+import { createId } from '@paralleldrive/cuid2';
+import {
+  pgSchema,
+  text,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+// ============================================================
+// SCHEMA NAMESPACE
+// ============================================================
+
+export const entitlementsSchema = pgSchema('entitlements');
+
+// ============================================================
+// TABLES
+// ============================================================
+
+// --- FeatureCatalog ---
+// Authoritative list of licensable feature/add-on keys.
+// feature_key is the PK and is never reused (withdrawn rows retained — PK collision prevents reuse).
+
+export const featureCatalog = entitlementsSchema.table('feature_catalog', {
+  featureKey: text('feature_key').primaryKey(),
+  displayName: text('display_name').notNull(),
+  description: text('description'),
+  publisher: text('publisher').notNull(),   // 'joyus' for first-party; publisher id for Phase 2 third-party
+  capabilityKinds: jsonb('capability_kinds').notNull(),  // string[] e.g. ["tool","provider"]
+  status: text('status').notNull(),         // 'active' | 'deprecated' | 'withdrawn'
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// --- FeatureEntitlements ---
+// Durable, subject-scoped grants. One live row per (subject_type, subject_id, feature_key).
+// Lifecycle changes update status in place; history goes to entitlement_decisions.
+// subject_id is a naked string (no FK) — no tenants table exists yet (WP12 dependency).
+
+export const featureEntitlements = entitlementsSchema.table('feature_entitlements', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  subjectType: text('subject_type').notNull(),   // 'tenant' | 'user'
+  subjectId: text('subject_id').notNull(),        // tenantId or userId per subjectType
+  featureKey: text('feature_key').notNull().references(() => featureCatalog.featureKey, { onDelete: 'restrict' }),
+  status: text('status').notNull(),               // 'active' | 'suspended' | 'expired' | 'revoked'
+  validFrom: timestamp('valid_from').notNull(),
+  validUntil: timestamp('valid_until'),           // NULL = perpetual until explicitly revoked
+  source: text('source').notNull(),               // 'admin' | 'resolver' | 'trial' | 'import'
+  limits: jsonb('limits'),                        // optional quota envelope e.g. {"maxRunsPerMonth":1000}
+  metadata: jsonb('metadata'),                    // free-form: billing reference, plan id, etc.
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  // One live grant per subject+feature. Status transitions update in place.
+  subjectFeatureUnique: uniqueIndex('entitlements_fe_subject_feature_unique')
+    .on(table.subjectType, table.subjectId, table.featureKey),
+  // Hot path: resolve(subject) — list all grants for a subject filtered by status
+  subjectStatusIdx: index('entitlements_fe_subject_status_idx')
+    .on(table.subjectType, table.subjectId, table.status),
+  // Catalog-side: who holds add-on Y
+  featureKeyIdx: index('entitlements_fe_feature_key_idx')
+    .on(table.featureKey),
+  // Partial index for fast active-set resolution (hot path for the gate)
+  // NOTE: Drizzle does not support partial indexes via the table builder — add this
+  // manually to the generated migration SQL:
+  //   CREATE INDEX entitlements_fe_active_subject_idx
+  //     ON entitlements.feature_entitlements (subject_type, subject_id)
+  //     WHERE status = 'active';
+}));
+
+// --- EntitlementDecisions ---
+// Append-only audit of every gate allow/deny decision.
+// Modeled after orchestrator_events (src/db/schema/events.ts): no UPDATE/DELETE.
+// Indexes support the two query axes: per-subject audit trail, per-feature analytics.
+
+export const entitlementDecisions = entitlementsSchema.table('entitlement_decisions', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  subjectType: text('subject_type').notNull(),
+  subjectId: text('subject_id').notNull(),
+  featureKey: text('feature_key').notNull(),
+  decision: text('decision').notNull(),           // 'allow' | 'deny'
+  reason: text('reason').notNull(),               // 'entitled' | 'not_entitled' | 'expired' |
+                                                  // 'suspended' | 'limit_exceeded' |
+                                                  // 'resolver_unavailable_fallback_deny'
+  resolvedFrom: text('resolved_from').notNull(),  // 'cache' | 'resolver' | 'db' | 'default_deny'
+  capability: text('capability'),                 // e.g. 'tool:advanced_pipeline_run'
+  sessionId: text('session_id'),                  // when available
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  // Per-subject audit trail (primary consumer: compliance, debugging)
+  subjectCreatedIdx: index('entitlements_decisions_subject_created_idx')
+    .on(table.subjectType, table.subjectId, table.createdAt),
+  // Per-feature analytics (conversion: how many denies per feature key)
+  featureCreatedIdx: index('entitlements_decisions_feature_created_idx')
+    .on(table.featureKey, table.createdAt),
+}));
+
+// ============================================================
+// TYPE EXPORTS
+// ============================================================
+
+export type FeatureCatalogEntry    = typeof featureCatalog.$inferSelect;
+export type NewFeatureCatalogEntry = typeof featureCatalog.$inferInsert;
+
+export type FeatureEntitlement    = typeof featureEntitlements.$inferSelect;
+export type NewFeatureEntitlement = typeof featureEntitlements.$inferInsert;
+
+export type EntitlementDecision    = typeof entitlementDecisions.$inferSelect;
+export type NewEntitlementDecision = typeof entitlementDecisions.$inferInsert;
+```
+
+**Files**:
+- `src/entitlements/schema.ts` (new, ~110 lines)
+
+**Validation checklist**:
+- [ ] `tsc --noEmit` passes with zero errors on `schema.ts`
+- [ ] All three tables are defined under `entitlementsSchema` (not top-level `pgTable`)
+- [ ] `featureCatalog.featureKey` is the PK (text, not cuid — it is a stable human-readable key)
+- [ ] `featureEntitlements.id` uses `createId()` from `@paralleldrive/cuid2`
+- [ ] `featureEntitlements.featureKey` references `featureCatalog.featureKey` with `onDelete: 'restrict'`
+- [ ] `uniqueIndex` covers `(subjectType, subjectId, featureKey)` on `featureEntitlements`
+- [ ] `entitlementDecisions` has NO FK to `featureEntitlements` — it is append-only audit, must survive grant deletion
+- [ ] Type exports use `$inferSelect` / `$inferInsert`
+
+**Edge cases**:
+- Drizzle's table builder does not support partial indexes via `index()` with a WHERE clause. The partial index `WHERE status = 'active'` must be added manually to the generated migration SQL after `drizzle-kit generate` (T006). Document this in a comment in the schema file.
+- `featureCatalog.featureKey` is the primary key — no `id` column. This differs from every other table in the codebase. This is correct and intentional: the key is the stable external identity (reverse-DNS, e.g. `com.joyus.addon.advanced-pipelines`), and using it as PK enforces the "never reused" constraint via DB mechanics.
+- `entitlementDecisions` intentionally has no FK to `feature_catalog.feature_key` — a decision row must be queryable even after a feature key is deprecated/withdrawn.
+
+---
+
+### T004: Create `src/entitlements/types.ts` — `Subject`, `FeatureKey`, `EffectiveEntitlement`, opaque `GateToken`, `GrantSource`, `GrantStatus`
+
+**Purpose**: Define the TypeScript types used across the feature-entitlement system. These are the domain types for WP02 (FeatureGate) and WP03 (un-forgeable enforcement) to build on.
+
+**Steps**:
+
+1. Create `src/entitlements/types.ts`.
+2. Define these key shapes (describe, do not fully copy — the implementer writes the exact code):
+
+**`Subject`**: A discriminated union representing what a grant attaches to. Must be explicit — the gate never infers the subject from ambient `tenantId == userId`.
+```typescript
+export type SubjectType = 'tenant' | 'user';
+export interface Subject {
+  subjectType: SubjectType;
+  subjectId: string;
+}
+```
+
+**`FeatureKey`**: A branded string to prevent passing arbitrary strings where a feature key is expected.
+```typescript
+declare const _featureKeyBrand: unique symbol;
+export type FeatureKey = string & { readonly [_featureKeyBrand]: void };
+export function toFeatureKey(raw: string): FeatureKey { return raw as FeatureKey; }
+```
+
+**`GrantSource`** and **`GrantStatus`**: String literal unions mirroring the DB columns in `feature_entitlements`:
+```typescript
+export type GrantSource = 'admin' | 'resolver' | 'trial' | 'import';
+export type GrantStatus = 'active' | 'suspended' | 'expired' | 'revoked';
+```
+
+**`EffectiveEntitlement`**: The resolved capability set for a user — the union over `{user:U} ∪ {tenant:T | U ∈ members(T)}`. This is what the gate checks (FR-019).
+```typescript
+export interface EffectiveEntitlement {
+  featureKeys: Set<FeatureKey>;
+  resolvedAt: Date;
+  /** Earliest valid_until across all contributing grants; null if any grant is perpetual. */
+  nextExpiry: Date | null;
+  /** Which subjects contributed (user grant vs inherited tenant grant) — for audit logging */
+  resolvedSubjects: Subject[];
+}
+```
+
+**`GateToken`**: An opaque, non-constructible proof-of-authorization minted only by `FeatureGate.assertEntitled`. WP03 makes gated entrypoints require this token, making it impossible to reach them without going through the gate. Define the brand here; `FeatureGate` (WP02) mints it.
+```typescript
+declare const _gateTokenBrand: unique symbol;
+export type GateToken = { readonly [_gateTokenBrand]: void };
+```
+
+**Decision audit types** (consumed by WP02's audit writer):
+```typescript
+export type DecisionOutcome = 'allow' | 'deny';
+export type DenyReason =
+  | 'not_entitled'
+  | 'expired'
+  | 'suspended'
+  | 'limit_exceeded'
+  | 'resolver_unavailable_fallback_deny';
+export type ResolvedFrom = 'cache' | 'resolver' | 'db' | 'default_deny';
+```
+
+**Constants**:
+```typescript
+export const DEFAULT_FEATURE_CACHE_TTL_SECONDS = 3600;   // 1 hour; matches content cache default
+export const FEATURE_KEY_SEPARATOR = ':';                 // used in effective-entitlement cache key: 'user:userId'
+```
+
+**Files**:
+- `src/entitlements/types.ts` (new, ~60 lines)
+
+**Validation checklist**:
+- [ ] `GateToken` is non-constructible outside the module that mints it (brand approach, not class)
+- [ ] `FeatureKey` is a branded string — prevents `string` from being passed as `FeatureKey` without explicit conversion
+- [ ] `EffectiveEntitlement.featureKeys` is `Set<FeatureKey>` (not `string[]`) for O(1) lookup at the gate
+- [ ] No imports from `./schema.ts` — `types.ts` must be importable without pulling in Drizzle
+
+**Edge cases**:
+- `GateToken` uses a unique symbol brand (not a class or runtime value). This means a `GateToken` is `{}` at runtime — it carries no data. The only thing it proves is that `assertEntitled` was called (because only that function returns one). WP03 will enforce that gated entrypoints require it as a parameter.
+- `EffectiveEntitlement.nextExpiry` being `null` means at least one contributing grant is perpetual (`valid_until IS NULL`); the gate should not cache past a non-null expiry.
+
+---
+
+### T005: Create Zod validation (`src/entitlements/validation.ts`) — grant create/modify/revoke, catalog entry
+
+**Purpose**: Define runtime input validation schemas for all write operations on the entitlements system, used by the operator grant REST routes and admin MCP tools (WP04).
+
+**Steps**:
+
+1. Create `src/entitlements/validation.ts`.
+2. Define these Zod schemas (describe key shapes; implementer writes exact code):
+
+**`createGrantSchema`** — validates inputs to create a `feature_entitlements` row:
+- `subjectType`: `z.enum(['tenant', 'user'])`
+- `subjectId`: `z.string().min(1)`
+- `featureKey`: `z.string().min(1).regex(/^[a-z0-9]+(\.[a-z0-9-]+)+$/, 'must be reverse-DNS style')`
+- `validFrom`: `z.string().datetime()` — ISO 8601; defaults to now if omitted
+- `validUntil`: `z.string().datetime().optional()` — nullable = perpetual
+- `source`: `z.enum(['admin', 'resolver', 'trial', 'import'])`
+- `limits`: `z.record(z.unknown()).optional()`
+- `metadata`: `z.record(z.unknown()).optional()`
+
+**`modifyGrantSchema`** — partial updates to an existing grant (patch semantics):
+- `status`: `z.enum(['active', 'suspended', 'expired', 'revoked']).optional()`
+- `validUntil`: `z.string().datetime().nullable().optional()`
+- `limits`: `z.record(z.unknown()).optional()`
+- `metadata`: `z.record(z.unknown()).optional()`
+
+**`revokeGrantSchema`** — identifies a grant to revoke (by subject + feature key):
+- `subjectType`: `z.enum(['tenant', 'user'])`
+- `subjectId`: `z.string().min(1)`
+- `featureKey`: `z.string().min(1)`
+
+**`createCatalogEntrySchema`** — validates inputs to create a `feature_catalog` row:
+- `featureKey`: reverse-DNS regex (same as above)
+- `displayName`: `z.string().min(1).max(200)`
+- `description`: `z.string().max(1000).optional()`
+- `publisher`: `z.string().min(1)`
+- `capabilityKinds`: `z.array(z.enum(['tool', 'provider', 'pipeline_step', 'connector', 'hook'])).min(1)`
+- `status`: `z.enum(['active', 'deprecated', 'withdrawn']).default('active')`
+
+Export inferred TypeScript types from each schema:
+```typescript
+export type CreateGrantInput   = z.infer<typeof createGrantSchema>;
+export type ModifyGrantInput   = z.infer<typeof modifyGrantSchema>;
+export type RevokeGrantInput   = z.infer<typeof revokeGrantSchema>;
+export type CreateCatalogInput = z.infer<typeof createCatalogEntrySchema>;
+```
+
+**Files**:
+- `src/entitlements/validation.ts` (new, ~70 lines)
+
+**Validation checklist**:
+- [ ] `featureKey` regex rejects `'advanced-pipelines'` (no dots) and accepts `'com.joyus.addon.advanced-pipelines'`
+- [ ] `createGrantSchema.parse({...})` throws `ZodError` if `featureKey` is missing
+- [ ] `modifyGrantSchema` is partial — all fields optional; parsing `{}` succeeds
+- [ ] `capabilityKinds` enum values match the `spec.md` FR-011 list exactly
+- [ ] No circular imports from `types.ts` (import `GrantSource`, `GrantStatus` literal types if desired, or re-define them inline)
+
+---
+
+### T006: Register schema in `drizzle.config.ts`; generate migration
+
+**Purpose**: Wire `src/entitlements/schema.ts` into Drizzle Kit so it generates the `CREATE SCHEMA` + three `CREATE TABLE` statements as migration `0008_entitlements_schema.sql`.
+
+**Steps**:
+
+1. Add `'./src/entitlements/schema.ts'` to the `schema` array in `drizzle.config.ts`:
+
+```typescript
+// drizzle.config.ts — add one line to the existing schema array
+schema: [
+  './src/db/schema.ts',
+  './src/db/schema/orchestrator.ts',
+  './src/content/schema.ts',
+  './src/pipelines/schema.ts',
+  './src/event-adapter/schema.ts',
+  './src/profiles/schema.ts',
+  './src/entitlements/schema.ts',   // NEW
+],
+```
+
+2. Run `npx drizzle-kit generate` (or the project's existing script). This produces `drizzle/migrations/0008_<slug>_entitlements_schema.sql` and updates `drizzle/migrations/meta/_journal.json`.
+
+3. Inspect the generated SQL. Verify it begins with `CREATE SCHEMA IF NOT EXISTS "entitlements";`. If Drizzle Kit generates `CREATE SCHEMA "entitlements";` without `IF NOT EXISTS` (as it did for the `profiles` schema in `0004_profile_isolation.sql:1`), edit the file to add `IF NOT EXISTS`. The `content` and `pipelines` schemas use the safe form (`0001_fine_young_avengers.sql:1,3`); match that.
+
+4. Manually add the partial index to the generated SQL, after the `feature_entitlements` table's standard indexes:
+
+```sql
+--> statement-breakpoint
+CREATE INDEX "entitlements_fe_active_subject_idx"
+  ON "entitlements"."feature_entitlements" ("subject_type", "subject_id")
+  WHERE "status" = 'active';
+```
+
+5. Commit both the generated `.sql` file and the updated `drizzle/migrations/meta/_journal.json`.
+
+**Files**:
+- `drizzle.config.ts` (modified — one line added)
+- `drizzle/migrations/0008_<slug>_entitlements_schema.sql` (new, generated then patched)
+- `drizzle/migrations/meta/_journal.json` (updated by drizzle-kit generate)
+
+**Validation checklist**:
+- [ ] `drizzle.config.ts` now has 7 entries in the `schema` array
+- [ ] Migration file contains `CREATE SCHEMA IF NOT EXISTS "entitlements";` as first statement
+- [ ] Migration file contains `CREATE TABLE "entitlements"."feature_catalog"` (with `feature_key` as PK — no `id` column)
+- [ ] Migration file contains `CREATE TABLE "entitlements"."feature_entitlements"` with the unique constraint on `(subject_type, subject_id, feature_key)`
+- [ ] Migration file contains `CREATE TABLE "entitlements"."entitlement_decisions"` with no FK to `feature_entitlements`
+- [ ] Partial index `WHERE "status" = 'active'` is present in the migration SQL
+- [ ] `npx drizzle-kit push` or `drizzle-kit migrate` applies the migration without errors against a test database
+- [ ] No existing migrations are modified
+
+**Edge cases**:
+- `feature_catalog.feature_key` is a text PK (not cuid). Drizzle Kit should generate `"feature_key" text PRIMARY KEY NOT NULL` — verify it does not add a `$defaultFn` (there is none; the key is operator-provided).
+- The `featureKey` FK on `feature_entitlements` uses `RESTRICT` on delete. Verify the generated SQL has `REFERENCES "entitlements"."feature_catalog"("feature_key") ON DELETE RESTRICT` (not CASCADE).
+- Drizzle Kit regenerates all schemas on each run. Confirm it does not re-emit `CREATE SCHEMA IF NOT EXISTS "content"` etc. in the new migration (it should not, since those schemas already appear in the journal).
+
+---
+
+### T007: Verify typecheck + existing content entitlement tests pass (extraction regression gate)
+
+**Purpose**: Confirm that the T001 extraction left the content entitlement path behaviorally identical. This is a **hard gate** — WP02 must not begin until this passes.
+
+**Steps**:
+
+1. Run `npm run typecheck` (or `tsc --noEmit`) from the `joyus-ai-mcp-server/` root. Zero errors required.
+2. Run `npm test` and confirm:
+   - The count of passing tests is equal to or greater than the pre-WP01 baseline.
+   - No tests that were passing before now fail.
+   - Focus on: `src/content/entitlements/` tests, `EntitlementService` tests, and any content-search tests that exercise the entitlement path.
+3. If any failures, diagnose and fix in the shim files (`interface.ts`, `cache.ts`, `http-resolver.ts`) or import paths before declaring done.
+
+**Files**:
+- No new files. Minor import-path corrections to shim files if needed.
+
+**Validation checklist**:
+- [ ] `npm run typecheck` exits 0 with zero errors
+- [ ] `npm test` exits 0 with no regressions vs. pre-WP01 baseline
+- [ ] `EntitlementService` resolves, caches, and falls back identically to before the extraction
+- [ ] Any test that touches `src/content/entitlements/` still passes
+- [ ] The new `src/entitlements/` files do not introduce import cycles detectable by the build
+
+**Edge cases**:
+- TypeScript path aliases (if any) in `tsconfig.json` may need updating for the new `src/entitlements/` path. Check `tsconfig.json` for any `paths` entries.
+- If the project uses `module: 'NodeNext'` or `moduleResolution: 'bundler'`, `.js` extensions in import paths matter — the shim re-exports must use `.js` suffixes consistently.
+
+---
+
+## Definition of Done
+
+- [ ] `src/entitlements/core/interface.ts` — `EntitlementResolver`, `ResolverContext`, `EntitlementResolverConfig` (source of truth)
+- [ ] `src/entitlements/core/cache.ts` — `EntitlementCache` (source of truth)
+- [ ] `src/entitlements/core/http-resolver.ts` — `HttpEntitlementResolver`, `HttpResolverConfig` with `featuresField` added (source of truth)
+- [ ] `src/entitlements/core/index.ts` — barrel export
+- [ ] `src/content/entitlements/interface.ts` — re-export shim only
+- [ ] `src/content/entitlements/cache.ts` — re-export shim only
+- [ ] `src/content/entitlements/http-resolver.ts` — re-export shim only
+- [ ] `src/content/types.ts` — `ResolvedEntitlements` extended with optional `featureKeys?: string[]`
+- [ ] `src/entitlements/schema.ts` — three tables, type exports, `pgSchema('entitlements')`
+- [ ] `src/entitlements/types.ts` — `Subject`, `FeatureKey`, `EffectiveEntitlement`, `GateToken`, `GrantSource`, `GrantStatus`, decision/audit types, constants
+- [ ] `src/entitlements/validation.ts` — Zod schemas for grant create/modify/revoke and catalog entry, with inferred TypeScript types
+- [ ] `drizzle.config.ts` — 7 schema entries
+- [ ] `drizzle/migrations/0008_*_entitlements_schema.sql` — `CREATE SCHEMA IF NOT EXISTS "entitlements"`, three tables, partial index patched in manually
+- [ ] `npm run typecheck` exits 0
+- [ ] `npm test` exits 0 with no regressions (T007 hard gate)
+
+---
+
+## Risks
+
+- **Extraction breaks content path (T007).** The content module (`EntitlementService`) imports `EntitlementCache` and `EntitlementResolver` from `./cache.js` and `./interface.js` relative to `src/content/entitlements/`. After T001, those files become re-export shims. If any import chain breaks, `EntitlementService` will fail at runtime without a compile-time error (dynamic imports, lazy requires). Mitigate: run the full test suite (T007) before merging.
+- **`ResolvedEntitlements` type spread.** Adding `featureKeys?: string[]` (T002) to `ResolvedEntitlements` in `src/content/types.ts` is the one non-additive change to a widely-imported type. It is backward compatible (optional field), but any code that spreads `ResolvedEntitlements` into a constructed object literal with exact type checking may need an explicit `featureKeys: []`. Scan for `satisfies ResolvedEntitlements` usages.
+- **Partial index not generated by Drizzle Kit.** The `WHERE status = 'active'` partial index is the hot-path index for the gate. If T006 forgets to patch it in, the gate will use the composite index instead — functionally correct but slower at scale. The migration review checklist must include this.
+- **Migration slug collision.** `drizzle-kit generate` derives the migration filename slug from the changed schema names. Verify the generated file is indeed prefixed `0008_` and not a higher number (would indicate a gap in the journal). If there is a gap, investigate before proceeding.
+- **`feature_catalog.featureKey` as text PK.** Every other table uses a cuid PK. Drizzle Kit may behave differently for text PKs without a default. Verify the generated SQL has no spurious default constraint on `feature_key`.
+
+---
+
+## Reviewer Guidance
+
+- **Extraction scope**: Verify the three shim files in `src/content/entitlements/` contain *only* re-exports — no logic, no new imports from content-module internals. If any content-specific logic crept into `src/entitlements/core/`, the boundary is wrong.
+- **`CREATE SCHEMA IF NOT EXISTS`**: Check the migration file's first line. The `profiles` schema migration (`0004_profile_isolation.sql`) omitted `IF NOT EXISTS`; the `content`/`pipelines` migration used it. Spec 015 requires the safe form.
+- **`featureCatalog.featureKey` PK**: Confirm no `$defaultFn` is attached to this column. The key is human-supplied and stable by design; an auto-generated default would be wrong.
+- **`entitlementDecisions` append-only**: Confirm there is no Drizzle `update()` or `delete()` call against this table anywhere in WP01 (there should be none — it is only written in WP02's audit writer). The append-only contract is enforced by convention in Phase 1; application-level enforcement is the only available mechanism before RLS lands (W5 dependency).
+- **`featureKeys?: string[]` on `ResolvedEntitlements`**: This is the only change to existing types. Confirm it is optional and that no downstream test breaks because of a stricter type check.
+- **T007 is non-negotiable**: Do not approve this WP without evidence that the pre-existing content entitlement test suite passes. A screenshot of `npm test` output or CI green is sufficient.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP02-featuregate-decision-core.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP02-featuregate-decision-core.md
@@ -1,0 +1,953 @@
+---
+work_package_id: "WP02"
+title: "FeatureGate Decision Core"
+lane: "planned"
+dependencies: ["WP01"]
+subtasks: ["T008", "T009", "T010", "T011", "T012", "T013", "T014"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP02: FeatureGate Decision Core
+
+**Implementation command**: `spec-kitty implement WP02`
+**Target repo**: `joyus-ai`
+**Dependencies**: WP01 (shared `src/entitlements/core/`, `entitlements` schema, `Subject` type, opaque `GateToken` type stub)
+**Priority**: P0 (security core — WP03, WP04, WP05 all depend on this)
+
+## Objective
+
+Build the complete feature-entitlement decision stack: a DB-backed, expiry-aware resolver; a subject-scoped cache with TTL capping to next grant expiry; a `MembershipResolver` seam (stubbed for Phase 1); an append-only audit writer; and the `FeatureGate` service that owns `isEntitled`/`assertEntitled`, computes the effective-entitlement union over the actor's subject set, and is the sole minter of the opaque `GateToken`. The gate fails closed on both access and lapsed grants at every step.
+
+## Context
+
+The existing `EntitlementService` (`src/content/entitlements/index.ts`) establishes the resolution pattern this WP reuses: cache → resolver → DB fallback → restricted mode. WP02 adopts that machinery (extracted to `src/entitlements/core/` by WP01) but inverts three key behaviors:
+
+| Axis | Content `EntitlementService` | WP02 `FeatureGate` |
+|---|---|---|
+| **Cache key** | `sessionId` (session-scoped) | `subject_type:subject_id` (durable, subject-scoped) |
+| **Deny semantics** | Silent — empty result | Explicit — throws `FeatureNotEntitledError` |
+| **DB fallback expiry** | No expiry filter (selects most-recent row) | MUST filter `status='active' AND (valid_until IS NULL OR valid_until > now())` |
+
+The third difference is the load-bearing correctness requirement of this entire WP. The content DB fallback (`index.ts:75-109`) selects by `userId+tenantId`, ordered by `resolvedAt DESC`, with no `expiresAt` filter. Naively copying that pattern into the feature fallback would serve a lapsed paid grant during a resolver outage — **failing open on a lapsed grant**. Every DB-touching code path in WP02 must carry the active+non-expired filter.
+
+The explicit-deny contract also runs in the opposite direction from content: the content gate is silent (unentitled returns empty results), so callers cannot know whether emptiness means "no content" or "no access." The feature gate signals through an exception so the API/MCP layer can return a structured upgrade response. This means `FeatureGate.assertEntitled` is a hard throw, not a soft return, and every caller must handle `FeatureNotEntitledError` explicitly rather than silently swallowing absent results.
+
+The `GateToken` mint point established here is the structural anchor for WP03's un-forgeable enforcement. `assertEntitled` is the only place a `GateToken` is produced; the type is defined so it cannot be constructed anywhere else. WP03 then wires gated entrypoints to require a token as their proof-of-gate parameter. The type shape must be locked down here even though WP03 does the wiring — if a future implementer can construct a `GateToken` without calling `assertEntitled`, FR-016's structural guarantee collapses to theater.
+
+## Subtasks
+
+---
+
+### T008: `FeatureEntitlementResolver` — DB-leads, expiry-aware
+
+**Purpose**: Resolve the set of active, non-expired `feature_key`s for a given subject from `entitlements.feature_entitlements`. This is the primary (DB-leads) resolver; an optional external `HttpEntitlementResolver` may front it in environments where a billing API is authoritative, but the DB is always the fallback source of truth.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/resolver.ts`.
+2. Implement `FeatureEntitlementResolver` against the `EntitlementResolver` interface from `src/entitlements/core/interface.ts` (extracted by WP01). The interface is generic over the ID pair; adapt it to take `subjectType` and `subjectId` in the `ResolverContext` or define a `FeatureResolverContext` that extends `ResolverContext` with those fields.
+3. The DB query MUST be the expiry-aware form shown below — no exceptions, no "we'll add that later."
+4. Return the resolved set as a `FeatureSet` (a `Set<string>` of feature keys) plus the TTL metadata needed by T010 to cap the cache entry.
+
+**Critical interfaces and algorithm**:
+
+```typescript
+// src/entitlements/feature/resolver.ts
+
+import { and, eq, gt, isNull, or } from 'drizzle-orm';
+import type { DrizzleClient } from '../../db/types.js';
+import type { Subject } from '../types.js';  // from WP01 T004
+import { featureEntitlements } from '../schema.js';  // from WP01 T003
+
+export interface FeatureResolverResult {
+  /** Resolved feature keys, post-filter (active + non-expired only). */
+  featureKeys: Set<string>;
+  /**
+   * Unix timestamp (ms) of the earliest valid_until among resolved grants,
+   * or null if all grants are perpetual. Used by the cache to cap TTL so
+   * no grant outlives its valid_until by more than one cache window (FR-017).
+   */
+  nextExpiryMs: number | null;
+  resolvedFrom: string;
+  resolvedAt: Date;
+}
+
+export class FeatureEntitlementResolver {
+  constructor(
+    private readonly db: DrizzleClient,
+    private readonly resolverName = 'feature-db',
+  ) {}
+
+  async resolve(subject: Subject): Promise<FeatureResolverResult> {
+    const now = new Date();
+
+    // FR-017: MUST filter status='active' AND (valid_until IS NULL OR valid_until > now).
+    // Do NOT omit the valid_until filter — the content DB fallback omits it and would
+    // serve lapsed licensed features on outage. That is the bug this code exists to prevent.
+    const rows = await this.db
+      .select({
+        featureKey: featureEntitlements.featureKey,
+        validUntil: featureEntitlements.validUntil,
+      })
+      .from(featureEntitlements)
+      .where(
+        and(
+          eq(featureEntitlements.subjectType, subject.subjectType),
+          eq(featureEntitlements.subjectId, subject.subjectId),
+          eq(featureEntitlements.status, 'active'),
+          or(
+            isNull(featureEntitlements.validUntil),
+            gt(featureEntitlements.validUntil, now),
+          ),
+        ),
+      );
+
+    const featureKeys = new Set(rows.map((r) => r.featureKey));
+
+    // Find the earliest upcoming expiry to cap the cache TTL (FR-017).
+    const expiringRows = rows.filter((r) => r.validUntil !== null);
+    const nextExpiryMs =
+      expiringRows.length > 0
+        ? Math.min(...expiringRows.map((r) => r.validUntil!.getTime()))
+        : null;
+
+    return {
+      featureKeys,
+      nextExpiryMs,
+      resolvedFrom: this.resolverName,
+      resolvedAt: now,
+    };
+  }
+}
+```
+
+**Files**:
+- `src/entitlements/feature/resolver.ts` (new, ~60 lines)
+
+**Validation**:
+- [ ] A grant with `valid_until = yesterday` is NOT returned
+- [ ] A grant with `valid_until = tomorrow` IS returned
+- [ ] A grant with `valid_until = null` IS returned (perpetual)
+- [ ] A grant with `status = 'suspended'` is NOT returned
+- [ ] `nextExpiryMs` is `null` when all returned grants are perpetual
+- [ ] `nextExpiryMs` is the earliest expiry when multiple expiring grants exist
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- The Drizzle `gt(column, now)` compares a `timestamp` column against a JS `Date`. Confirm Drizzle's pg adapter handles this without timezone coercion. If not, use `sql\`${featureEntitlements.validUntil} > NOW()\`` as the fallback.
+- An empty result (no rows) is a valid, non-error outcome: the subject simply holds no active grants. Return `{ featureKeys: new Set(), nextExpiryMs: null, ... }`.
+
+---
+
+### T009: `MembershipResolver` interface + `NullMembershipResolver`
+
+**Purpose**: Define the seam through which Phase 1.5 (org seat-licensing, WP12) will inject real tenant membership. Pre-WP12, the membership set is empty (`[]`), so the effective union in the gate reduces to `{user:U}` — the individual path works day one with zero tenant system.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/membership.ts`.
+2. Define the `MembershipResolver` interface. It takes a `userId` and returns the list of `Subject`s whose grants should be unioned into that user's effective entitlement. Pre-WP12, this is always `[]`.
+3. Implement `NullMembershipResolver` returning `[]`.
+
+**Interfaces**:
+
+```typescript
+// src/entitlements/feature/membership.ts
+
+import type { Subject } from '../types.js';
+
+/**
+ * Resolves the set of non-user subjects (e.g. tenant orgs) whose grants
+ * are inherited by the given user. Pre-WP12 this always returns [].
+ *
+ * Phase 1.5: replace NullMembershipResolver with a DB-backed implementation
+ * that reads tenant↔user membership (WP12-owned table) and returns the
+ * relevant { subjectType: 'tenant', subjectId: tenantId } entries.
+ */
+export interface MembershipResolver {
+  getMemberSubjects(userId: string): Promise<Subject[]>;
+}
+
+/**
+ * Phase 1 stub. Returns no inherited subjects.
+ * The gate's effective union degrades to {user:U} only.
+ * Replace with a real implementation when WP12 lands (Phase 1.5).
+ */
+export class NullMembershipResolver implements MembershipResolver {
+  async getMemberSubjects(_userId: string): Promise<Subject[]> {
+    return [];
+  }
+}
+```
+
+**Files**:
+- `src/entitlements/feature/membership.ts` (new, ~25 lines)
+
+**Validation**:
+- [ ] `NullMembershipResolver` returns `[]` for any input
+- [ ] `MembershipResolver` interface is satisfied by both `NullMembershipResolver` and a future DB-backed implementation
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- Leave a clear `// Phase 1.5: replace with WP12 implementation` comment so the activation path is self-documenting.
+- The interface takes `userId` (string), not a full `Subject` — callers always pass the actor's user ID.
+
+---
+
+### T010: Subject-scoped cache wiring
+
+**Purpose**: Wire the `EntitlementCache` (extracted to `src/entitlements/core/cache.ts` by WP01) for subject-scoped, expiry-aware caching of feature key sets. The cache key is `subject_type:subject_id`. The TTL is `min(defaultTtlSeconds, time-to-next-grant-expiry)` so a cached set never survives past the earliest `valid_until` of its constituent grants.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/feature-cache.ts`.
+2. Wrap `EntitlementCache` (or parameterize it — depending on the WP01 extraction approach) with a `FeatureEntitlementCache` that:
+   - Uses `subject_type:subject_id` as the cache key
+   - Caps the TTL at `min(configuredTtlMs, msUntilNextExpiry)` when `nextExpiryMs` is provided by the resolver
+   - Exposes explicit `invalidate(subject: Subject)` for use by the grant write path (WP04 T025)
+3. The cached value is a `Set<string>` of active feature keys (the post-filter resolved set from T008).
+
+**Implementation**:
+
+```typescript
+// src/entitlements/feature/feature-cache.ts
+
+import type { Subject } from '../types.js';
+
+// Reuse the generic cache from core (extracted by WP01).
+// EntitlementCache is parameterized over its value type in WP01's extraction.
+// If WP01 extracted it as content-specific, create a parallel generic version here.
+import { EntitlementCache } from '../core/cache.js';
+
+export const DEFAULT_FEATURE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Subject-keyed cache for resolved feature key sets.
+ *
+ * Key format: `${subjectType}:${subjectId}` — e.g. "user:usr_abc123"
+ * TTL: min(DEFAULT_FEATURE_CACHE_TTL_MS, msUntilNextExpiry)
+ *
+ * Unlike the content cache (keyed by sessionId, invalidated on session close),
+ * this cache is keyed by stable subject identity and invalidated on grant change.
+ */
+export class FeatureEntitlementCache {
+  // If EntitlementCache from core is still content-typed, use a local Map here
+  // and replicate the same get/set/invalidate/cleanup pattern. Do not import a
+  // content-typed class — prefer a clean generic or a local reimplementation.
+  private readonly inner: Map<string, { keys: Set<string>; expiresAt: number }> = new Map();
+
+  private cacheKey(subject: Subject): string {
+    return `${subject.subjectType}:${subject.subjectId}`;
+  }
+
+  get(subject: Subject): Set<string> | null {
+    const key = this.cacheKey(subject);
+    const entry = this.inner.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.inner.delete(key);
+      return null;
+    }
+    return entry.keys;
+  }
+
+  /**
+   * Store the resolved feature key set for a subject.
+   *
+   * @param subject - the subject being cached
+   * @param keys - post-filter set of active feature keys
+   * @param nextExpiryMs - Unix ms of earliest grant valid_until, or null for perpetual.
+   *   The cache TTL is capped to min(DEFAULT_FEATURE_CACHE_TTL_MS, msUntilNextExpiry)
+   *   so a cached entry never outlives the earliest expiring grant (FR-017).
+   */
+  set(subject: Subject, keys: Set<string>, nextExpiryMs: number | null): void {
+    const key = this.cacheKey(subject);
+    const defaultExpiry = Date.now() + DEFAULT_FEATURE_CACHE_TTL_MS;
+    const expiresAt =
+      nextExpiryMs !== null
+        ? Math.min(defaultExpiry, nextExpiryMs)
+        : defaultExpiry;
+    this.inner.set(key, { keys, expiresAt });
+  }
+
+  /**
+   * Explicit invalidation — called by the grant write path (WP04 T025)
+   * on grant/revoke/suspend/expire events.
+   *
+   * Multi-instance caveat (FR-018): this invalidates only the local node.
+   * Cross-node propagation relies on TTL expiry until a pub/sub bus is added.
+   */
+  invalidate(subject: Subject): void {
+    this.inner.delete(this.cacheKey(subject));
+  }
+
+  cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.inner.entries()) {
+      if (now > entry.expiresAt) this.inner.delete(key);
+    }
+  }
+}
+```
+
+**Files**:
+- `src/entitlements/feature/feature-cache.ts` (new, ~60 lines)
+
+**Validation**:
+- [ ] Cache key is `"user:usr_abc"` for `{ subjectType: 'user', subjectId: 'usr_abc' }`
+- [ ] When `nextExpiryMs` is 30 minutes from now and default TTL is 1 hour, effective TTL is 30 minutes
+- [ ] When `nextExpiryMs` is 2 hours from now and default TTL is 1 hour, effective TTL is 1 hour
+- [ ] `get()` returns `null` for an entry past its `expiresAt`
+- [ ] `invalidate()` removes the entry immediately
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- If WP01's extracted `EntitlementCache` is still typed to `ResolvedEntitlements` (content-module type), do not import it here. Write `FeatureEntitlementCache` as a self-contained class. The content cache can stay content-typed; this is the feature cache. Clean separation is preferable to a complex generic that both modules share.
+- `nextExpiryMs` precision: it is a Unix millisecond timestamp from the resolver. `Date.now()` subtraction gives ms-until-expiry; if the result is negative (grant already expired at resolve time but passed the DB filter due to clock skew), clamp to 0 — the entry should not be cached at all. Log a warning.
+
+---
+
+### T011: `entitlement_decisions` append-only audit writer
+
+**Purpose**: Write an allow or deny record to `entitlements.entitlement_decisions` for every gate decision. This table is append-only (no UPDATE/DELETE), following the `orchestrator_events` precedent. The audit writer has two methods and nothing else — it is not a general-purpose logger.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/audit.ts`.
+2. Implement `EntitlementAuditWriter` with `logAllow` and `logDeny` only.
+3. Both methods write to `entitlements.entitlement_decisions` via Drizzle insert. Failures should NOT propagate to the caller — audit write failure must not block a gate decision. Log the error to `console.error` (or the platform's logger) and swallow.
+
+**Implementation**:
+
+```typescript
+// src/entitlements/feature/audit.ts
+
+import { createId } from '@paralleldrive/cuid2';
+import type { DrizzleClient } from '../../db/types.js';
+import { entitlementDecisions } from '../schema.js';  // from WP01 T003
+import type { Subject } from '../types.js';
+
+export type DecisionReason =
+  | 'entitled'
+  | 'not_entitled'
+  | 'expired'
+  | 'suspended'
+  | 'limit_exceeded'
+  | 'resolver_unavailable_fallback_deny';
+
+export type ResolvedFrom = 'cache' | 'resolver' | 'db' | 'default_deny';
+
+export interface AuditContext {
+  /** The feature key being gated */
+  featureKey: string;
+  /** Which source produced the decision */
+  resolvedFrom: ResolvedFrom;
+  /** The specific capability being accessed, e.g. "tool:advanced_pipeline_run" */
+  capability?: string;
+  /** MCP/HTTP session id when available */
+  sessionId?: string;
+}
+
+export class EntitlementAuditWriter {
+  constructor(private readonly db: DrizzleClient) {}
+
+  async logAllow(subject: Subject, ctx: AuditContext): Promise<void> {
+    await this.write(subject, 'allow', 'entitled', ctx);
+  }
+
+  async logDeny(subject: Subject, reason: DecisionReason, ctx: AuditContext): Promise<void> {
+    await this.write(subject, 'deny', reason, ctx);
+  }
+
+  private async write(
+    subject: Subject,
+    decision: 'allow' | 'deny',
+    reason: DecisionReason,
+    ctx: AuditContext,
+  ): Promise<void> {
+    try {
+      await this.db.insert(entitlementDecisions).values({
+        id: createId(),
+        subjectType: subject.subjectType,
+        subjectId: subject.subjectId,
+        featureKey: ctx.featureKey,
+        decision,
+        reason,
+        resolvedFrom: ctx.resolvedFrom,
+        capability: ctx.capability ?? null,
+        sessionId: ctx.sessionId ?? null,
+        createdAt: new Date(),
+      });
+    } catch (err) {
+      // Audit write failure must NOT block the gate decision.
+      // Log and swallow — a missed audit row is preferable to a broken request.
+      console.error('[EntitlementAuditWriter] Failed to write decision row', {
+        decision,
+        featureKey: ctx.featureKey,
+        subject,
+        err,
+      });
+    }
+  }
+}
+```
+
+**Files**:
+- `src/entitlements/feature/audit.ts` (new, ~60 lines)
+
+**Validation**:
+- [ ] `logAllow` writes `decision='allow'`, `reason='entitled'`
+- [ ] `logDeny` writes `decision='deny'` with the provided reason
+- [ ] A DB insert failure does NOT throw from `logAllow`/`logDeny`
+- [ ] `capability` and `sessionId` are nullable (written as `null` when absent)
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- FR-006 says the table is append-only. The `EntitlementAuditWriter` never calls `update` or `delete`. A code reviewer should flag any such calls as a spec violation.
+- When FR-019's union resolves an allow via a *tenant* subject rather than the user's own grant, the `subject` passed to `logAllow` should be the specific subject that satisfied the allow (the tenant, not the user). The gate (T012) is responsible for passing the right subject to the audit call.
+
+---
+
+### T012: `FeatureGate` service — union, resolution order, `GateToken` mint
+
+**Purpose**: The single enforcement service. Resolves a user's effective entitlement as the union of `{user:U} ∪ membershipSubjects`, runs cache→resolver→DB-fallback→deny at every step (all expiry-aware), mints a `GateToken` on allow, and throws `FeatureNotEntitledError` on deny. This is the only place in the codebase that may mint a `GateToken`.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/gate.ts`.
+2. `FeatureGate` constructor takes `FeatureEntitlementResolver`, `FeatureEntitlementCache`, `MembershipResolver`, `EntitlementAuditWriter`.
+3. Implement `isEntitled` and `assertEntitled` per the signatures below.
+4. The union algorithm: resolve the subject set for the actor, resolve each subject's feature keys (cache→resolver→DB-fallback→deny), union all sets; allow if the feature key appears in the union.
+5. `GateToken` is imported from `src/entitlements/types.ts` (defined by WP01 T004). `assertEntitled` is the sole caller of the token mint function. The mint function must be unexported and co-located with the type, making external construction impossible at the type level. If WP01 only stubbed the type, complete the brand/mint pattern here.
+
+**Critical implementation**:
+
+```typescript
+// src/entitlements/feature/gate.ts
+
+import type { Subject } from '../types.js';
+import {
+  mintGateToken,  // unexported from types.ts; only re-exported here for assertEntitled's use
+  type GateToken,
+} from '../types.js';
+import type { FeatureEntitlementResolver } from './resolver.js';
+import type { FeatureEntitlementCache } from './feature-cache.js';
+import type { MembershipResolver } from './membership.js';
+import type { EntitlementAuditWriter } from './audit.js';
+import { FeatureNotEntitledError } from './errors.js';  // T013
+
+// ── GateToken type (if WP01 T004 only stubbed it, complete it here) ────────
+//
+// The GateToken is an opaque branded type. There is exactly ONE mint function.
+// It is NOT exported from this module — only assertEntitled calls it.
+// WP03 will wire gated entrypoints to require a GateToken parameter.
+//
+// If WP01 T004 already defined the brand+mint in src/entitlements/types.ts,
+// import mintGateToken from there. If it only declared the type, add the mint:
+//
+//   declare const _gateTokenBrand: unique symbol;
+//   export type GateToken = { readonly [_gateTokenBrand]: true };
+//   // Not exported — only assertEntitled calls this:
+//   export function mintGateToken(): GateToken {
+//     return {} as GateToken;
+//   }
+
+export class FeatureGate {
+  constructor(
+    private readonly resolver: FeatureEntitlementResolver,
+    private readonly cache: FeatureEntitlementCache,
+    private readonly membershipResolver: MembershipResolver,
+    private readonly audit: EntitlementAuditWriter,
+  ) {}
+
+  /**
+   * Non-throwing entitlement check. Does NOT mint a GateToken.
+   * Use assertEntitled for enforcement — isEntitled is for conditional logic
+   * (e.g. filtering tool lists) where a token is not yet needed.
+   */
+  async isEntitled(userId: string, featureKey: string): Promise<boolean> {
+    const { entitled } = await this.resolveEffective(userId, featureKey);
+    return entitled;
+  }
+
+  /**
+   * Enforcement method. Throws FeatureNotEntitledError on deny.
+   * Returns an opaque GateToken on allow — the ONLY place a GateToken is minted.
+   *
+   * The GateToken is the proof-of-gate that WP03 wires into gated entrypoints.
+   * No other code path may produce a GateToken. The type is branded/opaque
+   * so this cannot be circumvented at the type level.
+   *
+   * @param userId - the authenticated actor (always a user id; never inferred
+   *   from tenantId — the gate takes an explicit subject)
+   * @param featureKey - the feature being gated (e.g. "com.joyus.addon.advanced-pipelines")
+   * @param capability - optional human-readable capability name for audit + error payload
+   * @param sessionId - MCP/HTTP session id for audit correlation
+   */
+  async assertEntitled(
+    userId: string,
+    featureKey: string,
+    capability?: string,
+    sessionId?: string,
+  ): Promise<GateToken> {
+    const { entitled, satisfyingSubject, resolvedFrom } = await this.resolveEffective(
+      userId,
+      featureKey,
+    );
+
+    if (entitled && satisfyingSubject) {
+      await this.audit.logAllow(satisfyingSubject, {
+        featureKey,
+        resolvedFrom,
+        capability,
+        sessionId,
+      });
+      // The ONE and ONLY mint point. mintGateToken is not exported from this module.
+      return mintGateToken();
+    }
+
+    await this.audit.logDeny(
+      { subjectType: 'user', subjectId: userId },
+      'not_entitled',
+      { featureKey, resolvedFrom, capability, sessionId },
+    );
+    throw new FeatureNotEntitledError(featureKey, capability);
+  }
+
+  /**
+   * Resolve the effective entitlement for a user across their full subject set.
+   *
+   * Algorithm (FR-019):
+   *   subjectSet = { user:userId } ∪ membershipResolver.getMemberSubjects(userId)
+   *   for each subject in subjectSet:
+   *     resolve featureKeys (cache → resolver → DB fallback → empty)
+   *   effectiveKeys = union of all per-subject featureKeys
+   *   entitled = featureKey ∈ effectiveKeys
+   *
+   * Pre-WP12: membershipResolver returns [] so subjectSet = { user:userId }.
+   * Post-WP12: membershipResolver returns tenant subjects; one tenant grant
+   *   entitles every member with no per-user rows required.
+   *
+   * Resolution order per subject (FR-005, FR-017):
+   *   1. Cache (subject-keyed; post-filter set)
+   *   2. Resolver (FeatureEntitlementResolver.resolve; expiry-aware)
+   *   3. DB fallback (same expiry-aware query as the resolver — NOT the content fallback)
+   *   4. Empty set (default deny — never grant on fallback)
+   *
+   * All steps return the post-filter set; no step may return expired grants.
+   */
+  private async resolveEffective(
+    userId: string,
+    featureKey: string,
+  ): Promise<{
+    entitled: boolean;
+    satisfyingSubject: Subject | null;
+    resolvedFrom: 'cache' | 'resolver' | 'db' | 'default_deny';
+  }> {
+    const userSubject: Subject = { subjectType: 'user', subjectId: userId };
+    const memberSubjects = await this.membershipResolver.getMemberSubjects(userId);
+    const subjectSet: Subject[] = [userSubject, ...memberSubjects];
+
+    for (const subject of subjectSet) {
+      const { keys, resolvedFrom } = await this.resolveSubject(subject);
+      if (keys.has(featureKey)) {
+        return { entitled: true, satisfyingSubject: subject, resolvedFrom };
+      }
+    }
+
+    return { entitled: false, satisfyingSubject: null, resolvedFrom: 'default_deny' };
+  }
+
+  /**
+   * Resolve the feature key set for a single subject.
+   * Order: cache → resolver → DB fallback → empty.
+   * All steps are expiry-aware (returning only active, non-expired grants).
+   */
+  private async resolveSubject(subject: Subject): Promise<{
+    keys: Set<string>;
+    resolvedFrom: 'cache' | 'resolver' | 'db' | 'default_deny';
+  }> {
+    // 1. Cache
+    const cached = this.cache.get(subject);
+    if (cached !== null) {
+      return { keys: cached, resolvedFrom: 'cache' };
+    }
+
+    // 2. Resolver (DB-leads implementation; may be fronted by HttpEntitlementResolver
+    //    in environments where a billing API is authoritative)
+    try {
+      const result = await this.resolver.resolve(subject);
+      this.cache.set(subject, result.featureKeys, result.nextExpiryMs);
+      return { keys: result.featureKeys, resolvedFrom: 'resolver' };
+    } catch (_resolverErr) {
+      // Resolver failed — fall through to DB fallback.
+    }
+
+    // 3. DB fallback — MUST use the same expiry-aware query as the resolver.
+    // WARNING: Do NOT copy the content DB fallback (index.ts:75-109). That query
+    // selects the most-recent row with no expiresAt filter and would serve a lapsed
+    // paid grant on outage. The expiry-aware query lives in FeatureEntitlementResolver.
+    // Call it directly (bypass cache) for the fallback read.
+    try {
+      const fallback = await this.resolver.resolve(subject);
+      // Do not cache the fallback result — the resolver was unavailable and the
+      // data may be stale in ways we can't detect. Let the next call retry normally.
+      return { keys: fallback.featureKeys, resolvedFrom: 'db' };
+    } catch (_fallbackErr) {
+      // Both resolver paths failed. Default deny.
+    }
+
+    // 4. Default deny — never grant on total failure (FR-005).
+    return { keys: new Set(), resolvedFrom: 'default_deny' };
+  }
+}
+```
+
+> **Implementation note on the DB fallback**: The code above calls `this.resolver.resolve(subject)` twice (once as primary, once as fallback) because `FeatureEntitlementResolver` IS the DB layer. In the DB-leads design, the "resolver" reads the DB. If Phase 1 also wires an `HttpEntitlementResolver` in front (external billing), the class should accept a separate `dbFallbackResolver: FeatureEntitlementResolver` parameter that goes directly to DB, bypassing the HTTP layer. The critical invariant is: **the fallback path must use the expiry-aware DB query, never a raw select without the filter**.
+
+**Files**:
+- `src/entitlements/feature/gate.ts` (new, ~120 lines)
+
+**Validation**:
+- [ ] `assertEntitled` returns a `GateToken` when entitled
+- [ ] `assertEntitled` throws `FeatureNotEntitledError` when not entitled
+- [ ] `isEntitled` returns `boolean` and does NOT throw
+- [ ] Resolution order is cache → resolver → fallback → deny (not resolver → cache)
+- [ ] Pre-WP12: union is just `{user:U}` (NullMembershipResolver returns `[]`)
+- [ ] `assertEntitled` takes `userId` explicitly — never reads `tenantId` from ambient context
+- [ ] `logAllow` receives the satisfying subject (which subject's grant allowed it)
+- [ ] `logDeny` is called with `reason='not_entitled'` on default deny
+- [ ] `mintGateToken` is not accessible outside this module + `types.ts`
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- **Do not infer userId from tenantId**: The spec explicitly calls out `executor.ts:104`'s `tenantId == userId` collapse as a known shortcut that must not enter the gate API. `assertEntitled` takes `userId` as its first argument — the caller supplies it from the authenticated request context.
+- **Union short-circuits on first match**: The loop over `subjectSet` returns on the first subject that satisfies the feature key. This means the audit log captures which subject (user vs which tenant) allowed the access — important for post-WP12 debugging of inherited vs. personal entitlements.
+- **Audit on fallback deny**: When the fallback produces an empty set and the feature is not entitled, `logDeny` should use `reason='resolver_unavailable_fallback_deny'` if the resolver threw (distinguish from clean `not_entitled`). The `resolveSubject` private method needs to propagate whether a resolver error occurred to inform the deny reason. Adjust the implementation to track this.
+- **`isEntitled` does not audit**: Checking for tool list visibility should not produce deny audit rows (that would flood the log with benign list-filter calls). Only `assertEntitled` writes audit rows. If a future caller needs deny audit from `isEntitled`, that is a separate design decision.
+
+---
+
+### T013: `FeatureNotEntitledError` + structured upgrade payload
+
+**Purpose**: Define the error class thrown by `assertEntitled` on deny, carrying the structured payload that the API and MCP layers map to HTTP 402/403 and MCP tool errors. This is the explicit-deny signal — the opposite of the content path's silent empty result.
+
+**Steps**:
+
+1. Create `src/entitlements/feature/errors.ts`.
+2. Implement `FeatureNotEntitledError extends Error` with a machine-readable `upgradePayload`.
+3. Define `UpgradePayload` — the shape the HTTP layer maps to a 402/403 body and the MCP layer maps to a non-empty tool error.
+
+**Implementation**:
+
+```typescript
+// src/entitlements/feature/errors.ts
+
+/**
+ * Machine-readable payload attached to FeatureNotEntitledError.
+ * The HTTP layer maps this to a 402/403 response body.
+ * The MCP layer maps this to a non-empty tool error with isError: true.
+ */
+export interface UpgradePayload {
+  /** The feature key that was denied, e.g. "com.joyus.addon.advanced-pipelines" */
+  featureKey: string;
+  /** The specific capability that was blocked, e.g. "tool:advanced_pipeline_run" */
+  capability?: string;
+  /** Human-readable reason for the denial */
+  message: string;
+  /** HTTP status hint: 402 for "this is a licensed feature", 403 for "suspended/revoked" */
+  httpStatus: 402 | 403;
+  /**
+   * Upgrade action hint for the client UI.
+   * "upgrade_required" = not licensed at all.
+   * "contact_admin" = licensed at org level but user is not a member, or suspended.
+   */
+  upgradeAction: 'upgrade_required' | 'contact_admin';
+}
+
+export class FeatureNotEntitledError extends Error {
+  public readonly featureKey: string;
+  public readonly upgradePayload: UpgradePayload;
+
+  constructor(featureKey: string, capability?: string) {
+    const message = capability
+      ? `Not entitled to use ${capability} (requires feature: ${featureKey})`
+      : `Not entitled to feature: ${featureKey}`;
+
+    super(message);
+    this.name = 'FeatureNotEntitledError';
+    this.featureKey = featureKey;
+    this.upgradePayload = {
+      featureKey,
+      capability,
+      message,
+      httpStatus: 402,
+      upgradeAction: 'upgrade_required',
+    };
+
+    // Maintains proper prototype chain in transpiled environments
+    Object.setPrototypeOf(this, FeatureNotEntitledError.prototype);
+  }
+}
+
+/**
+ * Type guard for FeatureNotEntitledError.
+ * Use in Express error handlers and MCP tool dispatch to produce structured responses.
+ */
+export function isFeatureNotEntitledError(err: unknown): err is FeatureNotEntitledError {
+  return err instanceof FeatureNotEntitledError;
+}
+
+/**
+ * Map a FeatureNotEntitledError to the MCP tool error shape.
+ * Returns content array with isError: true per the MCP spec.
+ */
+export function toMcpToolError(err: FeatureNotEntitledError): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(err.upgradePayload),
+      },
+    ],
+    isError: true,
+  };
+}
+```
+
+**Files**:
+- `src/entitlements/feature/errors.ts` (new, ~65 lines)
+
+**Validation**:
+- [ ] `new FeatureNotEntitledError('com.joyus.addon.x').upgradePayload.httpStatus === 402`
+- [ ] `isFeatureNotEntitledError(new FeatureNotEntitledError('x'))` is `true`
+- [ ] `isFeatureNotEntitledError(new Error('other'))` is `false`
+- [ ] `toMcpToolError(err).isError === true`
+- [ ] `toMcpToolError(err).content[0].type === 'text'`
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- `httpStatus: 402` is the default for "upgrade required." A future caller may want 403 for suspended/revoked grants (the user IS entitled but the grant is suspended — different UX). The `upgradePayload` shape allows the gate to vary this in a future revision; for Phase 1 always emit 402.
+- `Object.setPrototypeOf` is required for `instanceof` to work correctly with transpiled ES classes. Do not omit it.
+
+---
+
+### T014: Unit tests
+
+**Purpose**: Verify the resolver's expiry/fail-closed behavior, the union degrades to `{user}` pre-WP12, the cache caps TTL to next expiry and responds to explicit invalidation, the audit writer is append-only and swallows write failures, and the gate's full resolution order including deny reasons.
+
+**Steps**:
+
+1. Create `tests/entitlements/unit/feature-resolver.test.ts`
+2. Create `tests/entitlements/unit/feature-cache.test.ts`
+3. Create `tests/entitlements/unit/entitlement-audit.test.ts`
+4. Create `tests/entitlements/unit/feature-gate.test.ts`
+
+Follow the Vitest + mock-DB pattern established in `tests/content/integration/entitlements.test.ts`: use `vi.fn()` for DB/resolver mocks, no real DB connections.
+
+**Test cases — resolver (T008)**:
+
+```typescript
+// tests/entitlements/unit/feature-resolver.test.ts
+
+describe('FeatureEntitlementResolver', () => {
+  it('returns only active, non-expired grants', async () => {
+    // Mock DB returns rows including one with valid_until = yesterday, one active,
+    // one perpetual (valid_until = null). Resolver should return only active + perpetual.
+  });
+
+  it('returns empty set when no active grants exist', async () => {
+    // Mock DB returns [] — resolver returns { featureKeys: new Set(), nextExpiryMs: null }
+  });
+
+  it('sets nextExpiryMs to the earliest valid_until among returned rows', async () => {
+    // Two grants: valid_until = 2h from now, valid_until = 4h from now.
+    // nextExpiryMs should be the 2h timestamp.
+  });
+
+  it('sets nextExpiryMs to null when all grants are perpetual', async () => {
+    // All returned rows have valid_until = null.
+  });
+
+  it('throws when the DB query fails (fail-closed)', async () => {
+    // Mock DB throws. Resolver should propagate the error — callers apply fallback logic.
+  });
+});
+```
+
+**Test cases — cache (T010)**:
+
+```typescript
+// tests/entitlements/unit/feature-cache.test.ts
+
+describe('FeatureEntitlementCache', () => {
+  it('caps TTL to nextExpiryMs when nextExpiryMs < default TTL', () => {
+    // nextExpiryMs = now + 30min; default TTL = 1h.
+    // Entry should expire in ~30min, not ~1h.
+  });
+
+  it('uses default TTL when nextExpiryMs > default TTL', () => {
+    // nextExpiryMs = now + 2h; default TTL = 1h.
+    // Entry should expire in ~1h.
+  });
+
+  it('uses default TTL when nextExpiryMs is null (perpetual grants)', () => {});
+
+  it('returns null for an expired entry', () => {
+    // Set with ttl=0 or back-date the expiry; get() should return null.
+  });
+
+  it('explicit invalidate removes the entry before TTL', () => {
+    // Set, then invalidate, then get() → null.
+  });
+
+  it('cleanup() removes expired entries', () => {
+    // Set two entries, one with ttl=0 (already expired), one valid. Cleanup. Verify only valid remains.
+  });
+});
+```
+
+**Test cases — audit (T011)**:
+
+```typescript
+// tests/entitlements/unit/entitlement-audit.test.ts
+
+describe('EntitlementAuditWriter', () => {
+  it('logAllow writes decision=allow, reason=entitled', async () => {
+    const mockInsert = vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    const writer = new EntitlementAuditWriter({ insert: mockInsert } as never);
+    await writer.logAllow({ subjectType: 'user', subjectId: 'u1' }, {
+      featureKey: 'com.joyus.addon.x', resolvedFrom: 'cache',
+    });
+    expect(mockInsert).toHaveBeenCalledOnce();
+    // Verify the values call received decision='allow', reason='entitled'
+  });
+
+  it('logDeny writes decision=deny with the provided reason', async () => {});
+
+  it('does NOT throw when the DB insert fails', async () => {
+    // Mock insert to throw. logAllow/logDeny should return without throwing.
+    const mockInsert = vi.fn().mockReturnValue({
+      values: vi.fn().mockRejectedValue(new Error('DB down')),
+    });
+    const writer = new EntitlementAuditWriter({ insert: mockInsert } as never);
+    await expect(
+      writer.logAllow({ subjectType: 'user', subjectId: 'u1' }, {
+        featureKey: 'com.joyus.addon.x', resolvedFrom: 'db',
+      }),
+    ).resolves.not.toThrow();
+  });
+});
+```
+
+**Test cases — gate (T012)**:
+
+```typescript
+// tests/entitlements/unit/feature-gate.test.ts
+
+describe('FeatureGate', () => {
+  describe('resolution order', () => {
+    it('returns cache hit without calling resolver', async () => {});
+    it('calls resolver on cache miss and caches the result', async () => {});
+    it('falls through to DB fallback when resolver throws', async () => {});
+    it('denies (and does not throw from assertEntitled) when all paths fail', async () => {
+      // All paths fail → FeatureNotEntitledError thrown with reason=resolver_unavailable
+    });
+  });
+
+  describe('union (FR-019)', () => {
+    it('pre-WP12: effective set is just {user:U} when NullMembershipResolver returns []', async () => {
+      // User has feature key X. NullMembershipResolver returns [].
+      // isEntitled(userId, 'X') → true.
+    });
+
+    it('union: entitled via membership subject even when user grant absent', async () => {
+      // User has no personal grant. Stubbed MembershipResolver returns [{ subjectType: 'tenant', subjectId: 't1' }].
+      // Tenant t1 has grant for feature X.
+      // isEntitled(userId, 'X') → true.
+    });
+
+    it('denies when neither user nor membership subjects have the feature', async () => {});
+  });
+
+  describe('explicit subject — no ambient tenantId inference', () => {
+    it('takes userId as explicit param; does not read tenantId from context', async () => {
+      // This test exists to pin the API contract. assertEntitled(userId, ...) — first arg is userId.
+      // The test verifies that calling assertEntitled with userId='u1' resolves against
+      // { subjectType: 'user', subjectId: 'u1' }, NOT against a tenantId.
+    });
+  });
+
+  describe('GateToken minting', () => {
+    it('assertEntitled returns a GateToken on allow', async () => {
+      const token = await gate.assertEntitled(userId, featureKey);
+      // Token is truthy and satisfies the GateToken type (opaque brand check)
+      expect(token).toBeTruthy();
+    });
+
+    it('assertEntitled throws FeatureNotEntitledError on deny', async () => {
+      await expect(gate.assertEntitled(userId, 'com.joyus.addon.not-granted'))
+        .rejects.toThrow(FeatureNotEntitledError);
+    });
+  });
+
+  describe('deny reasons', () => {
+    it('logs not_entitled when no grant exists', async () => {});
+    it('logs resolver_unavailable_fallback_deny when resolver throws and DB is also unavailable', async () => {});
+  });
+});
+```
+
+**Files**:
+- `tests/entitlements/unit/feature-resolver.test.ts` (new, ~60 lines)
+- `tests/entitlements/unit/feature-cache.test.ts` (new, ~50 lines)
+- `tests/entitlements/unit/entitlement-audit.test.ts` (new, ~40 lines)
+- `tests/entitlements/unit/feature-gate.test.ts` (new, ~100 lines)
+
+**Validation**:
+- [ ] All described test cases are implemented (not just `it.todo`)
+- [ ] `npm test -- tests/entitlements/unit/` exits 0
+- [ ] No test imports real DB connection or real HTTP resolver
+- [ ] Resolver expiry filter is tested with explicit past/future/null dates
+- [ ] Cache TTL capping is tested with numeric comparisons (not just "truthy")
+- [ ] Audit swallow-on-failure is tested (mock insert that rejects → logAllow resolves)
+- [ ] Union with empty membership is tested (pre-WP12 path)
+- [ ] Gate deny via `assertEntitled` throws `FeatureNotEntitledError`, not a generic error
+
+---
+
+## Definition of Done
+
+- [ ] `src/entitlements/feature/resolver.ts` — DB-leads, expiry-aware; `status='active' AND (valid_until IS NULL OR valid_until > now)` filter present; returns `nextExpiryMs`
+- [ ] `src/entitlements/feature/membership.ts` — `MembershipResolver` interface + `NullMembershipResolver`
+- [ ] `src/entitlements/feature/feature-cache.ts` — subject-keyed; TTL capped to `min(default, nextExpiryMs)`; explicit `invalidate(subject)`
+- [ ] `src/entitlements/feature/audit.ts` — `logAllow`/`logDeny` only; append-only writes; swallows DB errors
+- [ ] `src/entitlements/feature/gate.ts` — `isEntitled`/`assertEntitled`; union over `{user:U} ∪ membership`; resolution order cache→resolver→db-fallback→deny; sole `GateToken` mint point
+- [ ] `src/entitlements/feature/errors.ts` — `FeatureNotEntitledError` with `UpgradePayload`; `toMcpToolError` helper
+- [ ] `tests/entitlements/unit/*.test.ts` — resolver expiry/fail-closed, cache TTL capping, audit swallow, gate union + order + deny reasons
+- [ ] `npm run typecheck` exits 0 with zero errors
+- [ ] `npm test` exits 0 with no regressions on existing content entitlement tests
+- [ ] `mintGateToken` is not importable by arbitrary modules (enforce via unexported function or module boundary)
+
+## Risks
+
+- **DB fallback expiry regression**: The single highest-risk copy-paste error in this WP is writing the DB fallback without the `valid_until` filter. The content fallback (`index.ts:75-109`) is the wrong template. Every reviewer must check the fallback query for the active+non-expired predicate.
+- **GateToken mint escape**: If `mintGateToken` leaks (re-exported, or the `GateToken` type is constructible via a cast), WP03's structural enforcement is hollow. Keep the mint function module-private.
+- **Cache TTL math**: `min(defaultExpiry, nextExpiryMs)` operates on Unix milliseconds from two different bases. Double-check that `Date.now() + DEFAULT_FEATURE_CACHE_TTL_MS` and `nextExpiryMs` (from the resolver) are both in the same units (ms). Off-by-1000x here produces a 1-second or 1000-second TTL.
+- **Audit blocking the gate**: If `logAllow`/`logDeny` are awaited before returning the GateToken and the DB is slow, the gate adds latency to every gated call. Consider a fire-and-forget pattern (`void this.audit.logAllow(...)`) for latency-sensitive paths, with the understanding that audit completeness is best-effort.
+- **Union subject order**: The loop short-circuits on the first satisfying subject. If the union iterates membership subjects before the user subject, the audit log may record a tenant grant as the satisfying subject even when the user had a personal grant. Iterate user subject first for predictable attribution.
+
+## Reviewer Guidance
+
+- **Expiry filter verification (T008, T012)**: Open `resolver.ts` and confirm the Drizzle `.where()` clause contains both `eq(featureEntitlements.status, 'active')` and the `or(isNull(...), gt(...))` on `validUntil`. If either is absent, the resolver is incorrect. The content fallback is the reference for what NOT to do.
+- **GateToken mint point (T012)**: Confirm `mintGateToken` is called in exactly one place (`assertEntitled`) and is not exported from `gate.ts` or `errors.ts`. If it appears in any other call site, that is a FR-016 violation.
+- **Union pre-WP12 (T009, T012, T014)**: Confirm `NullMembershipResolver.getMemberSubjects` returns `[]` and the gate test for pre-WP12 behavior uses it. The union `{user:U} ∪ []` must not accidentally include phantom subjects.
+- **Audit swallow (T011)**: The audit write is wrapped in `try/catch` with no rethrow. Confirm the test for DB-down behavior verifies that `logAllow` resolves (not rejects) when the DB insert fails.
+- **No ambient context inference (T012)**: `assertEntitled` signature is `(userId: string, featureKey: string, ...)` — the first argument is always the explicit authenticated user id. There must be no `this.context?.tenantId` or equivalent read inside the gate. A reviewer who sees any implicit context read should flag it as a security concern.
+- **Content path regression**: Run `npm test -- tests/content/` after WP02 to verify the existing entitlement tests still pass. WP02 adds new files but should not touch `src/content/` — any modification there is unexpected and must be justified.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP03-unforgeable-enforcement.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP03-unforgeable-enforcement.md
@@ -1,0 +1,535 @@
+---
+work_package_id: "WP03"
+title: "Un-forgeable Gated-Path Enforcement"
+lane: "planned"
+dependencies: ["WP02"]
+subtasks: ["T015", "T016", "T017", "T018", "T019"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP03: Un-forgeable Gated-Path Enforcement
+
+**Implementation command**: `spec-kitty implement WP03`
+**Target repo**: `joyus-ai`
+**Dependencies**: WP02 (FeatureGate Decision Core — mints GateToken)
+**Priority**: P0 (Security keystone — without this, FR-016 is theater)
+
+## Objective
+
+Convert Phase 1 feature-gate enforcement from procedural (every call site remembers to check) to structural (a gated capability cannot be reached without passing through `FeatureGate.assertEntitled`). This is accomplished by introducing an opaque `GateToken` type that only `FeatureGate.assertEntitled` can mint, then making every gated entrypoint require one — making it a TypeScript compile error, not a review comment, to skip the gate. The existing `content_search` synthetic-entitlement bypass is the live counterexample this WP must close.
+
+## Context
+
+### The Live Counterexample
+
+`src/tools/executors/content-executor.ts` lines 223–231 contain the pattern this WP exists to prevent:
+
+```typescript
+// BEFORE — the fabricated bypass (content-executor.ts:217-231)
+const entitlements: ResolvedEntitlements = {
+  productIds: tenantProducts.map((p) => p.id),
+  sourceIds: [],
+  profileIds: [],
+  resolvedFrom: 'tool-executor',   // ← lies: no resolver was consulted
+  resolvedAt: new Date(),
+};
+const results = await context.searchService.search(query, entitlements, { ... });
+```
+
+This constructs a `ResolvedEntitlements` object inline and passes it straight to `SearchService.search()`, bypassing `EntitlementService`, the resolver, the cache, and any future `FeatureGate` check entirely. The bug is invisible at review because there is no type-level constraint that makes the bypass wrong — it is merely inadvertent. FR-016 names this as the proof that procedural enforcement is insufficient.
+
+### Procedural vs. Structural
+
+**Procedural** enforcement: every author who adds a gated call site is supposed to remember to call `FeatureGate.assertEntitled` first. One forgotten call = a licensed feature ships for free. The content_search path is proof the convention breaks.
+
+**Structural** enforcement: a gated service's public API *requires* a `GateToken` parameter that cannot be constructed anywhere except inside `FeatureGate.assertEntitled`. Forgetting the gate is a compile error, not a review gap. The TS type system enforces what the convention could not.
+
+Phase 2 achieves structural enforcement via the plugin host wrapping every contribution. Phase 1 has no host — WP03 is the Phase 1 equivalent: a branded/non-constructible token that makes the gate impossible to skip at the type level.
+
+---
+
+## Subtasks
+
+---
+
+### T015: Define the opaque `GateToken` type
+
+**Purpose**: Introduce a non-constructible branded type that only `FeatureGate.assertEntitled` (WP02) can produce. Nothing outside `src/entitlements/feature-gate.ts` can create a valid `GateToken`, so a gated entrypoint that requires one cannot be reached without passing through the gate.
+
+**TypeScript technique — private-constructor class (recommended)**:
+
+```typescript
+// src/entitlements/gate-token.ts
+
+/**
+ * GateToken — an un-forgeable proof that FeatureGate.assertEntitled
+ * was called and succeeded for a specific (subject, featureKey) pair.
+ *
+ * The constructor is private. The only way to obtain a GateToken is to
+ * call FeatureGate.assertEntitled(), which mints one on success.
+ *
+ * A gated service method that requires a GateToken parameter cannot be
+ * reached without going through FeatureGate — the TS compiler enforces
+ * this, not code review.
+ */
+export class GateToken {
+  /** The subject that was asserted (for audit/logging at the call site). */
+  readonly subject: Subject;
+  /** The feature key that was asserted. */
+  readonly featureKey: FeatureKey;
+  /** Timestamp the token was minted (for freshness checks if desired). */
+  readonly mintedAt: Date;
+
+  // Private constructor — only FeatureGate can call `new GateToken(...)`.
+  // External code cannot import the constructor or use `new GateToken()`
+  // because the constructor is not exported or accessible.
+  private constructor(subject: Subject, featureKey: FeatureKey) {
+    this.subject = subject;
+    this.featureKey = featureKey;
+    this.mintedAt = new Date();
+  }
+
+  /**
+   * Module-private mint. Called only by FeatureGate.assertEntitled().
+   * Not exported from this module — only FeatureGate imports it.
+   *
+   * Using a static factory method keeps the class cleanly non-constructible
+   * externally while giving FeatureGate a single, explicit mint point.
+   */
+  static _mint(subject: Subject, featureKey: FeatureKey): GateToken {
+    return new GateToken(subject, featureKey);
+  }
+}
+```
+
+**Why not a branded interface or `unique symbol`?**
+
+A branded interface (`type GateToken = { readonly _brand: unique symbol }`) can be fabricated at runtime with a cast (`{} as GateToken`) and provides no structural guarantee. A `unique symbol` brand is structurally un-forgeable at the TS level but has no runtime identity (cannot be `instanceof` checked, carries no payload, cannot be logged). The private-constructor class is un-forgeable at both the TS type level (no public constructor) and runtime (`instanceof GateToken` can gate at runtime if needed), and it carries the subject/featureKey for audit logging at the call site without a separate lookup.
+
+**`_mint` naming convention**: The leading underscore signals "do not call from outside the entitlements module." In Phase 2 when the plugin host takes over enforcement, `_mint` is removed and `GateToken` becomes purely internal to the host.
+
+**Files**:
+- `src/entitlements/gate-token.ts` (new, ~40 lines)
+
+**Validation**:
+- [ ] `tsc --noEmit` passes with zero errors
+- [ ] `new GateToken(...)` outside `feature-gate.ts` produces TS error: `Constructor of class 'GateToken' is private`
+- [ ] `GateToken._mint(...)` called from a file that has not imported `_mint` produces TS error (the method is not on the exported type surface — verify this by checking whether `_mint` is accessible through the exported type)
+- [ ] `instanceof GateToken` evaluates correctly at runtime in a test
+
+**Edge Cases**:
+- `GateToken._mint` is a static method on the class, so it IS accessible to any code that imports the class. To prevent external minting, either (a) do not export `_mint` from the module barrel (omit it from `src/entitlements/index.ts`) and have `FeatureGate` import directly from `gate-token.ts`; or (b) enforce via ESLint `no-restricted-imports` rule that only `feature-gate.ts` may import `gate-token.ts`. Document which approach is used.
+- The token does not expire. If a long-running operation holds a token, there is no built-in revocation. This is acceptable for Phase 1 — a token is minted per-call, not cached.
+
+---
+
+### T016: Make every gated entrypoint require a `GateToken` parameter
+
+**Purpose**: Change the type signature of every service or method that constitutes a "gated entrypoint" so that it accepts a `GateToken` as a required parameter. This is the mechanism that makes the TS compiler reject calls that bypass the gate.
+
+**What a "gated entrypoint" is**: Any public API on a service that executes a capability declared as belonging to a licensed add-on feature. In Phase 1, these are the provider/step/connector invocation points (FR-008). The `executeTool()` path gates at a higher level (WP05), but the underlying service methods must also require a token so a second path cannot bypass them.
+
+**Signature change pattern**:
+
+```typescript
+// BEFORE — no gate parameter
+class SearchService {
+  async search(
+    query: string,
+    entitlements: ResolvedEntitlements,
+    options?: SearchOptions,
+  ): Promise<SearchResult[]> { ... }
+}
+
+// AFTER — GateToken required for the gated path
+// Option A: token on the gated method itself (simplest, most explicit)
+class SearchService {
+  async search(
+    query: string,
+    entitlements: ResolvedEntitlements,
+    options?: SearchOptions,
+    _gate?: GateToken,   // ← required for add-on-owned search providers
+  ): Promise<SearchResult[]> { ... }
+}
+
+// Option B (preferred for cleaner separation): separate gated entry
+class SearchService {
+  /** Free-tier (core) search — no gate required */
+  async searchCore(query: string, ...): Promise<SearchResult[]> { ... }
+
+  /** Add-on search (e.g. semantic/vector) — GateToken required */
+  async searchPremium(query: string, gate: GateToken, ...): Promise<SearchResult[]> { ... }
+}
+```
+
+**Recommended approach**: For Phase 1, add `gate: GateToken` as a required parameter on the specific method variant that is being gated (not the core free method). This makes the gated/free split explicit in the type signature. Do not gate core/free methods — they must remain accessible to everyone (FR-007: "core tools are unaffected").
+
+**For `GenerationService.generate()` specifically** (the provider invocation point at `src/content/generation/index.ts:44`):
+
+```typescript
+// AFTER
+async generate(
+  query: string,
+  userId: string,
+  tenantId: string,
+  entitlements: ResolvedEntitlements,
+  gate: GateToken,         // ← required; proves assertEntitled was called
+  options?: GenerateOptions,
+): Promise<GenerationResult> { ... }
+```
+
+**For Inngest step handler execution** (`src/inngest/adapter.ts:64`): The `PipelineStepHandlerAdapter.run()` is the step invocation point. For gated step types, the `ExecutionContext` passed to `handler.execute(config, context)` should carry a `gate: GateToken` field so the handler can require it:
+
+```typescript
+// src/pipelines/types.ts — extend ExecutionContext
+export interface ExecutionContext {
+  tenantId: string;
+  // ... existing fields ...
+  gate?: GateToken;   // present if this step is gated; undefined for free steps
+}
+```
+
+Gated step handlers validate `context.gate instanceof GateToken` at the top of `execute()`.
+
+**Files**:
+- `src/content/generation/index.ts` — add `gate: GateToken` to `GenerationService.generate()`
+- `src/pipelines/types.ts` — extend `ExecutionContext` with optional `gate?: GateToken`
+- `src/pipelines/steps/interface.ts` — update `PipelineStepHandler.execute()` documentation
+- Any connector interface files that declare a gated `connect()` or `fetch()` (see T017 for the enumerated list)
+
+**Validation**:
+- [ ] `tsc --noEmit` passes with zero errors after signature changes
+- [ ] Any existing call to a gated method that does not pass a `GateToken` becomes a TS error — confirm by temporarily removing `gate` from one existing call and verifying the error fires
+- [ ] Free/core methods (those not gated) do not require a `GateToken`
+- [ ] Existing tests that call gated methods need to be updated to pass a fabricated test token — add a `GateToken._mint(testSubject, testFeatureKey)` test helper exported from a `test/helpers/gate-token.ts` fixture
+
+**Edge Cases**:
+- Do not add `GateToken` to the `ResolvedEntitlements` type (WP01 owns that type). The token is a separate, orthogonal proof-of-gate.
+- Some services are already fully internal to a call chain that is always gated at the top (e.g. a connector called only from `GenerationService`). Adding the token to the inner service is belt-and-suspenders. Do it anyway — a future refactor could expose the inner path.
+
+---
+
+### T017: Enumerate Phase-1 gated call sites
+
+**Purpose**: Produce a complete, auditable list of every call site that must require a `GateToken` in Phase 1. Derived from the actual codebase — not inferred from the spec alone.
+
+**Derivation method**: Start from `executeTool()` in `src/tools/executor.ts` and trace every non-OAuth dispatch branch, then follow each executor to the service invocation point. Also trace the Inngest pipeline execution path.
+
+**Enumerated Phase-1 gated call sites**:
+
+| # | Call site | File | Lines | Notes |
+|---|-----------|------|-------|-------|
+| 1 | `content_` tool dispatch → `executeContentTool()` | `src/tools/executor.ts` | 103–110 | Dispatches all `content_*` tools; `content_search` is the live bypass case |
+| 2 | `executeContentTool` → `context.searchService.search()` | `src/tools/executors/content-executor.ts` | 231 | The gated SearchService invocation; currently bypassed (see T018) |
+| 3 | `profile_` tool dispatch → `executeProfileTool()` | `src/tools/executor.ts` | 113–116 | Dispatches all `profile_*` tools; profile capabilities may be gated add-ons |
+| 4 | `pipeline_` tool dispatch → `executePipelineTool()` | `src/tools/executor.ts` | 118–129 | Dispatches all `pipeline_*` tools; advanced pipeline features may be gated |
+| 5 | OAuth-prefix dispatch (jira_, slack_, github_, gmail_, drive_, docs_) | `src/tools/executor.ts` | 133–181 | OAuth tools are currently all free/core; no gate needed in Phase 1, but enumerated so a future add-on OAuth tool has a named insertion point |
+| 6 | `GenerationService.generate()` — provider invocation | `src/content/generation/index.ts` | 44–60 | Calls `this.generator.generate()` → `this.provider.generate()`; gated if the provider is a premium add-on |
+| 7 | `ContentGenerator.generate()` → `provider.generate()` | `src/content/generation/generator.ts` | 27–31 | The actual `GenerationProvider` call; `PlaceholderGenerationProvider` is free, an add-on provider is gated |
+| 8 | Inngest adapter → `handler.execute()` | `src/inngest/adapter.ts` | 64 | Wraps `PipelineStepHandler.execute()` inside `step.run()`; gated step types need `GateToken` in `ExecutionContext` |
+| 9 | `content-audit-pipeline` → `registry.getHandler()` + `.execute()` | `src/inngest/functions/content-audit-pipeline.ts` | 76, 101, 181 | Three step invocations: `fidelity_check`, `content_generation`, `notification` |
+| 10 | `regulatory-change-monitor-pipeline` → `registry.getHandler()` + `.execute()` | `src/inngest/functions/regulatory-change-monitor-pipeline.ts` | 77, 102, 182 | Three step invocations: `source_query`, `content_generation`, `notification` |
+| 11 | `manual-trigger-pipeline` → `registry.getHandler()` + `.execute()` | `src/inngest/functions/manual-trigger-pipeline.ts` | 284 | Generic step execution loop over pipeline steps |
+| 12 | `ConnectorRegistry.getOrThrow()` → connector use | `src/content/connectors/registry.ts` | 21–27 | Connector fetch; a premium connector type (e.g. a proprietary data source) requires a gate before the `getOrThrow` call |
+| 13 | `StepRegistry.getHandler()` → step execution | `src/pipelines/steps/registry.ts` | 24 | Step lookup; gate check goes in the caller (Inngest function) before calling `adapter.run()` |
+
+**Phase-1 gating scope** (which of the above are actually gated vs. free in Phase 1):
+
+For Phase 1 with in-tree add-ons only, the **ownership map** (WP05/T027) determines which tool prefixes and step types belong to licensed features. Call sites 1–4 and 6–11 gate only when the dispatched tool/step/provider declares a `feature_key`. Call sites 5 (OAuth tools) and 12–13 are currently all free-tier; gate logic is a no-op until a premium connector or step type is registered with a `feature_key`.
+
+**What this enumeration is for**: A reviewer completing WP03 checks this list against the implementation to verify that every non-free invocation point either (a) requires a `GateToken` parameter, or (b) is documented as explicitly free/core for Phase 1 with the reason stated.
+
+**Files**:
+- This document (the enumeration is the artifact; no code changes in T017 itself)
+- `src/entitlements/gated-call-sites.ts` (new, ~30 lines) — a comment-only registry of the Phase-1 gated call sites, used by the reviewer and referenced in tests
+
+**Validation**:
+- [ ] Every non-free call site in the table above either requires a `GateToken` at the type level (after T016) or is explicitly documented as free-tier in `gated-call-sites.ts`
+- [ ] The Inngest pipeline invocation points (rows 8–11) are covered — either via `ExecutionContext.gate` or via the Inngest function checking entitlement before calling `adapter.run()`
+- [ ] A reviewer can trace from any tool name dispatched in `executor.ts` to its ultimate service invocation and find a `GateToken` checkpoint without gaps
+
+**Edge Cases**:
+- The `ops_` prefix (dispatch at `executor.ts:99`) routes to `executeOpsTool`. Ops tools are platform-internal (health checks, diagnostics); they do not carry a subject and are never gated. Document this explicitly in `gated-call-sites.ts`.
+- `content_resolve_entitlements` (content-executor.ts line 357) is a diagnostic tool for viewing the user's content entitlements — not an add-on feature. Free, not gated.
+- `content_generate` (content-executor.ts line 428) currently returns a placeholder and notes "GenerationService available in WP12." When `GenerationService` is fully wired, call site 6 activates. The GateToken signature on `GenerationService.generate()` (added in T016) ensures the gate is already in place when that happens.
+
+---
+
+### T018: Fix or quarantine the `content_search` synthetic-entitlement bypass
+
+**Purpose**: The `content_search` case in `content-executor.ts:210–254` fabricates a `ResolvedEntitlements` object and passes it directly to `SearchService.search()`, bypassing the resolver, cache, and any `FeatureGate` check. This must be fixed (route through real entitlement resolution) or explicitly quarantined so it cannot be copied as a template.
+
+**The live bypass — exact code**:
+
+```typescript
+// BEFORE: content-executor.ts:217-231 — the fabricated bypass
+case 'content_search': {
+  // ...
+  if (context.searchService) {
+    const tenantProducts = await db
+      .select({ id: contentProducts.id })
+      .from(contentProducts)
+      .where(and(eq(contentProducts.tenantId, tenantId), eq(contentProducts.isActive, true)));
+
+    // ← THIS IS THE BYPASS: a ResolvedEntitlements object is constructed
+    //   from a raw DB query with no resolver, no cache, no FeatureGate.
+    const entitlements: ResolvedEntitlements = {
+      productIds: tenantProducts.map((p) => p.id),
+      sourceIds: [],
+      profileIds: [],
+      resolvedFrom: 'tool-executor',   // ← not honest: no resolver ran
+      resolvedAt: new Date(),
+    };
+
+    const results = await context.searchService.search(query, entitlements, { ... });
+    // ...
+  }
+}
+```
+
+**Fix path (preferred)**: Route through `EntitlementService` (the content entitlement resolver, which already exists in `src/content/entitlements/`). The content entitlement system gates *data access* (which products/sources a session may query), not feature licensing — so this fix is about making the content gate honest, not about adding a feature gate. The `FeatureGate` for the `content_search` *tool itself* is a separate concern (WP05), applied at the tool dispatch level.
+
+```typescript
+// AFTER: content-executor.ts — route through EntitlementService
+case 'content_search': {
+  if (context.searchService) {
+    // Resolve content entitlements via EntitlementService (cache → resolver → DB)
+    // rather than fabricating them from a raw product query.
+    // EntitlementService is injected into ContentExecutorContext (add to T016/WP05).
+    const entitlements = await context.entitlementService.resolve(userId, tenantId);
+
+    const results = await context.searchService.search(query, entitlements, {
+      limit,
+      offset,
+      sourceId: sourceIds?.[0],
+    });
+    // ... rest unchanged
+  }
+}
+```
+
+This requires adding `entitlementService: EntitlementService` to `ContentExecutorContext` (currently defined at `content-executor.ts:21-26`) and injecting it at the call site in `executor.ts:105-110`.
+
+**Quarantine path (if the fix creates too much coupling before WP05)**: If wiring `EntitlementService` into `ContentExecutorContext` is deferred to WP05, add a prominent quarantine comment and a lint/TODO marker so the pattern is not repeated:
+
+```typescript
+// QUARANTINE: This constructs a ResolvedEntitlements object directly from a DB
+// query, bypassing EntitlementService, the resolver, and any FeatureGate.
+// This is a KNOWN BYPASS documented in Spec 015 FR-016. It exists because
+// EntitlementService is not yet wired into ContentExecutorContext (WP05 fixes this).
+// DO NOT COPY THIS PATTERN. All new code must go through EntitlementService.
+// Tracked: Spec 015 WP03 T018 / WP05 T030.
+// eslint-disable-next-line joyus/no-synthetic-entitlements
+const entitlements: ResolvedEntitlements = { ... };
+```
+
+Add a custom ESLint rule `joyus/no-synthetic-entitlements` that flags inline `ResolvedEntitlements` construction outside of `entitlement*.ts` files. This converts the quarantine into a lint error if anyone copies the pattern.
+
+**Decision**: Fix is preferred if WP05 context injection can be done in the same PR as WP03 (they are adjacent in the dependency graph). Quarantine if WP03 must ship before WP05. Either way, the bypass must not survive un-marked.
+
+**Files**:
+- `src/tools/executors/content-executor.ts` — fix or quarantine (lines 217–231)
+- `src/tools/executors/content-executor.ts` — add `entitlementService?: EntitlementService` to `ContentExecutorContext` (if fixing)
+- `src/tools/executor.ts` — inject `entitlementService` into the `content_` dispatch (lines 103–110, if fixing)
+- `eslint-rules/no-synthetic-entitlements.js` (new, ~30 lines, if quarantining)
+
+**Validation**:
+- [ ] The fabricated `ResolvedEntitlements` literal at content-executor.ts:223 is either gone (replaced by an `EntitlementService.resolve()` call) or surrounded by a quarantine comment + lint suppression with an explicit tracking reference
+- [ ] If fixed: `content_search` passes its integration test with a real (or test-doubled) `EntitlementService`
+- [ ] If quarantined: the ESLint rule fires when an inline `ResolvedEntitlements` literal is added to any non-entitlement file
+- [ ] No regression: `content_search` still returns results for an entitled user (WP06 T038)
+
+**Edge Cases**:
+- The SearchService path (`context.searchService`) and the fallback LIKE-search path (lines 256–312) both serve `content_search`. Only the SearchService path has the bypass — the LIKE-search fallback queries `contentSources` directly (no `ResolvedEntitlements` object). The fix/quarantine applies only to the SearchService branch.
+- `resolvedFrom: 'tool-executor'` in the bypassed code is semantically misleading — it implies the tool executor is a valid resolver origin, which it is not. The fixed version will show `resolvedFrom: 'db'` or `'cache'` from the real EntitlementService.
+
+---
+
+### T019: Unit tests — structural enforcement proof
+
+**Purpose**: Prove, in code, that the GateToken mechanism enforces the FR-016 guarantee: (1) a hand-constructed entitlement object cannot reach a gated path, and (2) a gated capability invoked via a second path (not `tools/call`) is still denied.
+
+**Test 1: Compile-time enforcement (TypeScript)**
+
+This is tested by `tsc --noEmit` as part of the build — not a vitest unit test. Create a file in `test/type-tests/` that attempts to call a gated method without a `GateToken` and verify tsc rejects it:
+
+```typescript
+// test/type-tests/gate-token-forgery.ts
+// This file must NOT compile. Run: tsc --noEmit test/type-tests/gate-token-forgery.ts
+// Expected: error TS2345 or TS2554 on each line marked @ts-expect-error
+
+import { GenerationService } from '../../src/content/generation/index.js';
+import type { ResolvedEntitlements } from '../../src/content/types.js';
+
+declare const svc: GenerationService;
+declare const ent: ResolvedEntitlements;
+
+// @ts-expect-error GateToken missing — must be a compile error
+await svc.generate('query', 'user1', 'tenant1', ent);
+
+// Attempting to forge a GateToken with a plain object:
+// @ts-expect-error plain object is not GateToken
+await svc.generate('query', 'user1', 'tenant1', ent, {} as never);
+```
+
+This test passes if `tsc --noEmit` exits with errors on the `@ts-expect-error` lines (meaning the errors ARE present, which is what we want). If tsc does NOT error, the `@ts-expect-error` suppressions themselves become errors — proving the test is self-enforcing.
+
+**Test 2: Runtime — fabricated object cannot satisfy GateToken**
+
+```typescript
+// test/unit/entitlements/gate-token.test.ts
+import { describe, it, expect } from 'vitest';
+import { GateToken } from '../../../src/entitlements/gate-token.js';
+import type { Subject, FeatureKey } from '../../../src/entitlements/types.js';
+
+describe('GateToken', () => {
+  const subject: Subject = { subject_type: 'user', subject_id: 'user-123' };
+  const featureKey: FeatureKey = 'com.joyus.addon.advanced-search';
+
+  it('cannot be constructed with new outside FeatureGate', () => {
+    // TypeScript prevents this at compile time, but verify at runtime too:
+    // @ts-expect-error testing private constructor
+    expect(() => new GateToken(subject, featureKey)).toThrow();
+    // OR: if TS catches it at compile time, this test simply documents the intent.
+  });
+
+  it('_mint produces a valid GateToken', () => {
+    const token = GateToken._mint(subject, featureKey);
+    expect(token).toBeInstanceOf(GateToken);
+    expect(token.subject).toEqual(subject);
+    expect(token.featureKey).toBe(featureKey);
+    expect(token.mintedAt).toBeInstanceOf(Date);
+  });
+
+  it('instanceof check distinguishes a real token from a plain object', () => {
+    const fake = { subject, featureKey, mintedAt: new Date() };
+    const real = GateToken._mint(subject, featureKey);
+    expect(real instanceof GateToken).toBe(true);
+    expect(fake instanceof GateToken).toBe(false);
+  });
+});
+```
+
+**Test 3: Runtime — second-path gating (the FR-016 structural guarantee)**
+
+This test proves that a gated capability reached via a path OTHER than `tools/call` (e.g. directly calling `GenerationService.generate()` from an Inngest pipeline step) is still denied if no valid `GateToken` is provided.
+
+```typescript
+// test/unit/entitlements/structural-enforcement.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { GenerationService } from '../../../src/content/generation/index.js';
+import { GateToken } from '../../../src/entitlements/gate-token.js';
+
+describe('Structural gate enforcement', () => {
+  it('denies GenerationService.generate() when called without a GateToken', async () => {
+    const mockSearchService = { search: vi.fn() };
+    const mockProvider = { generate: vi.fn() };
+    const mockDb = {} as never;
+    const svc = new GenerationService(mockSearchService as never, mockProvider, mockDb);
+
+    const subject = { subject_type: 'user' as const, subject_id: 'user-abc' };
+    const entitlements = { productIds: [], sourceIds: [], profileIds: [],
+      resolvedFrom: 'test', resolvedAt: new Date() };
+
+    // TypeScript prevents this call from even compiling without a GateToken.
+    // At runtime, if somehow reached (e.g. via `any` cast), the service must
+    // detect the missing/invalid token and throw.
+    await expect(
+      // @ts-expect-error deliberate missing GateToken
+      svc.generate('query', 'user-abc', 'tenant-abc', entitlements)
+    ).rejects.toThrow(/GateToken required/);
+  });
+
+  it('allows GenerationService.generate() with a valid GateToken', async () => {
+    // ... normal success path with GateToken._mint(subject, featureKey)
+    // ... verify mockProvider.generate was called
+  });
+
+  it('rejects a plain-object forgery even if TypeScript is bypassed', async () => {
+    // Simulate `any`-cast forgery at runtime:
+    const forgery = { subject: {}, featureKey: 'x', mintedAt: new Date() };
+    await expect(
+      (svc.generate as Function)('q', 'u', 't', entitlements, forgery)
+    ).rejects.toThrow(/GateToken required/);
+  });
+});
+```
+
+**Runtime guard in gated methods**: For the runtime tests to pass, gated service methods must include an explicit runtime check alongside the TS type:
+
+```typescript
+// Inside GenerationService.generate() — the runtime guard
+async generate(
+  query: string,
+  userId: string,
+  tenantId: string,
+  entitlements: ResolvedEntitlements,
+  gate: GateToken,
+  options?: GenerateOptions,
+): Promise<GenerationResult> {
+  // Runtime enforcement (defends against `any`-cast bypasses):
+  if (!(gate instanceof GateToken)) {
+    throw new Error('GateToken required — call FeatureGate.assertEntitled() first');
+  }
+  // ... rest of implementation
+}
+```
+
+**Files**:
+- `test/type-tests/gate-token-forgery.ts` (new, ~20 lines) — compile-time proof
+- `test/unit/entitlements/gate-token.test.ts` (new, ~40 lines)
+- `test/unit/entitlements/structural-enforcement.test.ts` (new, ~60 lines)
+
+**Validation**:
+- [ ] `tsc --noEmit test/type-tests/gate-token-forgery.ts` exits with errors (proving the type constraint is real)
+- [ ] `vitest run test/unit/entitlements/gate-token.test.ts` passes
+- [ ] `vitest run test/unit/entitlements/structural-enforcement.test.ts` passes
+- [ ] The "second path" test (calling `GenerationService.generate()` directly, not via `executeTool`) proves the gate holds even outside the MCP dispatch path
+
+**Edge Cases**:
+- `GateToken._mint` is accessible to tests since tests import directly from `gate-token.ts`. This is intentional — tests need a way to create valid tokens to exercise the success paths. Do not prevent tests from minting tokens.
+- The compile-time type test and the runtime vitest tests are complementary, not redundant: the type test proves TS rejects forgeries; the runtime test proves `any`-cast bypasses are caught at runtime.
+
+---
+
+## Definition of Done
+
+- [ ] `src/entitlements/gate-token.ts` — `GateToken` class with private constructor, `_mint()`, `subject`, `featureKey`, `mintedAt` fields
+- [ ] `GateToken._mint()` is called only from `FeatureGate.assertEntitled()` (WP02) — enforced by lint rule or module structure
+- [ ] Every Phase-1 gated entrypoint listed in T017 requires a `GateToken` at the type level (TS error without one) AND validates `instanceof GateToken` at runtime
+- [ ] `src/entitlements/gated-call-sites.ts` — comment registry of the 13 enumerated call sites with free/gated classification
+- [ ] `content-executor.ts:223-231` — either fixed (routes through `EntitlementService`) or explicitly quarantined with a lint rule preventing copy-paste
+- [ ] `test/type-tests/gate-token-forgery.ts` — tsc rejects forgery attempts
+- [ ] `test/unit/entitlements/gate-token.test.ts` — runtime token behavior confirmed
+- [ ] `test/unit/entitlements/structural-enforcement.test.ts` — second-path denial confirmed
+- [ ] `npm run validate` (typecheck + lint + test) exits 0 with no regressions
+
+---
+
+## Risks
+
+- **`_mint` accessibility**: The static `_mint` method is accessible to any importer of `gate-token.ts`. If the ESLint rule or module-structure restriction is not implemented, nothing mechanically prevents misuse. Decide and document the enforcement approach in the PR.
+- **`any`-cast bypasses**: TypeScript's structural guarantee only holds for correctly-typed code. A `as any` cast can bypass the type check at the callsite. The runtime `instanceof` guard (T019) is the defense against this; do not omit it.
+- **content_search regression**: Fixing the bypass (T018) changes how `content_search` resolves its entitlements. If `EntitlementService` is not injected correctly, `content_search` will break for all users. WP06 T038 is the regression gate — do not close WP03 until T038 passes.
+- **Inngest step gate coverage**: Steps invoked via the Inngest adapter (call sites 8–11) run asynchronously, possibly after the original `executeTool()` call has returned. The `GateToken` passed through `ExecutionContext` was minted at dispatch time, not at execution time. If a grant is revoked between dispatch and execution, the token is stale. For Phase 1 this is acceptable (document the staleness window = Inngest retry delay + execution time); the per-call gate check in WP05 is the primary enforcement for synchronous paths.
+- **Phase 2 migration**: When the plugin host (Phase 2) takes over enforcement, `GateToken._mint` should be removed or made truly inaccessible (no longer needed since the host wraps contributions). Annotate the token with a `// TODO(Phase-2): remove _mint when plugin host gates contributions` comment.
+
+---
+
+## Reviewer Guidance
+
+The single question to answer when reviewing this WP: **Can a gated capability be reached without a `GateToken` minted by `FeatureGate.assertEntitled()`?**
+
+Trace each of the 13 call sites in T017 and answer yes or no:
+- If yes — it is a gap; request a fix before merging.
+- If no — verify the `instanceof GateToken` runtime guard is present, not just the TypeScript type.
+
+Specific checks:
+1. `GateToken` constructor is `private` — verify by attempting `new GateToken(...)` in a test file and confirming the TS error.
+2. `_mint` is only called from `src/entitlements/feature-gate.ts` — grep the codebase for `_mint(` and verify no other caller exists.
+3. `content-executor.ts:223` — verify the fabricated literal is gone or quarantined with a lint suppression and a tracking comment. A bare `resolvedFrom: 'tool-executor'` in a `ResolvedEntitlements` literal is the tell.
+4. The Inngest execution path (call sites 8–11) — confirm that `ExecutionContext.gate` is set before `adapter.run()` is called in each Inngest function, and that gated step handlers check `context.gate instanceof GateToken`.
+5. `structural-enforcement.test.ts` — the "second path" test is the structural proof that FR-016 requires. Verify it calls `GenerationService.generate()` directly (not via `executeTool`), not just the MCP dispatch path.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP04-operator-grant-admin.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP04-operator-grant-admin.md
@@ -1,0 +1,891 @@
+---
+work_package_id: "WP04"
+title: "Operator Grant Administration (write path)"
+lane: "planned"
+dependencies: ["WP01", "WP02"]
+subtasks: ["T020", "T021", "T022", "T023", "T024", "T025", "T026"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP04: Operator Grant Administration (write path)
+
+**Implementation command**: `spec-kitty implement WP04`
+**Target repo**: `joyus-ai`
+**Dependencies**: WP01 (schema + types), WP02 (FeatureGate + subject-scoped cache)
+**Priority**: P1 — creates grants (Scenario 1). Without this, Phase 1 can enforce grants but cannot create them through any defined interface.
+
+## Objective
+
+Build the authorized write surface for `feature_entitlements` and `feature_catalog`: a `GrantsService`, a `CatalogService`, operator REST endpoints, and admin-only MCP tools. Every mutating operation is idempotent, carries actor identity in the audit trail, and triggers subject-cache invalidation on WP02's cache so revocations take effect before TTL expiry on the local node.
+
+This is also the boundary where billing automation later attaches (`source=resolver|import`). The design must not bake in assumptions that make that harder.
+
+## Context
+
+### Auth model in the codebase today
+
+The codebase has **no operator/admin role**. The `users` table (`src/db/schema.ts:54-60`) has only `id`, `email`, `name`, `mcpToken`, `createdAt`, `updatedAt` — no `isOperator`, no `role` column. Authentication is bearer-token-via-`mcpToken` (`src/auth/verify.ts:26-33`), which resolves to `req.mcpUser` (a `UserWithConnections`) via `requireBearerToken` middleware (`src/auth/middleware.ts:26-48`). Every authenticated user is a peer — there is no privileged tier.
+
+**This WP must define the operator/admin boundary.** The minimum viable approach is an **env-var allowlist**: `OPERATOR_USER_IDS=id1,id2,...` loaded at startup. A middleware reads this set and rejects any `req.mcpUser.id` not in it with 403. This requires zero schema migration, ships fast, and can be replaced later with `users.isOperator` column + a migration once the need for self-serve operator promotion is clear. The implementer must **confirm this decision** before wiring middleware — the alternative (adding `isOperator: boolean` to the `users` table, `src/db/schema.ts`) is equally valid and preferable if the operator set needs to be managed without a redeploy.
+
+**Precedent for a distinct admin tier:** `index.ts:373-405` already implements a separate `/event-adapter/admin` route protected by `session.adminUserId` (a session-cookie-based admin gate, distinct from bearer auth). This WP's operator gate follows the same principle — a distinct check, not reuse of the tenant-user bearer path — but uses the bearer token plus the operator check rather than session cookies, since the MCP and REST surfaces both expect bearer auth.
+
+**The crux of the security model:** A tenant user's bearer token must never satisfy the operator check. The operator check must be applied as a **separate, explicit middleware** layered on top of `requireBearerToken` — not as a conditional inside route handlers where it could be skipped.
+
+### Existing patterns to follow
+
+- **ToolDefinition shape** (`src/tools/index.ts:19-27`): `{ name, description, inputSchema: { type: 'object', properties, required? } }`. Admin MCP tools follow this exactly.
+- **Bearer token auth** (`src/auth/middleware.ts`): `requireBearerToken` sets `req.mcpUser`. Admin routes add `requireOperator` after this.
+- **Route mounting** (`src/index.ts:309-335`): routes are mounted with `app.use('/path', middleware, router)`. Admin entitlement routes mount as `/api/v1/admin/entitlements` and `/api/v1/admin/catalog`.
+- **Drizzle ORM** (`src/content/schema.ts`): CUID2 PKs, `$inferSelect`/`$inferInsert` types, `pgSchema` namespace. The `entitlements` schema was introduced by WP01.
+- **Content module init pattern** (`src/content/index.js`): modules export an `initializeXxx` function called from `index.ts`. This WP's services wire the same way.
+
+### Subject-cache invalidation hook (WP02 dependency)
+
+WP02 (`FeatureGate` + `EntitlementCache`) must expose an explicit `invalidateSubject(subject: Subject): void` method. WP04 calls this after every `GrantsService.grant()`, `modify()`, and `revoke()`. If WP02 has not landed yet, stub the call — but do not skip it. This is the invalidation on the local node; cross-instance propagation is TTL-bounded (FR-018, accepted as Phase 1 baseline).
+
+---
+
+## Subtasks
+
+### T020: `GrantsService` — idempotent grant/modify/revoke with actor audit
+
+**Purpose**: The single authoritative write surface for `feature_entitlements` rows. Every operation is idempotent (safe to retry), records actor identity to `entitlement_decisions` (or a grant-history log), and returns the current post-operation row.
+
+**Steps**:
+1. Create `src/entitlements/grants.service.ts`.
+2. Inject `DrizzleClient` and the WP02 `FeatureGate` (for cache invalidation) via constructor.
+3. Implement `grant`, `modify`, and `revoke` as described below.
+4. Write a grant-history record on every mutation using WP01's `entitlements.entitlement_decisions` table — this is the audit trail for FR-015. The record carries: `subject_type`, `subject_id`, `feature_key`, `decision='allow'|'deny'` (for grant) or a grant-lifecycle action (for modify/revoke), `reason`, `resolved_from='db'`, and the `actorId` in `metadata` (or a dedicated `actor_id` column if WP01 adds one — confirm with WP01 implementer).
+5. After every mutating DB write, call `featureGate.invalidateSubject(subject)`.
+
+**Idempotency contract:**
+
+The `UNIQUE (subject_type, subject_id, feature_key)` constraint (WP01 `data-model.md`) means there is exactly one live row per subject+feature. All three operations implement an **upsert/transition** pattern — they never error on "already in that state":
+
+```typescript
+// src/entitlements/grants.service.ts
+
+import { createId } from '@paralleldrive/cuid2';
+import { and, eq } from 'drizzle-orm';
+
+import type { DrizzleClient } from '../db/types.js';
+import type { FeatureGate } from './gate.js';            // WP02
+import {
+  featureEntitlements,
+  entitlementDecisions,
+} from './schema.js';                                     // WP01
+import type {
+  Subject,
+  FeatureKey,
+  GrantSource,
+  GrantStatus,
+} from './types.js';                                     // WP01
+
+export interface GrantInput {
+  subject: Subject;
+  featureKey: FeatureKey;
+  source: GrantSource;                // 'admin' | 'resolver' | 'trial' | 'import'
+  validFrom?: Date;                   // defaults to now()
+  validUntil?: Date | null;           // null = perpetual
+  limits?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ModifyInput {
+  subject: Subject;
+  featureKey: FeatureKey;
+  validUntil?: Date | null;
+  limits?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  status?: GrantStatus;
+}
+
+export class GrantsService {
+  constructor(
+    private readonly db: DrizzleClient,
+    private readonly featureGate: FeatureGate,           // for cache invalidation
+    private readonly actorId: string,                    // operator user id — set per-request
+  ) {}
+
+  /**
+   * Create or reactivate a grant (upsert by subject+featureKey).
+   * If a row already exists (any status), transitions it to 'active' with the new params.
+   * Idempotent: calling with the same inputs leaves the row unchanged and is not an error.
+   */
+  async grant(input: GrantInput): Promise<typeof featureEntitlements.$inferSelect> {
+    const now = new Date();
+    const validFrom = input.validFrom ?? now;
+
+    const existing = await this.findExisting(input.subject, input.featureKey);
+
+    let row: typeof featureEntitlements.$inferSelect;
+
+    if (!existing) {
+      const [inserted] = await this.db
+        .insert(featureEntitlements)
+        .values({
+          id: createId(),
+          subjectType: input.subject.subjectType,
+          subjectId: input.subject.subjectId,
+          featureKey: input.featureKey,
+          status: 'active',
+          validFrom,
+          validUntil: input.validUntil ?? null,
+          source: input.source,
+          limits: input.limits ?? null,
+          metadata: input.metadata ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      row = inserted;
+    } else {
+      const [updated] = await this.db
+        .update(featureEntitlements)
+        .set({
+          status: 'active',
+          validFrom,
+          validUntil: input.validUntil ?? null,
+          source: input.source,
+          limits: input.limits ?? null,
+          metadata: input.metadata ?? null,
+          updatedAt: now,
+        })
+        .where(eq(featureEntitlements.id, existing.id))
+        .returning();
+      row = updated;
+    }
+
+    await this.writeAudit(input.subject, input.featureKey, 'grant', 'entitled');
+    this.featureGate.invalidateSubject(input.subject);
+
+    return row;
+  }
+
+  /**
+   * Modify an existing grant's window, limits, or status.
+   * No-ops gracefully if the row does not exist (returns null).
+   */
+  async modify(input: ModifyInput): Promise<typeof featureEntitlements.$inferSelect | null> {
+    const existing = await this.findExisting(input.subject, input.featureKey);
+    if (!existing) return null;
+
+    const [updated] = await this.db
+      .update(featureEntitlements)
+      .set({
+        ...(input.validUntil !== undefined ? { validUntil: input.validUntil } : {}),
+        ...(input.limits !== undefined ? { limits: input.limits } : {}),
+        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+        ...(input.status !== undefined ? { status: input.status } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(featureEntitlements.id, existing.id))
+      .returning();
+
+    await this.writeAudit(input.subject, input.featureKey, 'modify', 'entitled');
+    this.featureGate.invalidateSubject(input.subject);
+
+    return updated;
+  }
+
+  /**
+   * Revoke a grant — transitions status to 'revoked'.
+   * Idempotent: if already revoked or absent, is a no-op.
+   */
+  async revoke(
+    subject: Subject,
+    featureKey: FeatureKey,
+  ): Promise<typeof featureEntitlements.$inferSelect | null> {
+    const existing = await this.findExisting(subject, featureKey);
+    if (!existing || existing.status === 'revoked') return existing ?? null;
+
+    const [updated] = await this.db
+      .update(featureEntitlements)
+      .set({ status: 'revoked', updatedAt: new Date() })
+      .where(eq(featureEntitlements.id, existing.id))
+      .returning();
+
+    await this.writeAudit(subject, featureKey, 'revoke', 'not_entitled');
+    this.featureGate.invalidateSubject(subject);
+
+    return updated;
+  }
+
+  /** List all grants for a subject (all statuses). */
+  async listForSubject(
+    subject: Subject,
+  ): Promise<Array<typeof featureEntitlements.$inferSelect>> {
+    return this.db
+      .select()
+      .from(featureEntitlements)
+      .where(
+        and(
+          eq(featureEntitlements.subjectType, subject.subjectType),
+          eq(featureEntitlements.subjectId, subject.subjectId),
+        ),
+      );
+  }
+
+  private async findExisting(subject: Subject, featureKey: FeatureKey) {
+    const [row] = await this.db
+      .select()
+      .from(featureEntitlements)
+      .where(
+        and(
+          eq(featureEntitlements.subjectType, subject.subjectType),
+          eq(featureEntitlements.subjectId, subject.subjectId),
+          eq(featureEntitlements.featureKey, featureKey),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
+  private async writeAudit(
+    subject: Subject,
+    featureKey: FeatureKey,
+    action: string,
+    decision: 'allow' | 'deny' | 'entitled' | 'not_entitled',
+  ): Promise<void> {
+    await this.db.insert(entitlementDecisions).values({
+      id: createId(),
+      subjectType: subject.subjectType,
+      subjectId: subject.subjectId,
+      featureKey,
+      decision: decision === 'entitled' || decision === 'allow' ? 'allow' : 'deny',
+      reason: decision === 'entitled' ? 'entitled' : 'not_entitled',
+      resolvedFrom: 'db',
+      capability: `admin:${action}`,
+      sessionId: null,
+      createdAt: new Date(),
+      // actor identity carried in capability field as 'admin:grant|modify|revoke'
+      // If WP01 adds a dedicated actor_id column, store this.actorId there instead.
+    });
+  }
+}
+```
+
+**DECISION REQUIRED — actor identity in audit:**
+The `entitlement_decisions` schema in WP01 (`data-model.md`) does not include an `actor_id` column. FR-015 requires "actor identity" in every grant write. Options:
+- (A) Add `actor_id text NULL` to `entitlement_decisions` in WP01 and record `this.actorId` there. **Recommended** — makes actor queryable.
+- (B) Embed actor in `capability` field as a structured string (e.g. `admin:grant:userId`). Zero schema change; harder to query.
+
+Confirm with WP01 implementer before landing. The `GrantsService` code above uses option B as a fallback but is written to easily adopt A.
+
+**Files**:
+- `src/entitlements/grants.service.ts` (new, ~140 lines)
+
+**Validation**:
+- [ ] `tsc --noEmit` passes with zero errors
+- [ ] `grant()` with no existing row inserts a new `active` row
+- [ ] `grant()` with an existing `revoked` row transitions it to `active` (no duplicate row)
+- [ ] `revoke()` called twice on the same subject+feature is a no-op on the second call
+- [ ] Every mutation writes one row to `entitlement_decisions`
+- [ ] `featureGate.invalidateSubject()` is called on every mutation
+
+**Edge Cases**:
+- `validFrom` default is `now()` — callers that set a future `validFrom` are creating a not-yet-active grant; the resolver must filter `valid_from <= now()` as well as `valid_until` (confirm in WP02 resolver).
+- The `GrantsService` is **not a singleton** — it is instantiated per-request with the requesting actor's `actorId`. Do not store actor state on a shared service instance.
+- `featureKey` FK → `feature_catalog` (RESTRICT on delete): inserting a grant for an unknown `featureKey` will fail at the DB level with a FK violation. Routes must handle this and return 422.
+
+---
+
+### T021: `CatalogService` — create and list `feature_catalog` entries
+
+**Purpose**: Manage the authoritative list of licensable features. Operators need to register a feature before they can grant it.
+
+**Steps**:
+1. Create `src/entitlements/catalog.service.ts`.
+2. Implement `create` and `list` methods against `entitlements.feature_catalog` (WP01 schema).
+3. `create` is idempotent on `feature_key` (PK): attempt insert; if PK collision, return existing row (do not error).
+4. `list` supports optional `status` filter (`active`/`deprecated`/`withdrawn`).
+
+```typescript
+// src/entitlements/catalog.service.ts
+
+import { createId } from '@paralleldrive/cuid2';
+import { eq } from 'drizzle-orm';
+
+import type { DrizzleClient } from '../db/types.js';
+import { featureCatalog } from './schema.js';             // WP01
+import type { FeatureKey } from './types.js';             // WP01
+
+export interface CreateCatalogEntryInput {
+  featureKey: FeatureKey;           // e.g. 'com.joyus.addon.advanced-pipelines'
+  displayName: string;
+  description?: string;
+  publisher: string;                // 'joyus' for first-party
+  capabilityKinds: string[];        // ['tool', 'provider', ...]
+  status?: 'active' | 'deprecated' | 'withdrawn';
+}
+
+export class CatalogService {
+  constructor(private readonly db: DrizzleClient) {}
+
+  /**
+   * Register a new feature in the catalog.
+   * If the feature_key already exists, returns the existing row (idempotent).
+   * Note: feature keys are never reused — 'withdrawn' entries block reinsertion at the PK level.
+   */
+  async create(
+    input: CreateCatalogEntryInput,
+  ): Promise<typeof featureCatalog.$inferSelect> {
+    const existing = await this.findByKey(input.featureKey);
+    if (existing) return existing;
+
+    const now = new Date();
+    const [inserted] = await this.db
+      .insert(featureCatalog)
+      .values({
+        featureKey: input.featureKey,
+        displayName: input.displayName,
+        description: input.description ?? null,
+        publisher: input.publisher,
+        capabilityKinds: input.capabilityKinds,
+        status: input.status ?? 'active',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    return inserted;
+  }
+
+  /** List catalog entries, optionally filtered by status. */
+  async list(
+    statusFilter?: 'active' | 'deprecated' | 'withdrawn',
+  ): Promise<Array<typeof featureCatalog.$inferSelect>> {
+    if (statusFilter) {
+      return this.db
+        .select()
+        .from(featureCatalog)
+        .where(eq(featureCatalog.status, statusFilter));
+    }
+    return this.db.select().from(featureCatalog);
+  }
+
+  private async findByKey(
+    featureKey: FeatureKey,
+  ): Promise<typeof featureCatalog.$inferSelect | null> {
+    const [row] = await this.db
+      .select()
+      .from(featureCatalog)
+      .where(eq(featureCatalog.featureKey, featureKey))
+      .limit(1);
+    return row ?? null;
+  }
+}
+```
+
+**Files**:
+- `src/entitlements/catalog.service.ts` (new, ~60 lines)
+
+**Validation**:
+- [ ] `create()` with a new `featureKey` inserts and returns the row
+- [ ] `create()` called twice with the same `featureKey` returns the same row, no duplicate
+- [ ] `list({ status: 'active' })` returns only active entries
+- [ ] `tsc --noEmit` passes
+
+**Edge Cases**:
+- A `withdrawn` feature key cannot be re-registered (PK collision → returns the withdrawn row). The caller sees the withdrawn row and should treat it as a permanent tombstone, not a conflict to retry.
+
+---
+
+### T022: Operator REST routes for grants and catalog
+
+**Purpose**: HTTP surface for operator tooling, billing automation (`source=import`), and CLI scripts. Admin-only: guarded by `requireBearerToken` + `requireOperator`.
+
+**Steps**:
+1. Create `src/entitlements/admin-routes.ts` exporting `createAdminEntitlementsRouter(services)`.
+2. Mount at `/api/v1/admin/entitlements` in `src/index.ts` (before the generic `/api` bearer router at line 335, following the content-route precedent at line 321).
+3. Use Zod validation from WP01 (`validation.ts`) for all request bodies.
+4. Return structured JSON errors on validation failure (422) and FK violation (422 "unknown feature_key").
+
+**Routes**:
+
+```
+POST   /api/v1/admin/entitlements/catalog
+         Body: CreateCatalogEntryInput
+         → 201 { entry }
+
+GET    /api/v1/admin/entitlements/catalog
+         Query: ?status=active|deprecated|withdrawn
+         → 200 { entries: [] }
+
+POST   /api/v1/admin/entitlements/grants
+         Body: { subject_type, subject_id, feature_key, source, valid_from?, valid_until?, limits?, metadata? }
+         → 201 { grant }
+
+PATCH  /api/v1/admin/entitlements/grants
+         Body: { subject_type, subject_id, feature_key, valid_until?, limits?, status? }
+         → 200 { grant } | 404 if not found
+
+DELETE /api/v1/admin/entitlements/grants
+         Body: { subject_type, subject_id, feature_key }
+         → 200 { grant } | 200 { revoked: false } if already absent
+
+GET    /api/v1/admin/entitlements/grants
+         Query: ?subject_type=&subject_id=
+         → 200 { grants: [] }
+```
+
+**Sketch** (router factory pattern, matching `createPipelineRouter` / `createAdminRouter`):
+
+```typescript
+// src/entitlements/admin-routes.ts
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { requireBearerToken } from '../auth/middleware.js';
+import { requireOperator } from './operator-auth.js';        // T024
+import type { GrantsService } from './grants.service.js';
+import type { CatalogService } from './catalog.service.js';
+
+export function createAdminEntitlementsRouter(services: {
+  getGrantsService: (actorId: string) => GrantsService;     // factory — injects actorId per request
+  catalogService: CatalogService;
+}): Router {
+  const router = Router();
+
+  // All routes require bearer auth + operator role
+  router.use(requireBearerToken, requireOperator);
+
+  router.post('/catalog', async (req, res) => { /* ... */ });
+  router.get('/catalog', async (req, res) => { /* ... */ });
+  router.post('/grants', async (req, res) => { /* ... */ });
+  router.patch('/grants', async (req, res) => { /* ... */ });
+  router.delete('/grants', async (req, res) => { /* ... */ });
+  router.get('/grants', async (req, res) => { /* ... */ });
+
+  return router;
+}
+```
+
+**Files**:
+- `src/entitlements/admin-routes.ts` (new, ~130 lines)
+- `src/index.ts` (modified: add `app.use('/api/v1/admin/entitlements', createAdminEntitlementsRouter(...))`)
+
+**Validation**:
+- [ ] A valid operator token + valid body → 201/200 with the expected shape
+- [ ] A valid but non-operator bearer token → 403
+- [ ] No bearer token → 401 (from `requireBearerToken`)
+- [ ] Body missing required fields → 422 with Zod error detail
+- [ ] Grant with unknown `feature_key` → 422 "unknown_feature_key"
+
+**Edge Cases**:
+- `DELETE /grants` uses a request body (non-standard but consistent). If HTTP client constraints are a concern, an alternative is `POST /grants/revoke`. Decide and document.
+- Mount **before** `app.use('/api', requireBearerToken, ...)` (line 335 in `index.ts`) to avoid double middleware application.
+
+---
+
+### T023: Admin-only MCP tools for grants and catalog
+
+**Purpose**: Expose grant administration through the MCP surface so operators can manage entitlements directly from Claude Desktop or the Joyus AI MCP client, without switching to a separate HTTP tool.
+
+**Steps**:
+1. Create `src/tools/admin-entitlement-tools.ts` exporting `adminEntitlementTools: ToolDefinition[]`.
+2. Add `entitlement_admin_grant`, `entitlement_admin_revoke`, `entitlement_admin_list_grants`, `entitlement_admin_register_feature`, `entitlement_admin_list_catalog` tools matching the `ToolDefinition` shape exactly (`src/tools/index.ts:19-27`).
+3. Create `src/tools/executors/admin-entitlement-executor.ts` with `executeAdminEntitlementTool`.
+4. Wire into `executeTool` (`src/tools/executor.ts`): add an `entitlement_admin_` prefix branch — **after** the operator check confirms `req.mcpUser` is an operator (see T024).
+5. Wire into `getAllTools` (`src/tools/index.ts`): admin tools are included **only** for operator users; non-operator users must not see them in `tools/list`.
+
+**Tool definitions**:
+
+```typescript
+// src/tools/admin-entitlement-tools.ts
+import { ToolDefinition } from './index.js';
+
+export const adminEntitlementTools: ToolDefinition[] = [
+  {
+    name: 'entitlement_admin_grant',
+    description:
+      'OPERATOR ONLY. Grant a feature entitlement to a subject (user or tenant). ' +
+      'Idempotent — reactivates an existing revoked grant rather than creating a duplicate.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        subject_type: { type: 'string', enum: ['user', 'tenant'], description: 'Subject kind.' },
+        subject_id: { type: 'string', description: 'User ID or tenant ID.' },
+        feature_key: { type: 'string', description: 'Reverse-DNS feature key, e.g. com.joyus.addon.advanced-pipelines.' },
+        source: { type: 'string', enum: ['admin', 'trial', 'import'], description: 'Grant provenance.' },
+        valid_until: { type: 'string', description: 'ISO 8601 expiry datetime. Omit for perpetual.' },
+        limits: { type: 'object', description: 'Optional quota envelope, e.g. {"maxRunsPerMonth": 1000}.' },
+      },
+      required: ['subject_type', 'subject_id', 'feature_key', 'source'],
+    },
+  },
+  {
+    name: 'entitlement_admin_revoke',
+    description:
+      'OPERATOR ONLY. Revoke a feature entitlement. Idempotent. Cache is invalidated immediately on this node.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        subject_type: { type: 'string', enum: ['user', 'tenant'] },
+        subject_id: { type: 'string' },
+        feature_key: { type: 'string' },
+      },
+      required: ['subject_type', 'subject_id', 'feature_key'],
+    },
+  },
+  {
+    name: 'entitlement_admin_list_grants',
+    description: 'OPERATOR ONLY. List all grants for a subject (all statuses).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        subject_type: { type: 'string', enum: ['user', 'tenant'] },
+        subject_id: { type: 'string' },
+      },
+      required: ['subject_type', 'subject_id'],
+    },
+  },
+  {
+    name: 'entitlement_admin_register_feature',
+    description:
+      'OPERATOR ONLY. Register a new feature in the catalog. Idempotent on feature_key.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        feature_key: { type: 'string' },
+        display_name: { type: 'string' },
+        description: { type: 'string' },
+        publisher: { type: 'string' },
+        capability_kinds: {
+          type: 'array',
+          items: { type: 'string', enum: ['tool', 'provider', 'pipeline_step', 'connector', 'hook'] },
+        },
+      },
+      required: ['feature_key', 'display_name', 'publisher', 'capability_kinds'],
+    },
+  },
+  {
+    name: 'entitlement_admin_list_catalog',
+    description: 'OPERATOR ONLY. List registered features in the catalog.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', enum: ['active', 'deprecated', 'withdrawn'] },
+      },
+      required: [],
+    },
+  },
+];
+```
+
+**Wire-in to `getAllTools`** (`src/tools/index.ts`):
+```typescript
+// Add parameter: isOperator: boolean
+export async function getAllTools(userId: string, isOperator: boolean = false): Promise<ToolDefinition[]> {
+  // ... existing logic ...
+  if (isOperator) {
+    tools.push(...adminEntitlementTools);
+  }
+  return tools;
+}
+```
+
+The MCP request handler in `index.ts` must pass `isOperatorUser(req.mcpUser.id)` as the second arg.
+
+**Files**:
+- `src/tools/admin-entitlement-tools.ts` (new, ~70 lines)
+- `src/tools/executors/admin-entitlement-executor.ts` (new, ~60 lines)
+- `src/tools/index.ts` (modified: import + `getAllTools` signature + conditional push)
+- `src/tools/executor.ts` (modified: `entitlement_admin_` branch)
+
+**Validation**:
+- [ ] A non-operator user's `tools/list` response does not include `entitlement_admin_*` tools
+- [ ] An operator user's `tools/list` includes all five admin tools
+- [ ] `entitlement_admin_grant` with a valid payload executes without error
+- [ ] `entitlement_admin_grant` called by a non-operator via the MCP tool path → error (the prefix branch must check operator status before dispatching)
+
+---
+
+### T024: Authorization — operator/admin role distinct from tenant users
+
+**Purpose**: Define and enforce the operator boundary so no tenant user can invoke the grant surface, regardless of how they authenticate.
+
+**Decision required (implementer must confirm before coding):**
+
+**Option A — env-var allowlist (recommended for Phase 1):**
+```
+OPERATOR_USER_IDS=cuid_abc123,cuid_def456
+```
+`requireOperator` middleware reads this at startup into a `Set<string>` and checks `req.mcpUser.id` against it. Zero schema changes. Safe to ship fast. Operationally requires a redeploy to add/remove operators, which is acceptable for the small operator set in Phase 1.
+
+**Option B — `users.isOperator` column:**
+Add `isOperator: boolean('is_operator').notNull().default(false)` to `src/db/schema.ts` (the `users` table at line 54). Generate a Drizzle migration. `requireOperator` fetches the user record and checks the field. Enables self-serve operator promotion without redeploy. Adds a migration and a DB read per admin request.
+
+**Recommendation:** Start with Option A. Add a `TODO: migrate to Option B when operator set exceeds 5` comment so the threshold for switching is explicit rather than open-ended.
+
+**Implementation (Option A):**
+
+```typescript
+// src/entitlements/operator-auth.ts
+
+import { Request, Response, NextFunction } from 'express';
+
+// Loaded once at module initialization; changes require a process restart.
+const OPERATOR_USER_IDS: ReadonlySet<string> = new Set(
+  (process.env.OPERATOR_USER_IDS ?? '').split(',').map(s => s.trim()).filter(Boolean),
+);
+
+/**
+ * Returns true if the given userId is a configured platform operator.
+ * Used for both REST middleware and MCP tool filtering.
+ */
+export function isOperatorUser(userId: string): boolean {
+  return OPERATOR_USER_IDS.has(userId);
+}
+
+/**
+ * Express middleware: rejects non-operators with 403.
+ * Must be applied AFTER requireBearerToken (depends on req.mcpUser).
+ */
+export function requireOperator(req: Request, res: Response, next: NextFunction): void {
+  if (!req.mcpUser) {
+    // requireBearerToken was not applied before this — programming error.
+    res.status(500).json({ error: 'auth_configuration_error', message: 'Bearer auth must precede operator check' });
+    return;
+  }
+  if (!isOperatorUser(req.mcpUser.id)) {
+    res.status(403).json({ error: 'forbidden', message: 'Operator role required' });
+    return;
+  }
+  next();
+}
+```
+
+**MCP tool path enforcement** — the `entitlement_admin_` branch in `executeTool` must also call `isOperatorUser(userId)` and throw if false, because `executeTool` takes a plain `userId` string, not `req.mcpUser`. This is the second enforcement point and is non-optional: MCP tool execution goes through `executeTool` directly, not through the REST middleware chain.
+
+```typescript
+// In src/tools/executor.ts — add before the entitlement_admin_ handler:
+if (toolName.startsWith('entitlement_admin_')) {
+  if (!isOperatorUser(userId)) {
+    throw new Error('Operator role required for entitlement administration');
+  }
+  return executeAdminEntitlementTool(toolName, input, { userId, db });
+}
+```
+
+**Security invariant:** A tenant user's bearer token authenticates them as a regular user. The `isOperatorUser` check is a separate, explicit gate. These two checks must NEVER be collapsed into one (e.g., "if admin OR has right token") — they are orthogonal.
+
+**Files**:
+- `src/entitlements/operator-auth.ts` (new, ~35 lines)
+- `src/tools/executor.ts` (modified: add `entitlement_admin_` branch with operator check)
+- `.env.example` (modified: document `OPERATOR_USER_IDS=`)
+
+**Validation**:
+- [ ] `OPERATOR_USER_IDS` unset → `OPERATOR_USER_IDS` is empty set → all requests return 403
+- [ ] `OPERATOR_USER_IDS=known_id` → requests from `known_id` pass; all others return 403
+- [ ] A tenant user calling `entitlement_admin_grant` via MCP tool path → throws, not executes
+- [ ] `isOperatorUser` is pure and testable without Express context
+
+**Edge Cases**:
+- If `OPERATOR_USER_IDS` is an empty string (misconfiguration), no one is an operator. This is the safe default — fail closed on the grant surface.
+- Do not log the contents of `OPERATOR_USER_IDS` at startup; log only the count: `Operator user set initialized: N users`.
+
+---
+
+### T025: Cache invalidation on grant/revoke
+
+**Purpose**: Ensure that a revocation takes effect on the local node without waiting for TTL expiry. Hooks into WP02's subject-scoped `EntitlementCache`.
+
+**Steps**:
+1. Confirm WP02 exposes `featureGate.invalidateSubject(subject: Subject): void` (or `entitlementCache.invalidate(subject)`). If the interface is not yet settled, define it here and coordinate with WP02.
+2. `GrantsService` already calls this in T020 — this task is the integration verification and the documentation of the cross-node TTL bound.
+3. Add a comment in `GrantsService` that explicitly names the TTL bound:
+
+```typescript
+// Cache invalidation on this node is immediate.
+// Cross-node propagation is TTL-bounded (FR-018 Phase 1 baseline: default 1h).
+// A revoked grant may remain active on other instances for up to one TTL window.
+// Operators who need sub-TTL cross-node revocation must restart all instances
+// or reduce DEFAULT_FEATURE_ENTITLEMENT_TTL_SECONDS in config.
+this.featureGate.invalidateSubject(input.subject);
+```
+
+4. Add `DEFAULT_FEATURE_ENTITLEMENT_TTL_SECONDS` to `src/entitlements/types.ts` (or a config file) with a default of `3600` (1 hour). Make it overridable via `process.env.FEATURE_ENTITLEMENT_TTL_SECONDS` so operators who need faster revocation can reduce TTL without a code change.
+
+**Files**:
+- `src/entitlements/grants.service.ts` (modified: add comment block)
+- `src/entitlements/types.ts` (modified: add TTL constant)
+- No new files required if WP02 exposes the invalidation method
+
+**Validation**:
+- [ ] After `revoke()`, calling `featureGate.isEntitled(subject, featureKey)` on the same node returns `false` without waiting for TTL
+- [ ] If WP02's `invalidateSubject` is stubbed (WP02 not yet landed), the stub call does not throw and a log warning is emitted
+
+---
+
+### T026: Unit tests — authz, idempotency, audited writes, invalidation on change
+
+**Purpose**: Prove the correctness of the four most important WP04 invariants. These tests are the first line of defense before WP06 integration tests run.
+
+**Test file**: `src/entitlements/__tests__/grants.service.test.ts` (and `operator-auth.test.ts`)
+
+**Required test cases**:
+
+**1. Authorization: tenant user is denied on both surfaces**
+```typescript
+// REST surface
+it('returns 403 when non-operator bearer token calls POST /grants', async () => {
+  // Arrange: regular user token, not in OPERATOR_USER_IDS
+  // Act: POST /api/v1/admin/entitlements/grants
+  // Assert: 403 { error: 'forbidden' }
+});
+
+// MCP tool surface
+it('throws when non-operator userId calls entitlement_admin_grant via executeTool', async () => {
+  // Arrange: userId not in OPERATOR_USER_IDS
+  // Act: executeTool(nonOperatorUserId, 'entitlement_admin_grant', validInput)
+  // Assert: throws / rejects with 'Operator role required'
+});
+```
+
+**2. Idempotency**
+```typescript
+it('grant() called twice produces one row, not two', async () => {
+  await grantsService.grant(input);
+  await grantsService.grant(input);
+  const rows = await db.select().from(featureEntitlements).where(/* subject+feature */);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].status).toBe('active');
+});
+
+it('grant() on a revoked row reactivates it without inserting a new row', async () => {
+  await grantsService.grant(input);
+  await grantsService.revoke(subject, featureKey);
+  await grantsService.grant(input);
+  const rows = await db.select().from(featureEntitlements).where(/* subject+feature */);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].status).toBe('active');
+});
+
+it('revoke() called twice is a no-op on second call', async () => {
+  await grantsService.grant(input);
+  const first = await grantsService.revoke(subject, featureKey);
+  const second = await grantsService.revoke(subject, featureKey);
+  expect(first?.status).toBe('revoked');
+  expect(second?.status).toBe('revoked');
+});
+```
+
+**3. Audited writes carry actor identity**
+```typescript
+it('every grant() writes one audit row with the actor id in capability field', async () => {
+  const actorId = 'operator-cuid-123';
+  const service = new GrantsService(db, mockGate, actorId);
+  await service.grant(input);
+  const auditRows = await db.select().from(entitlementDecisions)
+    .where(/* subject+feature */);
+  expect(auditRows).toHaveLength(1);
+  expect(auditRows[0].capability).toContain(actorId);  // adjust if actor_id column added
+});
+
+it('revoke() writes one audit row with decision=deny', async () => {
+  const service = new GrantsService(db, mockGate, 'operator-id');
+  await service.grant(input);
+  await service.revoke(subject, featureKey);
+  const auditRows = await db.select().from(entitlementDecisions)
+    .where(/* subject+feature */);
+  expect(auditRows).toHaveLength(2);
+  expect(auditRows[1].decision).toBe('deny');
+});
+```
+
+**4. Cache invalidation is called on every mutation**
+```typescript
+it('invalidateSubject is called on grant', async () => {
+  const mockGate = { invalidateSubject: jest.fn() };
+  const service = new GrantsService(db, mockGate as any, 'operator-id');
+  await service.grant(input);
+  expect(mockGate.invalidateSubject).toHaveBeenCalledWith(input.subject);
+});
+
+it('invalidateSubject is called on revoke', async () => {
+  const mockGate = { invalidateSubject: jest.fn() };
+  const service = new GrantsService(db, mockGate as any, 'operator-id');
+  await service.grant(input);
+  await service.revoke(input.subject, input.featureKey);
+  expect(mockGate.invalidateSubject).toHaveBeenCalledTimes(2);
+});
+```
+
+**5. `isOperatorUser` correctly reads the env-var set**
+```typescript
+it('returns false when OPERATOR_USER_IDS is unset', () => {
+  // Module must be re-required with env cleared, or use dependency injection
+  expect(isOperatorUser('any-id')).toBe(false);
+});
+it('returns true only for IDs in OPERATOR_USER_IDS', () => {
+  process.env.OPERATOR_USER_IDS = 'op1,op2';
+  // re-initialize module or use injected set
+  expect(isOperatorUser('op1')).toBe(true);
+  expect(isOperatorUser('op3')).toBe(false);
+});
+```
+
+Note: because `OPERATOR_USER_IDS` is read at module initialization, testing requires either module re-initialization, dependency injection of the set, or extracting `buildOperatorSet(envVal)` as a pure function and testing that instead. **Recommend the pure function approach.**
+
+**Files**:
+- `src/entitlements/__tests__/grants.service.test.ts` (new, ~120 lines)
+- `src/entitlements/__tests__/operator-auth.test.ts` (new, ~30 lines)
+
+**Validation**:
+- [ ] All test cases pass
+- [ ] `npm test` exits 0 with no regressions in existing content/search tests (WP01's T007 gate still holds)
+
+---
+
+## Definition of Done
+
+- [ ] `src/entitlements/grants.service.ts` — `GrantsService` with `grant`, `modify`, `revoke`, `listForSubject`; idempotent; audit on every write; cache invalidation on every mutation
+- [ ] `src/entitlements/catalog.service.ts` — `CatalogService` with `create` (idempotent on PK), `list`
+- [ ] `src/entitlements/operator-auth.ts` — `requireOperator` middleware + `isOperatorUser` function; env-var allowlist (or schema column if Option B chosen — decision documented)
+- [ ] `src/entitlements/admin-routes.ts` — six REST endpoints; Zod validation; 401/403/422 error handling
+- [ ] `src/tools/admin-entitlement-tools.ts` — five `ToolDefinition` entries
+- [ ] `src/tools/executors/admin-entitlement-executor.ts` — dispatches admin tool calls to `GrantsService`/`CatalogService`
+- [ ] `src/tools/index.ts` — `getAllTools` omits admin tools for non-operators
+- [ ] `src/tools/executor.ts` — `entitlement_admin_` prefix branch with operator check
+- [ ] `src/index.ts` — admin router mounted at `/api/v1/admin/entitlements`
+- [ ] `.env.example` — `OPERATOR_USER_IDS` documented
+- [ ] Unit tests covering: authz denied (both surfaces), idempotency, audited writes with actor, invalidation on mutation
+- [ ] `npm run validate` (typecheck + lint + test) exits 0 with no regressions
+
+---
+
+## Risks
+
+**1. Authorization boundary is the top risk.**
+The `users` table has no role field. This WP must create the boundary from scratch. If `requireOperator` is accidentally omitted from even one route, a tenant user can self-grant. Mitigate: the middleware chain is explicit (`router.use(requireBearerToken, requireOperator)`) and applies to the entire router, not individual handlers. The unit test must confirm a non-operator token returns 403.
+
+**2. `GrantsService` is stateful per actor — not a singleton.**
+If instantiated as a singleton and the `actorId` is stored on the instance, concurrent requests will share and corrupt actor identity in the audit trail. Instantiate per request or pass `actorId` as a method argument.
+
+**3. Actor identity in audit trail has no dedicated column today.**
+`entitlement_decisions` (WP01) does not have an `actor_id` column. The workaround (embedding in `capability`) is auditable but not queryable by actor. If FR-015 compliance requires querying "all grants made by operator X," the column must be added in WP01. Coordinate before merging.
+
+**4. `featureGate.invalidateSubject` interface must be stable before this WP merges.**
+WP04 depends on WP02 exposing a specific method signature. If WP02 has not landed, use a stub interface and document the dependency explicitly in the PR.
+
+**5. Cache invalidation is local-node only.**
+Documented in T025. In a multi-instance deployment, a revoked grant can remain live on other nodes for up to the TTL window (default 1h). This is the stated Phase 1 baseline (FR-018). The operational knob (`FEATURE_ENTITLEMENT_TTL_SECONDS`) is the mitigation. Document this in the operator guide.
+
+**6. FK violation on unknown `feature_key`.**
+`feature_entitlements.feature_key` FK references `feature_catalog`. Inserting a grant for an unregistered feature will fail with a DB-level FK violation. Routes must catch this and return 422 "unknown_feature_key" — not 500.
+
+---
+
+## Reviewer Guidance
+
+- **Check the operator boundary first.** The crux of this WP is that a tenant user cannot grant themselves. Verify `requireOperator` is applied at the router level (not per-handler), and that `executeTool`'s `entitlement_admin_` branch has its own `isOperatorUser` check — because MCP tool calls do not go through the REST middleware chain.
+- **Verify idempotency at the DB layer.** `GrantsService.grant()` must never produce two rows for the same `(subject_type, subject_id, feature_key)`. The `UNIQUE` constraint enforces this at the DB level, but the application logic (upsert-not-insert) must handle the case cleanly rather than surfacing a constraint violation to the caller.
+- **Audit trail is append-only.** `entitlement_decisions` is an append-only log. Verify no UPDATE or DELETE statements are issued against it anywhere in this WP.
+- **`getAllTools` operator branching.** Confirm admin tools are filtered out for non-operators in the `tools/list` response — not just guarded in `executeTool`. A non-operator discovering admin tools through `tools/list` and hitting 403 on execution is a poor UX and leaks surface area.
+- **Confirm the actor identity decision** (column vs. embedded-in-capability) is resolved before merge and documented in the PR.
+- **`.env.example` must be updated.** `OPERATOR_USER_IDS` must be listed with an explanatory comment. Missing env docs are how production operators misconfigure deployments.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP05-tool-seam-gating.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP05-tool-seam-gating.md
@@ -1,0 +1,455 @@
+---
+work_package_id: "WP05"
+title: "Tool-Seam Gating"
+lane: "planned"
+dependencies: ["WP02", "WP03"]
+subtasks: ["T027", "T028", "T029", "T030", "T031", "T032"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP05: Tool-Seam Gating
+
+**Implementation command**: `spec-kitty implement WP05`
+**Target repo**: `joyus-ai`
+**Dependencies**: WP02 (FeatureGate decision core), WP03 (Un-forgeable gated-path enforcement)
+**Priority**: P1
+
+## Objective
+
+Wire feature-entitlement gating into the MCP tool seam (both visibility via `getAllTools` and execution via `executeTool`) and into the provider/step/connector call sites, so that add-on-owned capabilities are hidden and blocked for unentitled subjects, while core/free tools remain fully unaffected. Phase 1 uses a static ownership map as the bridge until the Phase 2 plugin registry replaces it. All gated invocations go through a `GateToken` minted by `FeatureGate.assertEntitled` (from WP03) — never a raw boolean check.
+
+## Context
+
+### The existing `getAllTools` filter
+
+`src/tools/index.ts` (lines 32–62) already filters by connected OAuth service before returning the tool list. The function builds a base array of `[opsTools, contentTools, pipelineTools, profileTools]` (always present) and conditionally appends service-gated arrays (`googleTools`, `jiraTools`, `slackTools`, `githubTools`) depending on which connections exist in the DB for the given `userId`. This filter must be **preserved exactly**. WP05 adds a second, orthogonal filter on top of it: tools in the base array (or any service array) that are add-on-owned are additionally filtered by entitlement. The two filters compose — a tool must pass both the connection check and the entitlement check to appear.
+
+### The existing `executeTool` dispatch
+
+`src/tools/executor.ts` (lines 96–182) dispatches by tool-name prefix:
+- `ops_` → `executeOpsTool` (core/free, never gated)
+- `content_` → `executeContentTool` (with `tenantId = userId` interim collapse at line 104)
+- `profile_` → `executeProfileTool` (with same `tenantId = userId` collapse at line 114)
+- `pipeline_` → `executePipelineTool` (with same collapse at line 119)
+- OAuth-prefixed (`jira_`, `slack_`, `github_`, `gmail_`, `drive_`, `docs_`) → OAUTH_PREFIX_REGISTRY lookup, then connection fetch + token refresh + `executeFunction`
+
+Only add-on-owned tools within these prefix groups are gated. Core tools (`ops_`, and any non-add-on `content_`/`profile_`/`pipeline_` tools) pass through without a gate call.
+
+### The ownership map as Phase 1 bridge
+
+Phase 2 will have a mutable plugin registry where each registered tool declares its `feature_key`. Phase 1 has no such registry — tool registration is static (each `*-tools.ts` file exports a hard-coded array). The `ownership.ts` static map is the Phase-1 bridge: it enumerates which tool names/prefixes are add-on-owned and what `feature_key` gates them. The map covers **only** add-on tools; absence from the map means core/free (default allow). This map is replaced wholesale in Phase 2 when the plugin host takes over registration.
+
+### The GateToken
+
+`FeatureGate.assertEntitled` (WP02/WP03) returns an opaque, non-constructible `GateToken`. Gated code paths require this token as a parameter — they cannot be reached by passing a hand-constructed entitlement object. The token proves the gate ran before any gated work begins. WP05 calls `assertEntitled` and threads the resulting token into the appropriate executor. The token is not stored beyond the immediate call; it is single-use proof-of-authorization for the current invocation.
+
+### Subject resolution
+
+In Phase 1, the subject is the individual user. The gate is called with `{ subject_type: 'user', subject_id: userId }` — explicitly constructed, never inferred from ambient state. The `tenantId === userId` collapse in `executor.ts` (lines 104, 114, 119) is an unrelated interim measure for downstream content/profile/pipeline logic; WP05 must not conflate the two. The gate always receives an explicit `Subject`.
+
+### Provider/step/connector gating (FR-008)
+
+These non-tool contributions run inside trusted core services:
+- **GenerationService** — provider is injected via DI in `src/content/index.ts` (lines 69–74); the generation call site in `src/content/generation/generator.ts` is the gating point for add-on generation providers.
+- **StepRegistry** — `src/pipelines/steps/registry.ts`; step handlers are invoked via `registry.execute(stepType, ...)`.
+- **ConnectorRegistry** — `src/content/connectors/index.ts`; connectors are invoked via `registry.sync(...)` or equivalent.
+
+Each of these registries can hold both core (free) and add-on contributions. An add-on contribution declares a `requiredFeatureKey` field at registration time; the core asserts entitlement before invoking it. Core contributions carry no `requiredFeatureKey` and bypass the gate.
+
+---
+
+## Subtasks
+
+### T027: `src/entitlements/ownership.ts` — Static add-on tool ownership map
+
+**Purpose**: Provide a Phase-1 bridge that maps add-on-owned tool names/prefixes to their `feature_key`, without touching the static tool-definition arrays. Only add-on tools appear in the map; core/free tools are absent (absence = default allow). In Phase 2 this file is deleted and the plugin registry takes over.
+
+**Steps**:
+1. Create `src/entitlements/ownership.ts`.
+2. Define the `ADD_ON_TOOL_OWNERSHIP` map as a `ReadonlyMap<string, FeatureKey>` keyed by either exact tool name or prefix (e.g. `'advanced_pipeline_'`). Use the `FeatureKey` branded type from WP01 types.
+3. Export a `getFeatureKeyForTool(toolName: string): FeatureKey | undefined` helper that checks exact-name first, then prefix, then returns `undefined` for core tools.
+4. Document clearly: returning `undefined` means the tool is core/free and must not be gated.
+
+**Inline reference shape**:
+
+```typescript
+// src/entitlements/ownership.ts
+import type { FeatureKey } from './types.js';
+
+/**
+ * Phase-1 static ownership map: add-on tool name (or prefix ending in '_') → feature_key.
+ *
+ * ABSENCE from this map means core/free — the tool is available to everyone
+ * and must never be gated. Do not add core tools here.
+ *
+ * Phase 2: deleted and replaced by the plugin registry.
+ */
+export const ADD_ON_TOOL_OWNERSHIP: ReadonlyMap<string, FeatureKey> = new Map([
+  // Example entries — populate with real add-on tools as they are built:
+  // ['advanced_pipeline_', 'com.joyus.addon.advanced-pipelines' as FeatureKey],
+  // ['content_semantic_search', 'com.joyus.addon.semantic-search' as FeatureKey],
+]);
+
+/**
+ * Returns the feature_key that gates this tool, or undefined if the tool is
+ * core/free and must not be gated.
+ *
+ * Checks exact name first, then prefix (entries whose key ends with '_').
+ */
+export function getFeatureKeyForTool(toolName: string): FeatureKey | undefined {
+  // Exact match
+  if (ADD_ON_TOOL_OWNERSHIP.has(toolName)) {
+    return ADD_ON_TOOL_OWNERSHIP.get(toolName);
+  }
+  // Prefix match (keys ending in '_' are treated as prefixes)
+  for (const [key, featureKey] of ADD_ON_TOOL_OWNERSHIP) {
+    if (key.endsWith('_') && toolName.startsWith(key)) {
+      return featureKey;
+    }
+  }
+  return undefined;
+}
+```
+
+**Files**:
+- `src/entitlements/ownership.ts` (new, ~35 lines)
+
+**Validation**:
+- [ ] `getFeatureKeyForTool('ops_health')` returns `undefined` (core tool, never in map)
+- [ ] `getFeatureKeyForTool('content_search')` returns `undefined` (core tool, never in map)
+- [ ] `getFeatureKeyForTool` returns the correct `FeatureKey` for any name/prefix in the map
+- [ ] `tsc --noEmit` passes with zero errors
+
+**Edge Cases**:
+- The map starts empty in Phase 1 until real add-on tools are registered. Empty map = all tools are core = no entitlement gating = correct behavior for the free product at launch.
+- A prefix key MUST end with `_` (the conventional tool-name separator). A key without a trailing `_` is treated as an exact name only.
+- If a tool matches both an exact key and a prefix key, the exact key wins (checked first).
+
+---
+
+### T028: `getAllTools()` — Omit add-on tools the subject lacks (FR-007)
+
+**Purpose**: After the existing connected-service filter runs, additionally remove add-on-owned tools whose `feature_key` the subject's effective entitlement does not include. Core/free tools are untouched regardless of entitlement state.
+
+**Steps**:
+1. Modify `src/tools/index.ts` — `getAllTools(userId: string)`.
+2. After the existing service-connection filter builds the `tools` array, call `FeatureGate.isEntitled` for each unique `feature_key` found via `getFeatureKeyForTool` across the collected tools.
+3. Batch the entitlement checks by unique feature key (one resolve per key, not one per tool) to stay within the < 10ms p95 budget.
+4. Filter out any tool whose `getFeatureKeyForTool` returns a key the subject is not entitled to.
+5. Tools where `getFeatureKeyForTool` returns `undefined` pass through unconditionally — they are core/free.
+
+**Inline reference shape**:
+
+```typescript
+// src/tools/index.ts — additions to getAllTools()
+import { getFeatureKeyForTool } from '../entitlements/ownership.js';
+import { featureGate } from '../entitlements/index.js';
+
+export async function getAllTools(userId: string): Promise<ToolDefinition[]> {
+  // --- Existing connected-service filter (unchanged) ---
+  const userConnections = await db
+    .select({ service: connections.service })
+    .from(connections)
+    .where(eq(connections.userId, userId));
+
+  const connectedServices = new Set(userConnections.map((c) => c.service));
+  const tools: ToolDefinition[] = [...opsTools, ...contentTools, ...pipelineTools, ...profileTools];
+
+  if (connectedServices.has('GOOGLE')) tools.push(...googleTools);
+  if (connectedServices.has('JIRA'))   tools.push(...jiraTools);
+  if (connectedServices.has('SLACK'))  tools.push(...slackTools);
+  if (connectedServices.has('GITHUB')) tools.push(...githubTools);
+
+  // --- Add-on entitlement filter (layered on top; does not affect core tools) ---
+  const subject = { subject_type: 'user' as const, subject_id: userId };
+
+  // Collect unique feature keys referenced by any tool in the list
+  const featureKeys = new Set<string>();
+  for (const tool of tools) {
+    const key = getFeatureKeyForTool(tool.name);
+    if (key !== undefined) featureKeys.add(key);
+  }
+
+  // Resolve entitlement for each unique key (cache hit is sub-millisecond)
+  const entitled = new Map<string, boolean>();
+  await Promise.all(
+    [...featureKeys].map(async (key) => {
+      entitled.set(key, await featureGate.isEntitled(subject, key as FeatureKey));
+    })
+  );
+
+  // Keep tool if: (a) it is core/free (no feature key), OR (b) the subject is entitled
+  return tools.filter((tool) => {
+    const key = getFeatureKeyForTool(tool.name);
+    return key === undefined || entitled.get(key) === true;
+  });
+}
+```
+
+**Files**:
+- `src/tools/index.ts` (modified — add imports + entitlement filter after existing service filter)
+
+**Validation**:
+- [ ] Core tools (`ops_*`, `content_*` with no ownership entry) are always present regardless of entitlement state
+- [ ] An add-on tool is absent for an unentitled user and present for an entitled user
+- [ ] The existing connected-service filter still works: a `jira_` tool requires both the JIRA connection AND entitlement (if add-on-owned)
+- [ ] `getAllTools` for a user with zero add-on grants returns the same result as today (no regression)
+- [ ] `tsc --noEmit` passes with zero errors
+
+**Edge Cases**:
+- `featureGate.isEntitled` must never throw — it is documented non-throwing (WP02). If the resolver is down, it returns `false` (fail-closed). No try/catch needed here, but confirm WP02 upholds this.
+- An empty `ADD_ON_TOOL_OWNERSHIP` map means `featureKeys` is empty and the filter pass-through is a no-op. Correct for Phase 1 before any add-ons ship.
+- Do not call `isEntitled` for tools with `undefined` feature key — pointless DB/cache work and risks false-excluding core tools on a future code path.
+
+---
+
+### T029: `executeTool()` — Assert entitlement before add-on dispatch (FR-007)
+
+**Purpose**: Before dispatching any add-on-owned tool, call `FeatureGate.assertEntitled` to obtain a `GateToken`. On deny, return a structured "upgrade required" error (not an exception, not an empty result). Core tools bypass the gate entirely — no code path change for `ops_`, non-add-on `content_`, `profile_`, or `pipeline_` tools.
+
+**Steps**:
+1. Modify `src/tools/executor.ts` — `executeTool(userId, toolName, input)`.
+2. At the top of `executeTool`, before any prefix dispatch, call `getFeatureKeyForTool(toolName)`.
+3. If a feature key is found, call `featureGate.assertEntitled(subject, featureKey)` — catching `FeatureNotEntitledError` and returning the structured upgrade-required payload.
+4. If `assertEntitled` succeeds, it returns a `GateToken`. Pass this token to the downstream executor as proof the gate ran. (In Phase 1 where executors do not yet accept a `GateToken` param, hold it as a `const _token = ...` — the type-system proof that `assertEntitled` was called before dispatch is the structural guarantee WP03 requires; the token value itself is passed in Phase 2 when executor signatures are updated.)
+5. If no feature key is found (core/free tool), skip the gate entirely.
+
+**Inline reference shape**:
+
+```typescript
+// src/tools/executor.ts — additions to executeTool()
+import { getFeatureKeyForTool } from '../entitlements/ownership.js';
+import { featureGate } from '../entitlements/index.js';
+import { FeatureNotEntitledError } from '../entitlements/errors.js';
+import type { FeatureKey } from '../entitlements/types.js';
+
+export async function executeTool(
+  userId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<unknown> {
+  // --- Entitlement gate (add-on tools only; core tools fall through immediately) ---
+  const featureKey = getFeatureKeyForTool(toolName);
+  if (featureKey !== undefined) {
+    const subject = { subject_type: 'user' as const, subject_id: userId };
+    try {
+      // assertEntitled mints a GateToken — proof the gate ran before dispatch.
+      // Phase 1: _gateToken held here; Phase 2: threaded into executor signature.
+      const _gateToken = await featureGate.assertEntitled(subject, featureKey, toolName);
+      void _gateToken; // used as structural proof; suppress unused-var lint
+    } catch (err) {
+      if (err instanceof FeatureNotEntitledError) {
+        // Return structured upgrade-required payload — not an exception, not empty.
+        return {
+          error: 'feature_not_entitled',
+          featureKey: err.featureKey,
+          message: `This capability requires the '${err.featureKey}' add-on. Upgrade your plan to unlock it.`,
+          upgrade: {
+            featureKey: err.featureKey,
+            reason: err.reason,
+          },
+        };
+      }
+      throw err; // unexpected errors propagate normally
+    }
+  }
+
+  // --- Existing dispatch (unchanged below this line) ---
+
+  if (toolName.startsWith('ops_')) {
+    return executeOpsTool(toolName, input, { userId });
+  }
+  // ... rest of existing dispatch unchanged ...
+}
+```
+
+**Files**:
+- `src/tools/executor.ts` (modified — add gate block at top of `executeTool`, before existing prefix dispatch)
+
+**Validation**:
+- [ ] Calling an add-on tool without entitlement returns `{ error: 'feature_not_entitled', featureKey, ... }` — not an exception, not null, not empty
+- [ ] Calling an add-on tool with valid entitlement dispatches normally (no change in behavior)
+- [ ] Calling any core tool (`ops_`, `content_search`, etc. with no ownership entry) does not call `assertEntitled` — zero gate overhead on the free path
+- [ ] `tsc --noEmit` passes with zero errors
+- [ ] The upgrade error payload shape matches the MCP error mapping defined in WP02 (T013)
+
+**Edge Cases**:
+- `FeatureNotEntitledError` must be imported from the WP02 error types, not caught as a generic `Error`. If a different error class is used in WP02, match it exactly.
+- The `_gateToken` is intentionally unused in Phase 1 — the structural guarantee is that `assertEntitled` was called before any dispatch. A lint rule (e.g. `@typescript-eslint/no-unused-vars` suppressed with `void _gateToken`) should be used rather than removing the token call.
+- Do not move the gate below the `ops_` check. The gate must be the first thing that runs for add-on tools; putting it after any dispatch-shortcut risks a race or bypass.
+- The subject is always `{ subject_type: 'user', subject_id: userId }` in Phase 1. Never infer from `tenantId`. The `tenantId === userId` collapse for downstream executors (lines 104, 114, 119 of the current file) is unrelated and must not change.
+
+---
+
+### T030: Provider/step/connector gating at enumerated call sites (FR-008)
+
+**Purpose**: Gate non-tool add-on contributions at their invocation boundaries in the trusted core services. A contribution declares `requiredFeatureKey?: FeatureKey` at registration time; the core asserts before invoking it. Core contributions with no `requiredFeatureKey` are unaffected. The set of call sites is finite and enumerated here.
+
+**Steps**:
+
+**Step A — Extend contribution registration types**:
+1. In `src/pipelines/steps/registry.ts`: add `requiredFeatureKey?: FeatureKey` to the step-handler registration type.
+2. In `src/content/connectors/index.ts`: add `requiredFeatureKey?: FeatureKey` to the connector registration type.
+3. In the generation provider DI surface (`src/content/index.ts` lines 69–74): add `requiredFeatureKey?: FeatureKey` to `GenerationProvider`.
+
+**Step B — Assert at each call site (enumerated)**:
+
+*Call site 1: GenerationService provider invocation (`src/content/generation/generator.ts`)*
+Before calling `this.provider.generate(...)`, if `this.provider.requiredFeatureKey` is set, call `featureGate.assertEntitled(subject, this.provider.requiredFeatureKey, 'generation_provider')`. The subject comes from the session/request context already threaded into generation. Catch `FeatureNotEntitledError` and surface as a structured upgrade response.
+
+*Call site 2: StepRegistry execution (`src/pipelines/steps/registry.ts`)*
+In the step invocation path (the method that calls `handler(...)`), check `handler.requiredFeatureKey` before calling. The `tenantId`/`userId` from the pipeline context forms the subject.
+
+*Call site 3: ConnectorRegistry sync (`src/content/connectors/index.ts` or its invocation in `SyncEngine`)*
+Before calling `connector.sync(...)`, check `connector.requiredFeatureKey`. The subject is the operator/tenant initiating the sync.
+
+**Step C — Document the complete enumeration**:
+Create a comment block in `src/entitlements/gated-sites.ts` (a compile-time documentation file, no runtime code) that lists every Phase-1 gated call site with file:line, so a reviewer can audit coverage is complete and no site was missed.
+
+**Files**:
+- `src/pipelines/steps/registry.ts` (modified — add `requiredFeatureKey` field to handler type + assert before invoke)
+- `src/content/connectors/index.ts` (modified — add `requiredFeatureKey` field + assert before invoke)
+- `src/content/generation/generator.ts` (modified — assert before provider call if `requiredFeatureKey` set)
+- `src/entitlements/gated-sites.ts` (new — compile-time enumeration documentation, ~30 lines)
+
+**Validation**:
+- [ ] A step handler with `requiredFeatureKey` set is denied for an unentitled subject with a `FeatureNotEntitledError`
+- [ ] A step handler without `requiredFeatureKey` is invoked normally — no gate call, no overhead
+- [ ] Same for connector and generation provider
+- [ ] `gated-sites.ts` lists all three call sites with file references
+- [ ] `tsc --noEmit` passes with zero errors across all modified files
+
+**Edge Cases**:
+- Phase 1 has zero add-on providers/steps/connectors registered with `requiredFeatureKey`. All checks are `undefined` → no-ops. The gating code must be present and correct, but it produces zero behavioral change until an add-on registers.
+- The generation provider in `content/index.ts` is a singleton injected at boot. If a tenant-scoped provider is ever used, the subject must come from the request context, not boot-time. Flag this as a Phase 2 concern in the `gated-sites.ts` comment.
+- Connector sync runs as a background job; the "subject" for a background sync is the tenant that owns the connector. The executor context must carry a subject, not derive it from an HTTP request. Verify the `SyncEngine` already carries a `tenantId`; if not, note it as a gap.
+
+---
+
+### T031: Module init wiring — `src/entitlements/index.ts` + `src/index.ts` mount
+
+**Purpose**: Wire the complete entitlement module (gate, resolver, cache, membership) into the application startup, and mount admin routes / register admin MCP tools so the module is operational at boot.
+
+**Steps**:
+
+**Step A — `src/entitlements/index.ts` barrel**:
+1. Create (or extend) the entitlements module barrel.
+2. Export: `FeatureGate` class, `featureGate` singleton, `FeatureEntitlementResolver`, `MembershipResolver`, `NullMembershipResolver`, `EntitlementCache` (from WP01 core extraction), `FeatureNotEntitledError`, `GateToken` type, `Subject`, `FeatureKey`, `getFeatureKeyForTool`.
+3. Instantiate the `featureGate` singleton with the `FeatureEntitlementResolver` (DB-leads), the `NullMembershipResolver` (pre-WP12), the subject-scoped `EntitlementCache`, and the audit writer. Export it as the canonical enforcement instance.
+
+**Step B — `src/index.ts` mount**:
+1. Import the admin routes from `src/entitlements/admin/routes.ts` (created by WP04) and mount them behind the operator-role middleware: `app.use('/api/v1/admin/entitlements', requireOperatorRole, entitlementsAdminRouter)`.
+2. Import the admin MCP tools from `src/entitlements/admin/tools.ts` (WP04) and register them in the MCP tool list — they are gated by the operator-role check inside the tool, not by `getAllTools` entitlement filtering (admin tools are not subject to the add-on ownership map).
+3. Log `[entitlements] Module initialized` on success; catch and log without crashing on failure (matching the `content` module pattern at lines 323–327 of `src/index.ts`).
+
+**Step C — Inject `featureGate` into `executor.ts` and `tools/index.ts`**:
+Both files import `featureGate` from `../entitlements/index.js`. Confirm the import resolves without circular dependencies. The entitlements module must not import from `tools/` or `executor.ts`.
+
+**Files**:
+- `src/entitlements/index.ts` (new or extended — module barrel + singleton wiring, ~60 lines)
+- `src/index.ts` (modified — mount admin routes + register admin tools + initialization block, ~15 lines added)
+
+**Validation**:
+- [ ] `featureGate` singleton is available to both `tools/index.ts` and `tools/executor.ts` without circular imports
+- [ ] Admin routes are mounted at `/api/v1/admin/entitlements` behind `requireOperatorRole`
+- [ ] `[entitlements] Module initialized` appears in server startup logs
+- [ ] Server starts cleanly if the entitlements DB tables do not yet exist (fail-soft with log, matching content module pattern)
+- [ ] `tsc --noEmit` passes with zero errors
+
+**Edge Cases**:
+- The `featureGate` singleton must be created once and shared — do not instantiate it inside `getAllTools` or `executeTool` (would create a new cache per call, defeating the cache purpose).
+- `NullMembershipResolver` (pre-WP12) returns `[]` for any user, so the effective subject set is `{user:U}` only. Swapping in a real `MembershipResolver` post-WP12 must require no changes to the gate or the seam wiring.
+- Admin tools registered for the MCP surface must be operator-role-gated inside the tool handler, not via `getFeatureKeyForTool` — they are core administrative capabilities, not purchasable add-ons.
+
+---
+
+### T032: Unit tests — core tools unaffected; add-on tools gated on list and call
+
+**Purpose**: Prove the three invariants that matter most: (1) core/free tools are always visible and executable regardless of entitlement state, (2) add-on tools are hidden in `getAllTools` for unentitled subjects and present for entitled ones, (3) `executeTool` on a gated add-on tool returns the upgrade-required payload on deny and dispatches normally on allow.
+
+**Steps**:
+1. Create `src/entitlements/__tests__/tool-seam.test.ts`.
+2. Set up fixtures:
+   - A fake `FeatureGate` that returns configurable allow/deny per feature key.
+   - A fake `ADD_ON_TOOL_OWNERSHIP` map with one test add-on tool (`test_addon_tool`) → `test.addon.feature` and one test prefix (`test_addon_prefix_`) → `test.addon.prefix.feature`.
+   - A core tool (`ops_health`) absent from the ownership map.
+3. Test `getAllTools` entitlement filter (T028):
+   - Unentitled user: `test_addon_tool` absent; `ops_health` present.
+   - Entitled user: `test_addon_tool` present; `ops_health` present.
+   - Gate denial during `isEntitled` (resolver down, returns false): add-on tool absent; core tool present.
+4. Test `executeTool` gate (T029):
+   - Add-on tool, unentitled: returns `{ error: 'feature_not_entitled', featureKey: 'test.addon.feature', ... }`.
+   - Add-on tool, entitled: dispatcher is called (mock confirms call).
+   - Core tool (`ops_health`): `assertEntitled` is never called; dispatcher runs directly.
+5. Test upgrade error shape: `error`, `featureKey`, `message`, and `upgrade.featureKey` fields all present.
+6. Test `getFeatureKeyForTool` (T027): exact match, prefix match, undefined for core.
+
+**Files**:
+- `src/entitlements/__tests__/tool-seam.test.ts` (new, ~120 lines)
+
+**Validation**:
+- [ ] `npm test -- --testPathPattern=tool-seam` exits 0
+- [ ] Core tool path: zero calls to `featureGate.assertEntitled` or `featureGate.isEntitled`
+- [ ] Add-on tool gated on both list (omitted when unentitled) AND call (upgrade error returned when unentitled)
+- [ ] Upgrade error shape matches the WP02 T013 definition exactly
+- [ ] Prefix ownership resolution tested: `test_addon_prefix_foo` resolves to `test.addon.prefix.feature`
+
+**Edge Cases**:
+- Test what happens when `ADD_ON_TOOL_OWNERSHIP` is empty (the Phase 1 launch state): `getAllTools` returns all tools; `executeTool` calls no gate. This is the regression-safety test for the free product.
+- Test that `getAllTools` does not call `isEntitled` for a tool with `undefined` feature key — confirms zero overhead on the core path.
+- Test that an `isEntitled` call that throws (unexpected error) is NOT caught by `getAllTools` — it should propagate, not silently exclude the tool. (This distinguishes "gate says no" from "gate crashed.")
+
+---
+
+## Definition of Done
+
+- [ ] `src/entitlements/ownership.ts` — static map + `getFeatureKeyForTool` helper; starts empty for Phase 1
+- [ ] `src/tools/index.ts` — entitlement filter added after existing service-connection filter; core tools unconditionally pass
+- [ ] `src/tools/executor.ts` — gate block at top of `executeTool`; upgrade-required payload on deny; core tools bypass gate
+- [ ] `src/pipelines/steps/registry.ts` — `requiredFeatureKey` on handler type; assert before invoke
+- [ ] `src/content/connectors/index.ts` — `requiredFeatureKey` on connector type; assert before invoke
+- [ ] `src/content/generation/generator.ts` — assert before provider call when `requiredFeatureKey` set
+- [ ] `src/entitlements/gated-sites.ts` — enumeration of all three Phase-1 call sites (FR-016 audit surface)
+- [ ] `src/entitlements/index.ts` — module barrel with `featureGate` singleton wired
+- [ ] `src/index.ts` — admin routes mounted; initialization block present
+- [ ] `src/entitlements/__tests__/tool-seam.test.ts` — all invariants proven
+- [ ] `npm run typecheck` exits 0 with zero errors
+- [ ] `npm test` exits 0 with no regressions in existing tests
+
+---
+
+## Risks
+
+**Core/free tool regression (HIGH, contained by T032)**
+The primary risk: touching `getAllTools` or `executeTool` could accidentally gate a core tool, breaking the free product. Mitigated by: (1) `getFeatureKeyForTool` returns `undefined` for any tool absent from the ownership map, and `undefined` means unconditional pass-through; (2) the T032 tests explicitly assert core tools are unaffected; (3) the ownership map starts empty, so Phase 1 at launch is a no-op filter.
+
+**Empty ownership map is correct, not a bug**
+Phase 1 ships with `ADD_ON_TOOL_OWNERSHIP` empty until real add-on tools are built. The filter must be a no-op in this state. This is correct behavior and is explicitly tested (T032 edge case).
+
+**Static map is a Phase-1 approximation only**
+The ownership map cannot be updated at runtime. If an add-on tool is added or removed from the codebase, the map must be manually updated. This is acceptable for Phase 1 (in-tree add-ons; Joyus engineers control both) but is a maintenance risk. Phase 2's plugin registry eliminates it. The risk is low for Phase 1 and the bridge pattern is intentional — call it out in code comments.
+
+**Subject derivation (LOW, enforced by type)**
+`executeTool` and `getAllTools` both derive the subject as `{ subject_type: 'user', subject_id: userId }`. The `tenantId === userId` collapse for downstream executors is unrelated. Mixing them would be a latent bug that only manifests post-WP12. The explicit `Subject` construction (not referencing `tenantId`) and the WP02 gate's explicit-subject requirement prevent this.
+
+**GateToken threading (DEFERRED to Phase 2)**
+Phase 1 holds the `GateToken` in `_gateToken` but does not pass it into executor signatures (those signatures are not yet updated to require it). The structural guarantee in Phase 1 is that `assertEntitled` must be called before dispatch — if it throws, dispatch never runs. Phase 2 makes this type-level by requiring `GateToken` as a parameter. This is intentional and documented.
+
+---
+
+## Reviewer Guidance
+
+**The invariant that matters most**: run the test suite with `ADD_ON_TOOL_OWNERSHIP` empty and confirm `getAllTools` and `executeTool` are byte-for-byte equivalent to the pre-WP05 behavior. Any deviation is a regression.
+
+**Verify filter composition order**: The entitlement filter must run *after* the connected-service filter in `getAllTools`, never before. If a tool requires both a JIRA connection and an add-on entitlement, both conditions must be checked independently — failing either removes the tool. The current structure (service filter first, entitlement filter second) is correct; do not invert.
+
+**Confirm `isEntitled` vs `assertEntitled` usage**:
+- `getAllTools` uses `isEntitled` (non-throwing, returns `false` on deny — tool is silently omitted from the list).
+- `executeTool` uses `assertEntitled` (throws `FeatureNotEntitledError` — caught and mapped to upgrade payload). This distinction is intentional: hiding from the list is UX; blocking execution is enforcement.
+
+**Check the gated-sites enumeration**: `src/entitlements/gated-sites.ts` must list every Phase-1 call site. If a reviewer finds a call site that invokes an add-on contribution without a gate, it is a FR-016 violation. The enumeration is the audit surface.
+
+**Do not trust the ownership map alone**: The map gates tools at the seam. But if an add-on contribution is also reachable through a provider/step/connector path (T030), that path must also be gated — the map-level gate on the tool name is insufficient coverage. The `gated-sites.ts` enumeration documents which paths are covered.

--- a/kitty-specs/015-add-on-plugin-architecture/tasks/WP06-integration-validation.md
+++ b/kitty-specs/015-add-on-plugin-architecture/tasks/WP06-integration-validation.md
@@ -1,0 +1,559 @@
+---
+work_package_id: "WP06"
+title: "Integration & Validation"
+lane: "planned"
+dependencies: ["WP01", "WP02", "WP03", "WP04", "WP05"]
+subtasks: ["T033", "T034", "T035", "T036", "T037", "T038", "T039", "T040"]
+history:
+  - date: "2026-06-14"
+    action: "created"
+    agent: "claude-opus"
+---
+
+# WP06: Integration & Validation
+
+**Implementation command**: `spec-kitty implement WP06`
+**Target repo**: `joyus-ai`
+**Dependencies**: WP01 (core extraction + schema), WP02 (FeatureGate decision core), WP03 (un-forgeable enforcement), WP04 (operator grant write path), WP05 (tool-seam gating)
+**Priority**: P1
+
+---
+
+## Objective
+
+Prove — with running code, not assertions — that Phase 1 of Spec 015 meets its success criteria. Every test in this WP is a load-bearing end-to-end scenario that verifies a specific SC cannot be broken silently. The three most critical are T035 (fail closed on lapsed grants during outage), T036 (structural enforcement via a second invocation path), and T038 (content-path regression gate). Pass these and the entitlement system earns the right to ship.
+
+---
+
+## Context
+
+### Test file to mirror
+
+`tests/content/integration/entitlements.test.ts` is the established convention for integration-level entitlement tests in this codebase. Study its patterns before writing a single line:
+
+- **Import style**: named imports from the compiled module paths (`.js` extensions on all local imports, per `"type": "module"` in `package.json`).
+- **Mock pattern**: `vi.fn()` for resolver mocks, a plain object literal `const mockDb = {} as never` for the DB when not needed, and a structured mock db when DB queries matter.
+- **Cache usage**: `new EntitlementCache()` directly, `.set(key, entitlements)`, `.get(key)`, `.invalidate(key)` — no factory functions.
+- **Fixture helper**: `makeEntitlements(sourceIds, overrides)` returns a `ResolvedEntitlements` — mirror this with a `makeFeatureGrant` / `makeSubject` helper for feature entitlements.
+- **Fail-closed assertions**: when a resolver throws, verify that `resolvedFrom` contains `'restricted'` or `'default_deny'` and that entitled content/features are absent. Never `expect(result).toBeDefined()` alone.
+- **TTL test pattern**: use a `ttlSeconds: 0` override to expire immediately; a short busy-wait (< 5 ms) is acceptable per existing convention (see `cache TTL` describe block).
+- **No real database, no network**: all tests use mocks. No test should open a real pg connection.
+
+### Test runner
+
+```
+npm run validate     # typecheck + lint + vitest run (the gate T040 must pass)
+npm test             # vitest run only
+```
+
+Vitest config (`vitest.config.ts`):
+- `environment: 'node'`
+- `include: ['src/**/*.test.ts', 'tests/**/*.test.ts']`
+- `testTimeout: 10000`
+- Coverage thresholds enforced (statements 59%, branches 74%, functions 67%, lines 59%)
+
+### New test file location
+
+```
+tests/entitlements/integration/feature-gate.test.ts
+```
+
+Mirror the directory structure of the existing content integration tests.
+
+### Fixtures needed (shared helpers — define in this file or a `helpers.ts` sibling)
+
+```typescript
+// Subject helpers
+function makeSubject(type: 'user' | 'tenant', id: string): Subject {
+  return { subject_type: type, subject_id: id };
+}
+
+// Grant helpers — mirrors makeEntitlements() in the content test
+function makeGrant(featureKey: string, overrides: Partial<FeatureEntitlement> = {}): FeatureEntitlement {
+  return {
+    id: 'grant-test',
+    subject_type: 'user',
+    subject_id: 'user-alice',
+    feature_key: featureKey,
+    status: 'active',
+    valid_from: new Date(Date.now() - 1000),
+    valid_until: null,           // perpetual by default
+    source: 'admin',
+    limits: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+// Fake operator context (WP04 admin role)
+function makeOperatorContext(): OperatorContext {
+  return { actorId: 'operator-sys', role: 'admin' };
+}
+
+// Resolver mocks
+function makeResolver(grants: string[]): FeatureEntitlementResolver {
+  return { resolve: vi.fn().mockResolvedValue(grants) };
+}
+
+function makeFailingResolver(): FeatureEntitlementResolver {
+  return { resolve: vi.fn().mockRejectedValue(new Error('resolver outage: connection refused')) };
+}
+```
+
+### Key types to import (paths will be stable post-WP01/WP02)
+
+```typescript
+import { FeatureGate, FeatureNotEntitledError } from '../../../src/entitlements/gate.js';
+import { FeatureEntitlementResolver }           from '../../../src/entitlements/resolver.js';
+import { EntitlementCache }                     from '../../../src/entitlements/core/cache.js';
+import { NullMembershipResolver }               from '../../../src/entitlements/membership.js';
+import type { Subject, FeatureKey }             from '../../../src/entitlements/types.js';
+import type { GateToken }                       from '../../../src/entitlements/gate.js';
+// WP04 grant administration
+import { GrantsService }                        from '../../../src/entitlements/grants-service.js';
+// WP05 tool seam
+import { getAllTools, executeTool }             from '../../../src/tools/index.js';
+```
+
+Adjust import paths to match the actual module layout produced by WP01–WP05. Do not hard-code paths that may shift — read the barrel exports from `src/entitlements/index.ts` first.
+
+---
+
+## SC Coverage Map
+
+| Test | Subtask | Success Criteria proved |
+|------|---------|------------------------|
+| T033 | individual licensing end-to-end | SC-1 (durable licensing), SC-2a (individual path, pre-WP12) |
+| T034 | explicit deny + audit log | SC-3 (explicit deny, decision logged) |
+| T035 | fail-closed on lapsed grants | SC-6 (expired grant denied on outage; valid grant still served) |
+| T036 | structural enforcement | SC-5 (second-path denied; hand-constructed object rejected) |
+| T037 | union resolution seam | SC-2 (union: {user} pre-WP12; membership stub adds tenant grant) |
+| T038 | content-path regression | SC-4 (reuse is real; existing content tests green) |
+| T039 | auditability query | SC-11 (every allow/deny queryable per subject + per feature) |
+
+Note: SC-7 (grant path exists) is exercised inside T033 (operator creates a grant via `GrantsService`, not raw SQL). SC-8, SC-9, SC-10 are Phase 2 only and are explicitly out of scope for WP06.
+
+---
+
+## Subtasks
+
+---
+
+### T033 — Individual licensing end-to-end (SC-1, SC-2a)
+
+**Purpose**: Prove the complete individual-subject licensing lifecycle: operator grants → `tools/list` filters in → `tools/call` succeeds → operator revokes → denied within one TTL. This is Scenario 1 from the spec enacted in a single test sequence.
+
+**Scenario enacted**:
+1. Operator creates a `user` grant for `com.joyus.addon.advanced-pipelines` on `user:alice` via `GrantsService.create(...)` (not raw SQL — satisfies FR-015).
+2. `getAllTools('user:alice')` returns the add-on tool (it was hidden before the grant).
+3. `FeatureGate.assertEntitled({ subject_type: 'user', subject_id: 'alice' }, 'com.joyus.addon.advanced-pipelines')` resolves without throwing.
+4. Operator revokes the grant via `GrantsService.revoke(...)`.
+5. After cache invalidation fires, the same `assertEntitled` call throws `FeatureNotEntitledError`.
+6. `getAllTools('user:alice')` no longer includes the add-on tool.
+
+**Key assertions**:
+- `GrantsService.create` result has `status: 'active'` and a non-null `id`.
+- Tool visibility before grant: add-on tool absent from list; after grant: present; after revoke: absent again.
+- `FeatureNotEntitledError.featureKey === 'com.joyus.addon.advanced-pipelines'`.
+- The decision log contains both an `allow` row (post-grant) and a `deny` row (post-revoke) for subject `user:alice`.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (new, within the `describe('Individual licensing')` block)
+
+**Validation**:
+- [ ] Test passes with `vitest run`
+- [ ] No raw DB inserts — only `GrantsService` API is used for the grant lifecycle
+- [ ] Tool list assertions check both the add-on tool name and the absence of any core tool being affected
+
+---
+
+### T034 — Explicit deny returns structured upgrade error (SC-3)
+
+**Purpose**: Prove that an unentitled gated call returns a machine-readable "upgrade required" payload — not an empty result, not a generic error — and that a decision row is appended to the audit log.
+
+**Scenario enacted**:
+1. Subject `user:bob` has no grants.
+2. `FeatureGate.assertEntitled({ subject_type: 'user', subject_id: 'bob' }, 'com.joyus.addon.advanced-pipelines')` is called.
+3. It throws `FeatureNotEntitledError`.
+4. The MCP/API error-mapping layer (or a test shim that mimics it) converts the error to an "upgrade required" payload.
+
+**Key assertions**:
+- The thrown error is an instance of `FeatureNotEntitledError` (not a generic `Error`).
+- `error.featureKey === 'com.joyus.addon.advanced-pipelines'`.
+- `error.reason === 'not_entitled'` (or equivalent field from WP02 T013).
+- The "upgrade required" payload is not empty and carries a `featureKey` field.
+- After the call, querying `entitlement_decisions` for `subject_id: 'bob'` returns a row with `decision: 'deny'` and `reason: 'not_entitled'`.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (within `describe('Explicit deny')` block)
+
+**Validation**:
+- [ ] `expect(() => gate.assertEntitled(...)).rejects.toThrow(FeatureNotEntitledError)`
+- [ ] Payload mapping produces a non-empty object with `featureKey` present
+- [ ] Decision log mock is called with `decision: 'deny'`
+
+---
+
+### T035 — Fail closed on lapsed grants: resolver outage + expired grant (SC-6, FR-017)
+
+**Purpose**: The single most important security test for grant-validity integrity. Proves that when the resolver is unreachable AND the only grant on file has `valid_until` in the past, the DB fallback denies — not grants. A naive content-fallback copy would serve the expired row (fail *open on a lapsed grant*); this test catches that bug before it ships.
+
+**Representative skeleton** (inline — this test is load-bearing):
+
+```typescript
+describe('Fail closed on lapsed grants (SC-6 / FR-017)', () => {
+  it('denies when resolver is down and the only DB grant is expired', async () => {
+    const FEATURE = 'com.joyus.addon.advanced-pipelines';
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-expired' };
+
+    // Resolver is unreachable
+    const failingResolver = makeFailingResolver();
+
+    // DB fallback returns one row — but it is expired
+    const expiredGrant = makeGrant(FEATURE, {
+      status: 'active',                          // status column still says 'active' (simulating a
+      valid_until: new Date(Date.now() - 60_000), // grant that just lapsed — valid_until is in the past)
+    });
+    const mockDb = buildMockDbWithGrants([expiredGrant]);
+
+    const cache = new EntitlementCache();
+    const gate = new FeatureGate(failingResolver, cache, new NullMembershipResolver(), mockDb);
+
+    // Assert: FeatureGate must deny, not grant
+    await expect(
+      gate.assertEntitled(subject, FEATURE)
+    ).rejects.toThrow(FeatureNotEntitledError);
+
+    // Assert: the decision recorded the exact reason
+    const lastDecision = getLastDecisionLog(mockDb);
+    expect(lastDecision.decision).toBe('deny');
+    expect(lastDecision.reason).toBe('resolver_unavailable_fallback_deny');
+    expect(lastDecision.feature_key).toBe(FEATURE);
+    expect(lastDecision.subject_id).toBe('user-expired');
+  });
+
+  it('still serves a valid grant when resolver is down', async () => {
+    const FEATURE = 'com.joyus.addon.advanced-pipelines';
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-valid' };
+
+    const failingResolver = makeFailingResolver();
+
+    // DB fallback returns a live grant
+    const validGrant = makeGrant(FEATURE, {
+      valid_until: new Date(Date.now() + 86_400_000), // expires tomorrow
+    });
+    const mockDb = buildMockDbWithGrants([validGrant]);
+
+    const cache = new EntitlementCache();
+    const gate = new FeatureGate(failingResolver, cache, new NullMembershipResolver(), mockDb);
+
+    // Assert: gate allows — the valid fallback should serve
+    const token: GateToken = await gate.assertEntitled(subject, FEATURE);
+    expect(token).toBeDefined();
+
+    const lastDecision = getLastDecisionLog(mockDb);
+    expect(lastDecision.decision).toBe('allow');
+    expect(lastDecision.resolved_from).toBe('db');
+  });
+});
+```
+
+**What `buildMockDbWithGrants` must do**: return a mock DB object whose `select(...).from(...).where(...)` chain returns only grants that pass the active + non-expired filter. Implement the mock so the WHERE predicate is applied in the mock (i.e., the mock checks `valid_until > now` before returning rows) — otherwise you are testing the mock, not the gate. Alternatively, mock the raw DB call to return the given rows unconditionally and rely on the gate's own filter; this also works but requires the gate to filter post-query. Either approach is valid; document which one the implementation uses.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (within `describe('Fail closed on lapsed grants')` block)
+
+**Validation**:
+- [ ] First test (`expired grant`) throws `FeatureNotEntitledError` with `reason: 'resolver_unavailable_fallback_deny'`
+- [ ] Second test (`valid grant`) resolves with a `GateToken` and records `resolved_from: 'db'`
+- [ ] Neither test makes a real network call or opens a real DB connection
+- [ ] The mock resolver's `resolve` function is called and throws in both tests (confirming the outage path is exercised)
+
+---
+
+### T036 — Structural enforcement: second path and un-forgeable token (SC-5, FR-016)
+
+**Purpose**: Proves that gated capabilities cannot be reached by any path other than a `FeatureGate`-minted `GateToken`. Two scenarios: (a) a gated pipeline step invoked without going through `tools/call` is still denied; (b) a hand-constructed entitlement/grant object cannot be passed to the gated step to bypass the gate.
+
+**Representative skeleton** (inline — this test is load-bearing):
+
+```typescript
+describe('Structural enforcement — second path and un-forgeable token (SC-5 / FR-016)', () => {
+  it('denies a gated pipeline step invoked via its registry (not tools/call)', async () => {
+    const FEATURE = 'com.joyus.addon.advanced-pipelines';
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-noentitle' };
+
+    // Subject has no grant
+    const resolver = makeResolver([]); // empty feature set
+    const gate = new FeatureGate(resolver, new EntitlementCache(), new NullMembershipResolver(), {} as never);
+
+    // Invoke the gated pipeline step handler directly through the StepRegistry,
+    // bypassing the tools/call path — the gate should still fire
+    const stepRegistry = buildStepRegistryWithGatedStep(FEATURE, gate);
+
+    await expect(
+      stepRegistry.execute('advanced_pipeline_step', { subject }, {})
+    ).rejects.toThrow(FeatureNotEntitledError);
+  });
+
+  it('rejects a hand-constructed grant object at the type boundary', () => {
+    // This test is a compile-time / structural check.
+    // The gated step handler's signature must require a GateToken, not a raw
+    // FeatureEntitlement or boolean. Verify at the TypeScript level that
+    // passing a fake object fails to type-check.
+    //
+    // At runtime: attempt to call a gated handler with a raw object where
+    // the token parameter is expected — it must throw or fail.
+
+    const fakeToken = { featureKey: 'com.joyus.addon.advanced-pipelines' }; // not a real GateToken
+
+    // The gated step's call signature is: execute(token: GateToken, input: ...).
+    // Passing fakeToken must either: (a) cause a TypeScript compile error (caught by T040),
+    // or (b) throw at runtime because GateToken is branded/opaque and the gate validates it.
+    expect(() => {
+      // @ts-expect-error — deliberate: fakeToken is not a GateToken
+      invokeGatedStepWithRawToken(fakeToken, {});
+    }).toThrow();
+  });
+});
+```
+
+**Notes on implementation**:
+- `buildStepRegistryWithGatedStep` is a test helper that creates a `StepRegistry` instance, registers a mock gated step that declares `requiresFeature: FEATURE`, and wires the provided `gate` at the call site.
+- The `@ts-expect-error` approach for the type-boundary test means the test validates that the compile-time guard is in place. T040 (`npm run validate` including typecheck) will catch if this boundary is accidentally removed.
+- If `GateToken` is implemented as a branded/opaque type (e.g., `declare const _brand: unique symbol; type GateToken = { [_brand]: true }`) rather than a class with runtime identity, the runtime portion of the second test may be a no-op at runtime. That is acceptable: the type-level guard is the enforcement mechanism. Document this explicitly in a test comment.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (within `describe('Structural enforcement')` block)
+
+**Validation**:
+- [ ] First test (second-path) throws `FeatureNotEntitledError` when invoked via the step registry
+- [ ] Second test (un-forgeable token) either fails at typecheck (caught by T040) or throws at runtime
+- [ ] No modification to the gated step's enforcement logic is made just to make the test pass — verify the step is genuinely gated in the registry
+
+---
+
+### T037 — Union resolution: individual pre-WP12, then membership-stub tenant grant (SC-2 seam, FR-019)
+
+**Purpose**: Proves both halves of the FR-019 union. Pre-WP12: a user with only a `user:U` grant is entitled (the individual path works today with no tenant system). Post-WP12 seam: a `NullMembershipResolver` swapped for a stub that returns one tenant grants the user membership-based access — proving the seam Phase 1.5 depends on is correctly wired without requiring WP12 to exist.
+
+**Representative skeleton** (inline — this test is load-bearing):
+
+```typescript
+describe('Union resolution — individual-first + membership seam (SC-2 / FR-019)', () => {
+  const FEATURE = 'com.joyus.addon.advanced-pipelines';
+
+  it('pre-WP12: individual user grant is sufficient with no org membership', async () => {
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-alice' };
+
+    // Only a user grant; NullMembershipResolver returns []
+    const resolver = makeResolver([FEATURE]);
+    const gate = new FeatureGate(
+      resolver,
+      new EntitlementCache(),
+      new NullMembershipResolver(),  // <-- the pre-WP12 state
+      {} as never,
+    );
+
+    const token = await gate.assertEntitled(subject, FEATURE);
+    expect(token).toBeDefined();
+  });
+
+  it('pre-WP12: user with no grant and no org membership is denied', async () => {
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-bob' };
+
+    const resolver = makeResolver([]); // no grants
+    const gate = new FeatureGate(resolver, new EntitlementCache(), new NullMembershipResolver(), {} as never);
+
+    await expect(gate.assertEntitled(subject, FEATURE)).rejects.toThrow(FeatureNotEntitledError);
+  });
+
+  it('post-WP12 seam: tenant grant inherited by member via membership stub', async () => {
+    // Swap NullMembershipResolver for a stub that says user-carol belongs to tenant-acme
+    const membershipStub = {
+      getMemberships: vi.fn().mockResolvedValue(['tenant-acme']),
+    };
+
+    // user-carol has no personal grant; tenant-acme has the feature grant
+    const userResolver = makeResolver([]); // user:carol → no features
+    const tenantResolver = makeResolver([FEATURE]); // tenant:acme → has the feature
+
+    // The gate must union: effective = user grants ∪ tenant grants
+    // Wire a gate that resolves both subjects and unions them
+    const gate = new FeatureGate(
+      buildUnionResolver(userResolver, tenantResolver),
+      new EntitlementCache(),
+      membershipStub,
+      {} as never,
+    );
+
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-carol' };
+    const token = await gate.assertEntitled(subject, FEATURE);
+    expect(token).toBeDefined();
+
+    // Confirm the audit records which subject satisfied the allow
+    const decision = getLastDecisionLog();
+    expect(decision.decision).toBe('allow');
+    // The allow came from the tenant subject, not the user subject directly
+    expect(decision.resolved_subject_type).toBe('tenant');
+    expect(decision.resolved_subject_id).toBe('tenant-acme');
+  });
+
+  it('removing membership revokes inherited access on next resolve', async () => {
+    // After membership is revoked, the union no longer includes tenant-acme's grant
+    const membershipStub = {
+      getMemberships: vi.fn().mockResolvedValue([]), // membership removed
+    };
+    const tenantResolver = makeResolver([FEATURE]);
+    const gate = new FeatureGate(
+      buildUnionResolver(makeResolver([]), tenantResolver),
+      new EntitlementCache(),
+      membershipStub,
+      {} as never,
+    );
+
+    const subject: Subject = { subject_type: 'user', subject_id: 'user-carol' };
+    await expect(gate.assertEntitled(subject, FEATURE)).rejects.toThrow(FeatureNotEntitledError);
+  });
+});
+```
+
+**Note on `buildUnionResolver`**: this is a test helper (not production code) that routes `user:X` subjects to `userResolver` and `tenant:Y` subjects to `tenantResolver`. It simulates the per-subject resolution that `FeatureGate` performs internally during union. If the gate's production implementation already accepts a single resolver and derives per-subject resolution itself, this helper may be unnecessary — pass the single resolver and verify union behavior through the gate's public `assertEntitled` API alone.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (within `describe('Union resolution')` block)
+
+**Validation**:
+- [ ] All four tests pass
+- [ ] `NullMembershipResolver` is imported from production code, not defined inline
+- [ ] The membership-stub test confirms the `resolved_subject_type` in the decision log
+
+---
+
+### T038 — Content-path regression gate (SC-4, non-negotiable)
+
+**Purpose**: Prove that the WP01 extraction of `EntitlementResolver`, `HttpEntitlementResolver`, and `EntitlementCache` into `src/entitlements/core/` did not break the content entitlement path. The existing test file is the gate.
+
+**This test does not write new test code.** It runs the existing test suite:
+
+```
+tests/content/integration/entitlements.test.ts
+```
+
+and asserts all tests remain green. If any test in that file fails after WP01–WP05 land, this subtask is **blocked** — do not proceed to T039/T040 until it is resolved.
+
+**Mechanism**:
+- Run `npx vitest run tests/content/integration/entitlements.test.ts` in isolation.
+- All 10 existing tests must pass (the 3 `describe` blocks in the file as of grounding: cache hit/miss, fail-closed fallback, search result filtering, generation citations, TTL/invalidation).
+- If import paths changed in WP01 (e.g., `EntitlementCache` moved from `src/content/entitlements/cache.js` to `src/entitlements/core/cache.js`), the existing content test file must have been updated with re-exports that preserve the old import paths. If it was not, fix the re-exports — do not modify the test file's import paths.
+
+**Files**:
+- `tests/content/integration/entitlements.test.ts` (read-only; fix is in re-exports if needed)
+- `src/content/entitlements/cache.ts` (re-export only if import was moved)
+- `src/content/entitlements/index.ts` (re-export only if imports were moved)
+
+**Validation**:
+- [ ] `npx vitest run tests/content/integration/entitlements.test.ts` exits 0
+- [ ] Test count matches pre-WP01 baseline (no tests silently dropped)
+- [ ] Zero modifications to the test file itself
+
+---
+
+### T039 — Auditability: every allow/deny queryable per subject and per feature (SC-11)
+
+**Purpose**: Prove that the `entitlement_decisions` table (FR-006) makes every gate decision queryable by (a) subject and (b) feature key, within the defined retention window.
+
+**Scenario enacted**:
+1. Run a sequence of four gate evaluations:
+   - `user:alice` + `com.joyus.addon.advanced-pipelines` → allow (has grant)
+   - `user:bob` + `com.joyus.addon.advanced-pipelines` → deny (no grant)
+   - `user:alice` + `com.joyus.addon.some-other-feature` → deny (no grant for this feature)
+   - `user:carol` + `com.joyus.addon.advanced-pipelines` → allow (has grant)
+2. Query the decision log by subject `user:alice` — expect 2 rows (1 allow, 1 deny for different features).
+3. Query by subject `user:bob` — expect 1 row (1 deny).
+4. Query by feature `com.joyus.addon.advanced-pipelines` — expect 4 rows (2 allows, 2 denies including bob and the revoke from T033 if run in sequence — or just the 3 from this test if isolated).
+5. Query by subject `user:alice` + feature `com.joyus.addon.advanced-pipelines` — expect exactly 1 allow row.
+
+**Key assertions**:
+- The mock decision logger's `logAllow` and `logDeny` calls (from WP02 T011) are invoked with the correct `subject`, `feature_key`, and `reason` arguments.
+- A query helper over the mock log returns the expected subsets.
+- Every row carries: `subject_type`, `subject_id`, `feature_key`, `decision`, `reason`, `resolved_from`, `created_at`.
+
+**Files**:
+- `tests/entitlements/integration/feature-gate.test.ts` (within `describe('Auditability')` block)
+
+**Validation**:
+- [ ] Per-subject query returns only that subject's decisions
+- [ ] Per-feature query returns decisions across all subjects for that feature
+- [ ] Combined subject+feature query returns exactly the expected rows
+- [ ] Every logged row has all required fields populated (no `undefined` values)
+
+---
+
+### T040 — Validation sweep: `npm run validate`, zero regressions
+
+**Purpose**: The integration gate. Runs the full project validation pipeline — typecheck, lint, and all tests — and asserts zero failures. This is the Definition of Done checkpoint for the entire Spec 015 Phase 1 work.
+
+**Steps**:
+1. From the `joyus-ai-mcp-server/` directory, run: `npm run validate`
+2. The command runs: `npm run typecheck && npm run lint && npm test` (confirmed from `package.json`).
+3. All three must exit 0.
+4. Coverage thresholds must not regress (statements 59%, branches 74%, functions 67%, lines 59% — from `vitest.config.ts`).
+
+**This subtask is a pure execution check — no new test code.** If it fails:
+- Typecheck failures: fix the types, do not use `as any` or `@ts-ignore` unless the existing codebase already uses them in that location.
+- Lint failures: fix the lint errors, do not disable rules.
+- Test failures: diagnose root cause; if a pre-existing test is now failing, the cause is in WP01–WP05, not in this WP's test additions.
+- Coverage regression: add targeted tests to the failing module; do not lower the thresholds.
+
+**Files**:
+- No new files. CI command only.
+
+**Validation**:
+- [ ] `npm run validate` exits 0
+- [ ] Zero new TypeScript errors introduced by WP01–WP06
+- [ ] Zero lint errors in `src/entitlements/` or any modified existing file
+- [ ] All existing tests pass (T038 is a subset; this confirms the full suite)
+- [ ] Coverage thresholds not regressed
+
+---
+
+## Definition of Done
+
+- [ ] `tests/entitlements/integration/feature-gate.test.ts` exists and contains all T033–T039 test scenarios
+- [ ] T033: individual grant/revoke lifecycle passes; tool visibility changes confirmed
+- [ ] T034: `FeatureNotEntitledError` thrown with `featureKey` + `reason`; upgrade payload non-empty; decision logged
+- [ ] T035: expired grant denied on outage; valid grant still served; reasons recorded correctly
+- [ ] T036: gated pipeline step denied via second path; hand-constructed token rejected at type boundary
+- [ ] T037: user grant alone is sufficient pre-WP12; membership stub adds tenant grant; membership removal revokes
+- [ ] T038: `tests/content/integration/entitlements.test.ts` — all tests green, zero modifications to the file
+- [ ] T039: allow/deny decisions queryable by subject, by feature, and by subject+feature
+- [ ] T040: `npm run validate` exits 0 with no typecheck, lint, or test failures
+- [ ] No real database connections in any test; all DB interactions use mocks
+- [ ] All new test imports use `.js` extensions on local paths (ESM module requirement)
+- [ ] Test file header comment follows the established convention (see `entitlements.test.ts` line 1–6)
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| T035 mock ambiguity: the mock DB returns expired rows and the gate is supposed to filter them — but if the mock applies the filter and the gate also applies it, the test proves nothing | High | Document clearly whether the mock returns raw rows (gate filters) or pre-filtered rows (mock filters). Pick one approach consistently and assert on the resolver's call trace to confirm the outage path was exercised. |
+| T036 type-boundary test becomes a no-op if `GateToken` is a pure branded type with no runtime identity | Medium | Add a comment explaining that the type guard is the mechanism. Confirm in T040 that `@ts-expect-error` is caught by typecheck — if it is NOT caught, the branded type is not enforced and the WP03 guarantee is broken. |
+| T037 union helper (`buildUnionResolver`) diverges from production union behavior | Medium | Prefer testing through `gate.assertEntitled` alone if the gate already handles subject-set resolution internally. Only introduce the helper if the gate requires you to pass per-subject resolvers explicitly. |
+| T038 import path breakage after WP01 extraction | High | Run T038 immediately after WP01 lands, before WP02. If it breaks, fix re-exports before continuing. This is the earliest possible catch of the extraction regression. |
+| Coverage regression: new `src/entitlements/` code is added but not covered by the new tests | Medium | Run `npm run test:coverage` after T033–T039 pass. If the thresholds fail, trace uncovered branches and add targeted tests. Do not lower thresholds. |
+| `GateToken` not yet typed when this WP is implemented (WP03 dependency) | Low | If WP03 used `void` or `unknown` as a placeholder for `GateToken`, update the T035/T036 test assertions after the final type is confirmed. Do not write tests assuming a specific shape; use `expect(token).toBeDefined()` as the minimum. |
+
+---
+
+## Reviewer Guidance
+
+- **T035 is the grant-validity test.** Review it with adversarial eyes: does the mock actually simulate an outage (resolver throws), and does the mock DB actually have an expired grant row? If either condition is not genuinely met, the test is a false positive. Check the mock resolver's call trace.
+- **T036, first case**: confirm the gated step is invoked through the step registry's public `execute` method, not through a test-only back door. If the test calls the step handler directly (bypassing the registry), it does not prove structural enforcement.
+- **T037, membership-stub case**: check that `resolved_subject_type: 'tenant'` appears in the decision log. If the decision log records the actor's `user:carol` subject instead of the satisfying `tenant:acme` subject, the audit is misleading — FR-006 requires the log to show which subject satisfied the allow.
+- **T038**: verify the test count before and after. If a test was silently skipped due to an import error (Vitest sometimes skips rather than fails on bad imports), the count will drop. A dropped test is a hidden regression.
+- **Imports**: every local import in the new test file must use the `.js` extension. Missing extensions cause silent failures in Vitest under `"type": "module"`. Check the first run's error output carefully if tests fail to collect.
+- **No `as any`**: the existing test file (`entitlements.test.ts`) uses `{} as never` for the mock DB when DB is not exercised. Mirror this pattern. Do not use `as any` — it defeats the typecheck gate.


### PR DESCRIPTION
## What

Promotes the **add-on / plugin architecture + feature-entitlements** spec into `kitty-specs/` as the implementation-facing technical spec.

Designed and pressure-tested in the private planning repo (proposal-critic reviewed). This promotion is **sanitized** — GTM/pricing/revenue strategy and code-reasoning analysis stay private; what lands here is the technical architecture.

### Contents (`kitty-specs/015-add-on-plugin-architecture/`)
- **spec.md** — 19 FRs across two layers (extension + entitlement), phased: individual-first (Phase 1, no tenant identity) → org-level entitlement via membership-inheritance union, FR-019 (Phase 1.5, needs tenant identity) → plugin host + SDK (Phase 2)
- **data-model.md** — new persistent `entitlements` schema; reuses the existing `EntitlementResolver`/`HttpEntitlementResolver`/`EntitlementCache` machinery rather than rebuilding it
- **plan.md + tasks.md + tasks/WP01–06** — implement-ready Phase 1 decomposition (6 WPs, 40 subtasks)

### Key technical decisions
- Reuse the resolution machinery (extract to `src/entitlements/core/`); build a new persistent, **explicit-deny** system on top (the existing `content.entitlements` is session-scoped + silent-deny)
- Structural, un-forgeable gate enforcement (`GateToken`) — closes a live bypass the codebase already contains (`content-executor.ts:223`)
- Effective entitlement = **union** of a user's own grants ∪ their orgs' grants (FR-019), so org-level entitlement inherits via membership with no redesign

### Dependency
- The org path depends on **tenant identity**, already specced as **Spec 013 — Tenant Identity Resolution** (spec-only); its WP01 adds the tenants/membership schema the union needs. The individual path (Phase 1) ships without it.

## Notes
- Spec only — no code changes.
- `.gitignore` updated with the per-spec WP-file allowlist exceptions (matches the established convention for 005–013).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
